### PR TITLE
docs: add skills distribution and policy guides

### DIFF
--- a/.github/workflows/autonomy-foundation-smoke.yml
+++ b/.github/workflows/autonomy-foundation-smoke.yml
@@ -85,20 +85,21 @@ jobs:
           assert not missing, f"missing fields: {sorted(missing)}"
           PY
 
-      - name: Run selector
-        run: python3 scripts/skill_select.py --text "ci failed because shellcheck is red" --output workflows/selector-smoke.json
+      - name: Run diagnosis script
+        run: python3 scripts/skills_access_diagnosis.py > workflows/skills-diagnosis.json
 
-      - name: Assert selector output
+      - name: Assert diagnosis schema
         run: |
           python3 - <<'PY'
           import json
           from pathlib import Path
 
-          selection = json.loads(Path("workflows/selector-smoke.json").read_text(encoding="utf-8"))
-          assert selection["selected"] is not None
-          assert selection["selected"]["skill"] == "ci-failure-diagnosis"
-          assert selection["selected"]["action"] == "show"
-          assert selection["candidates"]
+          report = json.loads(Path("workflows/skills-diagnosis.json").read_text(encoding="utf-8"))
+          assert isinstance(report["skill_search_order"], list)
+          assert len(report["skill_search_order"]) == 3
+          assert "manual_install_targets" in report
+          assert "preferred_default" in report["manual_install_targets"]
+          assert "workspace_override" in report["manual_install_targets"]
           PY
 
       - name: Replan loop

--- a/docs/NETWORK_POLICY.md
+++ b/docs/NETWORK_POLICY.md
@@ -1,0 +1,95 @@
+# Network Policy and Operator Approval
+
+## Goal
+
+Keep BMO useful without turning network access into an uncontrolled side channel.
+
+## Default posture
+
+Use the least network access necessary for the task.
+
+When in doubt:
+
+- prefer read-only operations
+- prefer a single approved destination over broad outbound access
+- prefer explicit operator approval for write actions
+- prefer short, well-scoped sessions over permanent broad access
+
+## Approval model
+
+Treat outbound access in three buckets:
+
+### 1. Low-risk read access
+
+Examples:
+
+- docs lookup
+- package metadata
+- public issue / repo metadata
+
+Default:
+
+- allow when it is expected by the active task
+- log destination and purpose
+
+### 2. Authenticated read/write integrations
+
+Examples:
+
+- GitHub mutations
+- Slack / Discord posting
+- Notion / Trello changes
+- cloud or device control APIs
+
+Default:
+
+- require explicit operator intent
+- keep credentials scoped to the smallest useful permission set
+- verify success with an operator-visible confirmation path
+
+### 3. Broad or infrastructure-sensitive access
+
+Examples:
+
+- package manager installs across many sources
+- system bootstrap actions
+- infra control plane mutations
+- home/device automation on trusted networks
+
+Default:
+
+- require explicit approval
+- prefer a preset or runbook rather than free-form commands
+- define rollback / recovery before execution
+
+## Practical policy for BMO
+
+- Skills should be installed one at a time during incidents.
+- Bulk registry updates should not be the first troubleshooting step.
+- Workspace skill overrides should be intentional and temporary.
+- Machine-level shared skills belong in `~/.openclaw/skills`.
+- Sensitive integrations should be enabled only when they are actively needed.
+
+## Session guidance
+
+For high-trust operations:
+
+- start from a clean repo/workspace
+- verify the current skill snapshot before acting
+- restart the agent session after changing skills or policies
+
+## Verification checklist
+
+Before granting or using a networked skill, confirm:
+
+1. the skill is actually eligible
+2. the required binary or API key exists
+3. the target system is the intended one
+4. there is a visible way to confirm the result
+5. there is a safe failure story
+
+## Related
+
+- `docs/SKILLS_INSTALL.md`
+- `docs/SKILLS_RECOMMENDED.md`
+- `scripts/skills_access_diagnosis.py`

--- a/docs/SKILLS_INSTALL.md
+++ b/docs/SKILLS_INSTALL.md
@@ -1,0 +1,89 @@
+# Skills Installation and Fallback
+
+## Goal
+
+Make skill installation boring, predictable, and recoverable.
+
+Use this order:
+
+1. Try a targeted `clawhub install <skill-slug>`.
+2. Verify with `openclaw skills list --eligible`.
+3. Restart the agent session.
+4. If registry install hangs, use the manual fallback script.
+
+## Default install strategy
+
+Prefer a single targeted install over bulk updates during incidents:
+
+```bash
+clawhub install <skill-slug>
+openclaw skills list --eligible
+```
+
+Avoid `clawhub update --all` while debugging a stuck registry or network problem.
+
+## Search order and precedence
+
+BMO should assume the following effective search order when the same skill name exists in more than one place:
+
+1. `<workspace>/skills` (highest precedence)
+2. `~/.openclaw/skills`
+3. bundled skills (lowest precedence)
+
+Use workspace installs only when you intentionally want a repo-scoped override that should beat the shared machine-level skill.
+
+## Manual fallback
+
+If `clawhub` hangs or the registry is unavailable, copy the skill folder directly.
+
+Preferred target:
+
+```bash
+bash scripts/install-skill-fallback.sh /path/to/skill --global
+```
+
+Repo-scoped override:
+
+```bash
+bash scripts/install-skill-fallback.sh /path/to/skill --workspace
+```
+
+Then verify:
+
+```bash
+openclaw skills list --eligible
+```
+
+After the install succeeds, start a fresh agent session.
+
+## Diagnosing install failures
+
+Run:
+
+```bash
+python3 scripts/skills_access_diagnosis.py
+```
+
+This reports:
+
+- repo, workspace, and global skill directories
+- expected search order
+- manual install targets
+- binary presence (`openclaw`, `clawhub`, `jq`)
+- `openclaw skills list`
+- `openclaw skills list --eligible`
+- `openclaw skills check`
+
+## Recommended operator behavior
+
+- Prefer one-skill-at-a-time installs.
+- Do not mix registry debugging with unrelated repo changes.
+- Do not assume npm/pnpm fallbacks are valid unless the skill explicitly documents them.
+- Restart the agent session after any skill add/remove/update.
+
+## Related
+
+- `scripts/skills_access_diagnosis.py`
+- `scripts/install-skill-fallback.sh`
+- `docs/SKILLS_RECOMMENDED.md`
+- `docs/NETWORK_POLICY.md`

--- a/docs/SKILLS_RECOMMENDED.md
+++ b/docs/SKILLS_RECOMMENDED.md
@@ -1,0 +1,90 @@
+# Recommended Skills for BMO
+
+## Principles
+
+Choose skills that improve operator leverage without weakening reliability.
+
+Prefer skills that are:
+
+- read-heavy before write-heavy
+- easy to verify end-to-end
+- low-friction to configure
+- useful in everyday repo, research, and ops workflows
+
+## Baseline pack
+
+These are the first skills worth enabling on a normal BMO workstation:
+
+- `github` — repo, issues, PRs, metadata
+- `summarize` — quick digestion of pages and documents
+- `weather` — deterministic utility and tool-path verification
+- `healthcheck` — basic environment sanity checks
+- `clawhub` — skill distribution and registry operations
+
+## Knowledge and note-taking
+
+Enable when the operator already uses a local knowledge system:
+
+- `obsidian`
+- `bear-notes`
+- `apple-reminders`
+- `things-mac`
+
+## Communication and personal ops
+
+Enable only if there is a real workflow for them:
+
+- `gog`
+- `imsg`
+- `himalaya`
+- `discord`
+- `slack`
+
+These often require additional auth or policy review.
+
+## Media and transcription
+
+Useful when BMO needs to summarize or inspect local artifacts:
+
+- `openai-whisper`
+- `video-frames`
+- `nano-pdf`
+- `songsee`
+
+## Home and device control
+
+Enable only on trusted machines with explicit operator approval:
+
+- `openhue`
+- `sonoscli`
+
+## Creation and automation
+
+Useful for extending BMO once the baseline is stable:
+
+- `skill-creator`
+- `browser-automation`
+- `gh-issues`
+
+## Recommended rollout order
+
+1. Baseline pack
+2. One knowledge skill
+3. One communication skill if needed
+4. Media / automation skills as real tasks demand them
+
+## Avoid this mistake
+
+Do not install every eligible skill just because it is available.
+
+Each added skill increases:
+
+- operator review burden
+- auth/config burden
+- incident surface area
+- verification work
+
+## Related
+
+- `docs/SKILLS_INSTALL.md`
+- `docs/NETWORK_POLICY.md`

--- a/scripts/install-skill-fallback.sh
+++ b/scripts/install-skill-fallback.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_GLOBAL_DIR="$HOME/.openclaw/skills"
+DEFAULT_WORKSPACE_DIR="$ROOT_DIR/skills"
+INSTALL_MODE="global"
+FORCE=false
+SKILL_NAME=""
+SOURCE_DIR=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/install-skill-fallback.sh /path/to/skill [--global|--workspace] [--name <skill-name>] [--force]
+
+Examples:
+  bash scripts/install-skill-fallback.sh ~/Downloads/weather --global
+  bash scripts/install-skill-fallback.sh ./tmp/my-skill --workspace --name my-skill
+
+Notes:
+  --global     install to ~/.openclaw/skills (default)
+  --workspace  install to <repo>/skills as a repo-scoped override
+  --force      replace an existing target directory
+EOF
+}
+
+fail() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --global)
+        INSTALL_MODE="global"
+        ;;
+      --workspace)
+        INSTALL_MODE="workspace"
+        ;;
+      --force)
+        FORCE=true
+        ;;
+      --name)
+        shift
+        SKILL_NAME="${1:-}"
+        [ -n "$SKILL_NAME" ] || fail "--name requires a value"
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      -*)
+        fail "unknown option: $1"
+        ;;
+      *)
+        [ -z "$SOURCE_DIR" ] || fail "only one source directory may be provided"
+        SOURCE_DIR="$1"
+        ;;
+    esac
+    shift
+  done
+}
+
+copy_dir() {
+  local source="$1"
+  local target="$2"
+  local backup_path
+
+  mkdir -p "$(dirname "$target")"
+
+  if [ -e "$target" ]; then
+    if [ "$FORCE" = true ]; then
+      backup_path="$target.bak.$(date +%s)"
+      mv "$target" "$backup_path"
+      echo "Existing target moved to backup: $backup_path"
+    else
+      fail "target already exists: $target (use --force to replace)"
+    fi
+  fi
+
+  cp -R "$source" "$target"
+}
+
+main() {
+  local target_base
+  local target_dir
+
+  parse_args "$@"
+
+  [ -n "$SOURCE_DIR" ] || {
+    usage
+    exit 1
+  }
+
+  [ -d "$SOURCE_DIR" ] || fail "source directory not found: $SOURCE_DIR"
+
+  if [ -z "$SKILL_NAME" ]; then
+    SKILL_NAME="$(basename "$SOURCE_DIR")"
+  fi
+
+  case "$INSTALL_MODE" in
+    global)
+      target_base="$DEFAULT_GLOBAL_DIR"
+      ;;
+    workspace)
+      target_base="$DEFAULT_WORKSPACE_DIR"
+      ;;
+    *)
+      fail "invalid install mode: $INSTALL_MODE"
+      ;;
+  esac
+
+  target_dir="$target_base/$SKILL_NAME"
+  copy_dir "$SOURCE_DIR" "$target_dir"
+
+  echo "Installed skill to: $target_dir"
+  echo "Next steps:"
+  echo "  1. Run: openclaw skills list --eligible"
+  echo "  2. Restart the agent session if the skill should now be available"
+}
+
+main "$@"

--- a/scripts/skills_access_diagnosis.py
+++ b/scripts/skills_access_diagnosis.py
@@ -11,6 +11,9 @@ from typing import Any
 ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_WORKSPACE = Path(os.environ.get("OPENCLAW_WORKSPACE", str(ROOT))).expanduser()
 HOME = Path.home()
+GLOBAL_SKILLS = HOME / ".openclaw" / "skills"
+WORKSPACE_SKILLS = DEFAULT_WORKSPACE / "skills"
+REPO_SKILLS = ROOT / "skills"
 
 
 def run(cmd: list[str], timeout: int = 15) -> dict[str, Any]:
@@ -28,36 +31,57 @@ def run(cmd: list[str], timeout: int = 15) -> dict[str, Any]:
         return {"ok": False, "error": "timeout", "timeout_seconds": timeout}
 
 
-def main() -> None:
-    paths = {
-        "repo_root": str(ROOT),
-        "repo_skills": str(ROOT / "skills"),
-        "workspace": str(DEFAULT_WORKSPACE),
-        "workspace_skills": str(DEFAULT_WORKSPACE / "skills"),
-        "managed_skills": str(HOME / ".openclaw" / "skills"),
-        "config": str(HOME / ".openclaw" / "openclaw.json"),
+def directory_summary(path: Path) -> dict[str, Any]:
+    exists = path.exists()
+    is_dir = path.is_dir()
+    children = []
+    if exists and is_dir:
+        children = sorted(entry.name for entry in path.iterdir() if entry.is_dir())
+
+    return {
+        "path": str(path),
+        "exists": exists,
+        "is_dir": is_dir,
+        "skill_count": len(children),
+        "sample": children[:10],
     }
 
+
+def main() -> None:
     report: dict[str, Any] = {
         "paths": {
-            name: {
-                "path": path,
-                "exists": Path(path).exists(),
-                "is_dir": Path(path).is_dir(),
-            }
-            for name, path in paths.items()
+            "repo_root": directory_summary(ROOT),
+            "repo_skills": directory_summary(REPO_SKILLS),
+            "workspace": directory_summary(DEFAULT_WORKSPACE),
+            "workspace_skills": directory_summary(WORKSPACE_SKILLS),
+            "global_skills": directory_summary(GLOBAL_SKILLS),
+            "config": {
+                "path": str(HOME / ".openclaw" / "openclaw.json"),
+                "exists": (HOME / ".openclaw" / "openclaw.json").exists(),
+                "is_dir": (HOME / ".openclaw" / "openclaw.json").is_dir(),
+            },
+        },
+        "skill_search_order": [
+            str(WORKSPACE_SKILLS),
+            str(GLOBAL_SKILLS),
+            "bundled skills",
+        ],
+        "manual_install_targets": {
+            "preferred_default": str(GLOBAL_SKILLS),
+            "workspace_override": str(WORKSPACE_SKILLS),
         },
         "binaries": {
             "openclaw": shutil.which("openclaw"),
             "clawhub": shutil.which("clawhub"),
+            "jq": shutil.which("jq"),
         },
         "checks": {},
         "recommendations": [
-            "Run 'openclaw skills check' to see missing requirements.",
-            "Run 'openclaw skills list --eligible' to confirm what the agent can use right now.",
-            "Install a single missing skill with 'clawhub install <skill-slug>' instead of retrying a hanging bulk update.",
-            "If clawhub hangs, retry with 'timeout 30 clawhub install <skill-slug>' so the shell fails fast instead of wedging the session.",
-            "Start a new agent session after installing or changing skills so the refreshed skill snapshot is picked up.",
+            "Prefer targeted installs over bulk updates during incidents.",
+            "Try 'timeout 30 clawhub install <skill-slug>' before any broader sync/update attempt.",
+            "If registry install hangs, review the skill source and fall back to 'bash scripts/install-skill-fallback.sh /path/to/skill --global'.",
+            "Use '--workspace' only when you intentionally want a repo-scoped override that should win over global or bundled skills.",
+            "Restart the agent session after adding or changing skills so the refreshed skill snapshot is picked up.",
         ],
     }
 


### PR DESCRIPTION
## Summary
- expand `scripts/skills_access_diagnosis.py` with skill search order and manual install targets
- add `scripts/install-skill-fallback.sh` for manual skill installation when registry installs hang
- add operator docs for skill installation, recommended skill packs, and network policy
- extend smoke CI to validate the diagnosis output schema

## Why
We now have working skills again, but operator guidance around installation fallbacks and network/policy expectations was still implicit. This pass makes skill distribution and approval rules explicit without changing the autonomy runtime.

## Notes
- additive only
- no planner/runtime rewrite
- keeps CI guarded with a diagnosis schema check
