### PR TITLE
feat: extract shared skill scoring engine

### DIFF
--- a/.github/workflows/autonomy-foundation-smoke.yml
+++ b/.github/workflows/autonomy-foundation-smoke.yml
@@ -58,5 +58,32 @@ jobs:
       - name: Score skills
         run: python3 scripts/skill_confidence.py --output workflows/smoke-scorecard.json
 
+      - name: Assert scorecard schema
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          scorecard = json.loads(Path("workflows/smoke-scorecard.json").read_text(encoding="utf-8"))
+          assert scorecard["score_model"] == "beta-prior-v1"
+          assert isinstance(scorecard["skills"], dict)
+          assert "ci-failure-diagnosis" in scorecard["skills"]
+
+          sample = scorecard["skills"]["ci-failure-diagnosis"]
+          required = {
+              "attempts",
+              "successes",
+              "failures",
+              "success_rate",
+              "posterior_confidence",
+              "recency_weight",
+              "disabled",
+              "decayed",
+              "final_score",
+          }
+          missing = required - set(sample)
+          assert not missing, f"missing fields: {sorted(missing)}"
+          PY
+
       - name: Replan loop
         run: bash scripts/skill_replan.sh

--- a/scripts/skill_confidence.py
+++ b/scripts/skill_confidence.py
@@ -3,26 +3,22 @@ from __future__ import annotations
 
 import argparse
 import json
-import time
 from pathlib import Path
+
+from skill_scoring import (
+    DEFAULT_HEALTH,
+    DEFAULT_MEMORY,
+    DEFAULT_REGISTRY,
+    build_scorecard,
+    load_json,
+    save_json,
+)
 
 ROOT = Path(__file__).resolve().parent.parent
 REGISTRY = ROOT / "skills" / "index.json"
 MEMORY = ROOT / "skills" / "memory.json"
 HEALTH = ROOT / "skills" / "health.json"
 DEFAULT_OUTPUT = ROOT / "skills" / "scorecard.json"
-DECAY_SECONDS = 60 * 60 * 24 * 3
-
-
-def load(path: Path, default: dict) -> dict:
-    if not path.exists():
-        return json.loads(json.dumps(default))
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def save(path: Path, data: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
 def main() -> None:
@@ -30,69 +26,15 @@ def main() -> None:
     parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
     args = parser.parse_args()
 
-    registry = load(REGISTRY, {"skills": {}})
-    memory = load(MEMORY, {"history": []})
-    health = load(HEALTH, {"disabled_skills": []})
-
-    disabled_skills = set(health.get("disabled_skills", []))
-    history = memory.get("history", [])
-    now = time.time()
-
-    by_skill: dict[str, dict[str, float]] = {}
-    for item in history:
-        skill = item.get("skill")
-        if not skill:
-            continue
-        bucket = by_skill.setdefault(skill, {"ok": 0, "fail": 0, "last_ts": 0.0})
-        if item.get("success"):
-            bucket["ok"] += 1
-        else:
-            bucket["fail"] += 1
-
-        ts = item.get("ts")
-        if isinstance(ts, (int, float)):
-            bucket["last_ts"] = max(bucket["last_ts"], float(ts))
-
-    scorecard = {
-        "generated_at": int(now),
-        "skills": {},
-    }
-
-    for skill, spec in registry.get("skills", {}).items():
-        counts = by_skill.get(skill, {"ok": 0, "fail": 0, "last_ts": 0.0})
-        successes = int(counts["ok"])
-        failures = int(counts["fail"])
-        attempts = successes + failures
-
-        posterior_confidence = (successes + 1) / (attempts + 2)
-        last_ts = counts.get("last_ts", 0.0)
-        if last_ts:
-            age = max(0.0, now - last_ts)
-            recency_weight = max(0.5, 1.0 - min(age / DECAY_SECONDS, 1.0) * 0.5)
-        else:
-            recency_weight = 1.0
-
-        disabled = bool(spec.get("disabled")) or skill in disabled_skills
-        decayed = bool(spec.get("decayed"))
-        decay_penalty = 0.85 if decayed else 1.0
-        final_score = 0.0 if disabled else round(posterior_confidence * recency_weight * decay_penalty, 4)
-
-        scorecard["skills"][skill] = {
-            "attempts": attempts,
-            "successes": successes,
-            "failures": failures,
-            "success_rate": round((successes / attempts) if attempts else 0.0, 4),
-            "posterior_confidence": round(posterior_confidence, 4),
-            "recency_weight": round(recency_weight, 4),
-            "disabled": disabled,
-            "decayed": decayed,
-            "final_score": final_score,
-        }
+    registry = load_json(REGISTRY, DEFAULT_REGISTRY)
+    memory = load_json(MEMORY, DEFAULT_MEMORY)
+    health = load_json(HEALTH, DEFAULT_HEALTH)
+    scorecard = build_scorecard(registry=registry, memory=memory, health=health)
 
     out = Path(args.output)
     if not out.is_absolute():
         out = ROOT / out
-    save(out, scorecard)
+    save_json(out, scorecard)
     print(json.dumps({"scorecard": str(out.relative_to(ROOT)), "skills_scored": len(scorecard["skills"])}, indent=2))
 
 

--- a/scripts/skill_scoring.py
+++ b/scripts/skill_scoring.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+DECAY_SECONDS = 60 * 60 * 24 * 3
+DEFAULT_REGISTRY = {"skills": {}}
+DEFAULT_MEMORY = {"history": []}
+DEFAULT_HEALTH = {"disabled_skills": []}
+SCORE_MODEL = "beta-prior-v1"
+
+
+def deep_copy(data: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(data))
+
+
+def load_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+    if not path.exists():
+        return deep_copy(default)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def collect_history_by_skill(history: list[dict[str, Any]]) -> dict[str, dict[str, float]]:
+    by_skill: dict[str, dict[str, float]] = {}
+    for item in history:
+        skill = item.get("skill")
+        if not isinstance(skill, str) or not skill:
+            continue
+
+        bucket = by_skill.setdefault(skill, {"ok": 0.0, "fail": 0.0, "last_ts": 0.0})
+        if item.get("success"):
+            bucket["ok"] += 1
+        else:
+            bucket["fail"] += 1
+
+        ts = item.get("ts")
+        if isinstance(ts, (int, float)):
+            bucket["last_ts"] = max(bucket["last_ts"], float(ts))
+
+    return by_skill
+
+
+def score_skill(
+    *,
+    spec: dict[str, Any],
+    counts: dict[str, float],
+    now: float,
+    disabled_skills: set[str],
+    skill_name: str,
+) -> dict[str, Any]:
+    successes = int(counts.get("ok", 0.0))
+    failures = int(counts.get("fail", 0.0))
+    attempts = successes + failures
+
+    posterior_confidence = (successes + 1) / (attempts + 2)
+    last_ts = float(counts.get("last_ts", 0.0))
+    if last_ts:
+        age = max(0.0, now - last_ts)
+        recency_weight = max(0.5, 1.0 - min(age / DECAY_SECONDS, 1.0) * 0.5)
+    else:
+        recency_weight = 1.0
+
+    disabled = bool(spec.get("disabled")) or skill_name in disabled_skills
+    decayed = bool(spec.get("decayed"))
+    decay_penalty = 0.85 if decayed else 1.0
+    final_score = 0.0 if disabled else round(posterior_confidence * recency_weight * decay_penalty, 4)
+
+    return {
+        "attempts": attempts,
+        "successes": successes,
+        "failures": failures,
+        "success_rate": round((successes / attempts) if attempts else 0.0, 4),
+        "posterior_confidence": round(posterior_confidence, 4),
+        "recency_weight": round(recency_weight, 4),
+        "disabled": disabled,
+        "decayed": decayed,
+        "final_score": final_score,
+    }
+
+
+def build_scorecard(
+    *,
+    registry: dict[str, Any],
+    memory: dict[str, Any],
+    health: dict[str, Any],
+    now: float | None = None,
+) -> dict[str, Any]:
+    timestamp = time.time() if now is None else now
+    disabled_skills = set(health.get("disabled_skills", []))
+    by_skill = collect_history_by_skill(memory.get("history", []))
+
+    skills = {}
+    for skill_name, spec in sorted(registry.get("skills", {}).items()):
+        counts = by_skill.get(skill_name, {"ok": 0.0, "fail": 0.0, "last_ts": 0.0})
+        skills[skill_name] = score_skill(
+            spec=spec,
+            counts=counts,
+            now=timestamp,
+            disabled_skills=disabled_skills,
+            skill_name=skill_name,
+        )
+
+    return {
+        "generated_at": int(timestamp),
+        "score_model": SCORE_MODEL,
+        "skills": skills,
+    }


### PR DESCRIPTION
## Summary
- extract shared scoring logic into `scripts/skill_scoring.py`
- keep `scripts/skill_confidence.py` as the CLI wrapper
- harden smoke CI with a scorecard schema assertion

## Why
The autonomy loop is now stable after #46. The next safe upgrade is to make skill scoring canonical and reusable before changing selection or planner internals.

## Notes
- no planner rewrite in this pass
- no behavior change to the closed loop beyond producing a canonical score model output
- keeps the current `skill_confidence.py` entrypoint for compatibility
