### PR TITLE
feat: wire selector into recovery paths

### DIFF
--- a/.github/workflows/autonomy-foundation-smoke.yml
+++ b/.github/workflows/autonomy-foundation-smoke.yml
@@ -85,5 +85,21 @@ jobs:
           assert not missing, f"missing fields: {sorted(missing)}"
           PY
 
+      - name: Run selector
+        run: python3 scripts/skill_select.py --text "ci failed because shellcheck is red" --output workflows/selector-smoke.json
+
+      - name: Assert selector output
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          selection = json.loads(Path("workflows/selector-smoke.json").read_text(encoding="utf-8"))
+          assert selection["selected"] is not None
+          assert selection["selected"]["skill"] == "ci-failure-diagnosis"
+          assert selection["selected"]["action"] == "show"
+          assert selection["candidates"]
+          PY
+
       - name: Replan loop
         run: bash scripts/skill_replan.sh

--- a/scripts/skill-auto.sh
+++ b/scripts/skill-auto.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SKILL_RUNNER="$ROOT_DIR/scripts/skill.sh"
+SELECTOR="$ROOT_DIR/scripts/skill_select.py"
 MODE="suggest"
 INPUT=""
 
@@ -72,6 +73,19 @@ suggest_for_text() {
   echo ""
 }
 
+select_with_selector() {
+  local text="$1"
+  local tmp
+
+  [ -f "$SELECTOR" ] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  tmp="$(mktemp)"
+  python3 "$SELECTOR" --text "$text" --output "$tmp" >/dev/null
+  jq -r '.selected | if . == null then "" else "\(.skill) \(.action)" end' "$tmp"
+  rm -f "$tmp"
+}
+
 main() {
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -101,8 +115,12 @@ main() {
   suggestion="$(suggest_for_text "$text")"
 
   if [ -z "$suggestion" ]; then
+    suggestion="$(select_with_selector "$text" || true)"
+  fi
+
+  if [ -z "$suggestion" ]; then
     echo "No auto-trigger match found."
-    echo "Try manual inspection with: $SKILL_RUNNER list"
+    echo "Try manual inspection with: bash $SKILL_RUNNER list"
     exit 1
   fi
 
@@ -113,8 +131,8 @@ main() {
   echo "Suggested action: $action"
 
   if [ "$MODE" = "apply" ]; then
-    echo "Applying: $SKILL_RUNNER run $skill $action"
-    "$SKILL_RUNNER" run "$skill" "$action"
+    echo "Applying: bash $SKILL_RUNNER run $skill $action"
+    bash "$SKILL_RUNNER" run "$skill" "$action"
   fi
 }
 

--- a/scripts/skill-recover-learned.sh
+++ b/scripts/skill-recover-learned.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REGISTRY="$ROOT_DIR/skills/index.json"
-MEMORY="$ROOT_DIR/skills/memory.json"
 SKILL_RUNNER="$ROOT_DIR/scripts/skill.sh"
+SELECTOR="$ROOT_DIR/scripts/skill_select.py"
 MAX_RETRIES=2
 AUTO_APPLY=false
 INPUT=""
@@ -24,56 +24,24 @@ read_input() {
   cat
 }
 
-trigger_scores() {
+select_match() {
   local text="$1"
-  require_cmd jq
-  jq -r --arg txt "$text" '
-    .skills
-    | to_entries
-    | map({
-        skill: .key,
-        action: .value.default_action,
-        score: ([.value.triggers[] | ascii_downcase | select($txt | contains(.))] | length)
-      })
-    | map(select(.score > 0))
-    | .[]
-    | [.skill, .action, (.score|tostring)] | @tsv
-  ' "$REGISTRY"
-}
+  local tmp
 
-memory_bonus() {
-  local skill="$1"
-  [ -f "$MEMORY" ] || {
-    echo 0
-    return
+  require_cmd jq
+  [ -f "$REGISTRY" ] || {
+    echo "Missing skill registry: $REGISTRY" >&2
+    exit 1
+  }
+  [ -f "$SELECTOR" ] || {
+    echo "Missing selector: $SELECTOR" >&2
+    exit 1
   }
 
-  require_cmd jq
-  jq -r --arg skill "$skill" '
-    [.history[] | select(.skill == $skill)] as $h
-    | if ($h | length) == 0 then 0
-      else (($h | map(select(.success == true)) | length) - ($h | map(select(.success == false)) | length))
-      end
-  ' "$MEMORY"
-}
-
-best_match() {
-  local text="$1"
-  local best=""
-  local best_score=-999
-  local bonus total
-
-  while IFS=$'\t' read -r skill action score; do
-    bonus="$(memory_bonus "$skill")"
-    total=$((score + bonus))
-
-    if [ "$total" -gt "$best_score" ]; then
-      best_score="$total"
-      best="$skill\t$action\t$score\t$bonus\t$total"
-    fi
-  done < <(trigger_scores "$text")
-
-  printf '%b\n' "$best"
+  tmp="$(mktemp)"
+  python3 "$SELECTOR" --text "$text" --output "$tmp" >/dev/null
+  jq -r '.selected | if . == null then "" else "\(.skill)\t\(.action)" end' "$tmp"
+  rm -f "$tmp"
 }
 
 main() {
@@ -106,7 +74,7 @@ main() {
   lower="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
 
   for ((attempt = 1; attempt <= MAX_RETRIES; attempt++)); do
-    match="$(best_match "$lower")"
+    match="$(select_match "$lower")"
 
     if [ -z "$match" ]; then
       echo "No learned recovery match found." >&2


### PR DESCRIPTION
## Summary
- route `skill-recover-learned.sh` through `scripts/skill_select.py`
- add selector fallback to `scripts/skill-auto.sh`
- extend autonomy smoke CI to verify selector output

## Why
The shared scorer and selector helpers are already on master, but the main recovery entrypoints were still using older ad hoc matching. This keeps the upgrade additive while making recovery and suggestion paths use the canonical selector.

## Notes
- no planner rewrite in this pass
- keeps current shell entrypoints intact
- adds smoke coverage for selector behavior
