### PR TITLE
Add PR-only incremental shell and workflow lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.11
 
       - name: Install shell lint dependencies
         run: |


### PR DESCRIPTION
## Summary
- add a dedicated `lint` workflow for shellcheck, shfmt, and actionlint
- run the lint workflow only on pull requests
- lint only shell scripts changed in the pull request to avoid failing on historical shell debt

## Why
The earlier lint attempts were still too brittle for this repo. This version removes the mixed push/pull_request logic and keeps the workflow focused on the review path that actually matters for branch protection.

## Included
- `.github/workflows/lint.yml`

## Notes
This is intentionally additive. It does not replace the existing `ci` or `codeql` workflows.

If you want to enforce it later in the ruleset, the expected job/check name should be:
- `shell-and-workflow-lint`
