### PR TITLE
feat: consolidate legacy parity into BMO runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch
+.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all
 
 # Docker Compose file
 COMPOSE_FILE=compose.yaml
@@ -97,10 +97,20 @@ recover-session:
 checkpoint:
 	@./scripts/checkpoint.sh $(if $(ARGS),$(ARGS))
 
-# Health check target (from PrismBot integration)
+# Health check target
 health-check:
-	@echo "Running PrismBot-style health check..."
+	@echo "Running BMO health check..."
 	@./scripts/bot-health.sh
+
+# BMO recovery target
+recover-bmo:
+	@echo "Running BMO recovery..."
+	@./scripts/bot-recover.sh
+
+# Multi-repo update target
+update-all:
+	@echo "Updating local BMO repos..."
+	@./scripts/update-all.sh
 
 # omni-bmo bridge targets
 omni-sync:

--- a/RESEARCH_CITATION_MODE.md
+++ b/RESEARCH_CITATION_MODE.md
@@ -1,0 +1,22 @@
+# Research Citation Mode
+
+Use this mode for claims about facts, timelines, pricing, policies, technical behavior, or external sources.
+
+## Response Structure (required)
+
+1. **Answer first** (1-3 lines)
+2. **Evidence** (bullets with source + date)
+3. **Confidence** (High/Medium/Low)
+4. **Unknowns / Next check**
+
+## Citation Format
+
+- External: `Source: <url> (accessed YYYY-MM-DD UTC)`
+- Local memory/file: `Source: <path>#Lx-Ly`
+
+## Guardrails
+
+- Do not present assumptions as facts.
+- If evidence conflicts, say so explicitly.
+- If source quality is weak, lower confidence.
+- If no verifiable source is available, state: "I can’t verify this yet."

--- a/docs/BMO_CONSOLIDATION.md
+++ b/docs/BMO_CONSOLIDATION.md
@@ -1,0 +1,49 @@
+# BMO Consolidation Plan
+
+## Canonical runtime
+
+`bmo-stack` is the only live runtime and operator control plane.
+
+- **BMO** is the only front-facing agent.
+- **Council members** are internal subagents / role components.
+- **PrismBot** is archived source material.
+- **omni-bmo** is a donor repo for local embodied runtime features.
+
+## What this means
+
+Do not design new features as if PrismBot is still an active runtime.
+
+Use PrismBot and omni-bmo only for:
+
+- migration reference
+- feature import
+- compatibility notes
+- historical operator workflows worth preserving
+
+## Naming rules going forward
+
+Prefer BMO-first names:
+
+- `BMO_API_TOKEN`
+- `BMO_OMNI_TOKEN`
+- `BMO_OMNI_BASE_URL`
+
+Legacy names such as `PRISMBOT_API_TOKEN` are compatibility fallbacks only.
+
+## Repo roles
+
+- `bmo-stack` = host runtime, orchestration, skills, autonomy, operator policy
+- `omni-bmo` = local embodied runtime donor repo
+- `PrismBot` = archived workspace / product donor repo
+
+## Import priorities
+
+1. operator parity from PrismBot
+2. embodied runtime parity from omni-bmo
+3. only then consider deeper repo consolidation
+
+## Guardrails
+
+- No new feature should require PrismBot to exist as a live runtime.
+- No new feature should use PrismBot naming as the primary contract.
+- BMO remains the source of truth for identity and operator-facing behavior.

--- a/docs/BMO_ON_MY_MACBOOK.md
+++ b/docs/BMO_ON_MY_MACBOOK.md
@@ -1,0 +1,59 @@
+# BMO on My MacBook
+
+## Goal
+
+Run one coherent BMO setup on a MacBook without pretending the old donor repos are still the live runtime.
+
+## What is live
+
+- `bmo-stack` is the only live runtime and operator control plane.
+- BMO is the only front-facing agent.
+- Council members are internal subagents.
+
+## What is archived or donor-only
+
+- `PrismBot` is archived source material.
+- `omni-bmo` is a donor repo for embodied local runtime features.
+
+## Recommended layout
+
+```text
+~/code/
+  bmo-stack/
+  omni-bmo/        # optional donor/runtime bridge target
+  PrismBot/        # optional archived reference copy
+```
+
+## Daily operator flow
+
+From `bmo-stack`:
+
+```bash
+make doctor-plus
+make health-check
+make omni-doctor
+```
+
+If you need to refresh all local repos:
+
+```bash
+make update-all
+```
+
+If BMO is unhealthy:
+
+```bash
+make recover-bmo
+```
+
+## Integration rules
+
+- Keep new runtime logic BMO-first.
+- Use PrismBot docs/scripts as migration references only.
+- Use `omni-bmo` helpers only through BMO bridge scripts unless there is a good reason not to.
+
+## Related
+
+- `docs/BMO_CONSOLIDATION.md`
+- `docs/OMNI_BMO_INTEGRATION.md`
+- `RESEARCH_CITATION_MODE.md`

--- a/docs/OMNI_BMO_INTEGRATION.md
+++ b/docs/OMNI_BMO_INTEGRATION.md
@@ -2,19 +2,22 @@
 
 ## Goal
 
-Run the `omni-bmo` local embodied agent on the same MacBook while keeping `bmo-stack` as the host/orchestration layer.
+Run `omni-bmo` on the same MacBook while keeping `bmo-stack` as the canonical host/orchestration layer.
 
-This bridge does **not** merge the repos. It gives you a clean way to:
+This bridge does **not** make PrismBot a runtime dependency.
+
+It gives you a clean way to:
 
 - sync `omni-bmo`
 - check readiness
-- provide a shared env contract
+- provide a shared BMO-first env contract
 - launch `omni-bmo` from the `bmo-stack` workspace
 
 ## Repo roles
 
-- `bmo-stack` = host/runtime/orchestration stack
-- `omni-bmo` = local embodied runtime (voice, face, vision, local loop)
+- `bmo-stack` = canonical host/runtime/orchestration stack
+- `omni-bmo` = donor repo for local embodied runtime features
+- `PrismBot` = archived donor repo only
 
 ## Quickstart
 
@@ -53,6 +56,16 @@ bash scripts/bmo-omni-launch.sh
 - Omni API health endpoint reachability
 - basic binary availability (`git`, `python3`, `openclaw`, `ollama`, `curl`)
 
+## Naming rules
+
+Prefer these names:
+
+- `BMO_API_TOKEN`
+- `BMO_OMNI_TOKEN`
+- `BMO_OMNI_BASE_URL`
+
+Legacy names such as `PRISMBOT_API_TOKEN` are fallback-only compatibility bridges.
+
 ## Current assumptions
 
 - `omni-bmo` lives at `./omni-bmo` by default
@@ -65,17 +78,18 @@ bash scripts/bmo-omni-launch.sh
 - it does not provision `omni-bmo` dependencies automatically
 - it does not rewrite `omni-bmo/config.json`
 - it does not install LaunchAgent/systemd services for you
-- it does not merge PrismBot or `omni-bmo` app layers into `bmo-stack`
+- it does not make PrismBot a runtime dependency
 
 ## Recommended operator flow
 
-- keep all three repos separate on disk
-- keep `bmo-stack` as the control/orchestration repo
+- keep `bmo-stack` as the source of truth
+- use PrismBot and `omni-bmo` as donor repos only
 - use helper scripts here to verify and launch `omni-bmo`
-- only add tighter integration after the basic bridge is stable
+- only add tighter integration after the bridge is stable
 
 ## Related
 
+- `docs/BMO_CONSOLIDATION.md`
 - `scripts/sync-omni-bmo.sh`
 - `scripts/bmo-omni-doctor.sh`
 - `scripts/bmo-omni-launch.sh`

--- a/scripts/bmo-omni-doctor.sh
+++ b/scripts/bmo-omni-doctor.sh
@@ -32,6 +32,7 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 OMNI_BASE_URL="${BMO_OMNI_BASE_URL:-${OMNI_LOCAL_BASE_URL:-$DEFAULT_OMNI_BASE_URL}}"
+TOKEN_VALUE="${BMO_API_TOKEN:-${BMO_OMNI_TOKEN:-${PRISMBOT_API_TOKEN:-}}}"
 
 check_command() {
   local cmd="$1"
@@ -69,7 +70,7 @@ check_url() {
   fi
 }
 
-printf '%s\n' "omni-bmo bridge doctor"
+printf '%s\n' "BMO omni bridge doctor"
 printf '%s\n' "repo root: $ROOT_DIR"
 printf '%s\n' "omni dir:  $OMNI_DIR"
 printf '%s\n' "env file:  $ENV_FILE"
@@ -88,10 +89,10 @@ check_file "$OMNI_DIR/config.json" "omni-bmo config"
 check_file "$OMNI_DIR/venv/bin/python" "omni-bmo venv python"
 check_file "$ENV_FILE" "bmo omni env"
 
-if [ -n "${PRISMBOT_API_TOKEN:-}" ] || [ -n "${BMO_OMNI_TOKEN:-}" ]; then
-  pass "Omni token environment is configured"
+if [ -n "$TOKEN_VALUE" ]; then
+  pass "BMO/Omni token environment is configured"
 else
-  warn "No Omni token configured (set PRISMBOT_API_TOKEN or BMO_OMNI_TOKEN if required)"
+  warn "No BMO/Omni token configured (prefer BMO_API_TOKEN or BMO_OMNI_TOKEN; PRISMBOT_API_TOKEN is legacy-only)"
 fi
 
 check_url "$OMNI_BASE_URL/health"

--- a/scripts/bmo-omni-launch.sh
+++ b/scripts/bmo-omni-launch.sh
@@ -15,7 +15,7 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 OMNI_BASE_URL="${BMO_OMNI_BASE_URL:-${OMNI_LOCAL_BASE_URL:-$DEFAULT_OMNI_BASE_URL}}"
-TOKEN_VALUE="${BMO_OMNI_TOKEN:-${PRISMBOT_API_TOKEN:-}}"
+TOKEN_VALUE="${BMO_API_TOKEN:-${BMO_OMNI_TOKEN:-${PRISMBOT_API_TOKEN:-}}}"
 
 [ -d "$OMNI_DIR" ] || {
   echo "Error: omni-bmo repo not found at $OMNI_DIR" >&2
@@ -33,6 +33,7 @@ if [ -f "$OMNI_DIR/venv/bin/activate" ]; then
   . "$OMNI_DIR/venv/bin/activate"
 fi
 
+export BMO_API_TOKEN="$TOKEN_VALUE"
 export PRISMBOT_API_TOKEN="$TOKEN_VALUE"
 export OMNI_BASE_URL="$OMNI_BASE_URL"
 
@@ -42,9 +43,9 @@ echo "Launching omni-bmo from: $OMNI_DIR"
 echo "Using Omni base URL: $OMNI_BASE_URL"
 
 if [ -n "$TOKEN_VALUE" ]; then
-  echo "Omni token present via environment"
+  echo "BMO/Omni token present via environment"
 else
-  echo "Warning: no Omni token present in environment"
+  echo "Warning: no BMO/Omni token present in environment"
 fi
 
 exec python3 agent.py

--- a/scripts/bot-recover.sh
+++ b/scripts/bot-recover.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+command -v openclaw >/dev/null 2>&1 || {
+  echo "Error: openclaw CLI not found in PATH" >&2
+  exit 1
+}
+
+echo "[1/5] Restarting gateway service..."
+openclaw gateway restart
+
+echo "[2/5] Waiting for warm-up..."
+sleep 5
+
+echo "[3/5] Checking gateway status..."
+openclaw gateway status || true
+
+echo "[4/5] Running BMO health check..."
+bash "$SCRIPT_DIR/bot-health.sh" || true
+
+echo "[5/5] Running omni-bmo bridge doctor (if present)..."
+if [ -f "$SCRIPT_DIR/bmo-omni-doctor.sh" ]; then
+  bash "$SCRIPT_DIR/bmo-omni-doctor.sh" || true
+else
+  echo "omni-bmo bridge doctor not present; skipping"
+fi
+
+echo "Recovery pass complete."
+echo "If issues persist, run: openclaw gateway status && openclaw status"

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BMO_STACK_DIR="${BMO_STACK_DIR:-$ROOT_DIR}"
+PRISMBOT_DIR="${PRISMBOT_DIR:-$ROOT_DIR/PrismBot}"
+OMNI_BMO_DIR="${OMNI_BMO_DIR:-$ROOT_DIR/omni-bmo}"
+
+log() {
+  printf '[update-all] %s\n' "$*"
+}
+
+sync_repo() {
+  local name="$1"
+  local dir="$2"
+
+  if [ ! -d "$dir/.git" ]; then
+    log "$name: missing repo at $dir, skipping"
+    return 0
+  fi
+
+  log "$name: fetch"
+  git -C "$dir" fetch --all --prune
+
+  if [ -n "$(git -C "$dir" status --porcelain)" ]; then
+    log "$name: dirty tree, skipping pull (commit/stash first)"
+    return 0
+  fi
+
+  log "$name: pull --ff-only"
+  git -C "$dir" pull --ff-only
+}
+
+command -v git >/dev/null 2>&1 || {
+  echo "Error: git not found in PATH" >&2
+  exit 1
+}
+
+log "bmo-stack: $BMO_STACK_DIR"
+log "PrismBot archive: $PRISMBOT_DIR"
+log "omni-bmo: $OMNI_BMO_DIR"
+
+sync_repo "bmo-stack" "$BMO_STACK_DIR"
+sync_repo "PrismBot archive" "$PRISMBOT_DIR"
+
+if [ -d "$OMNI_BMO_DIR/.git" ]; then
+  sync_repo "omni-bmo" "$OMNI_BMO_DIR"
+else
+  log "omni-bmo: not present, using bridge sync helper"
+  bash "$ROOT_DIR/scripts/sync-omni-bmo.sh"
+fi
+
+log "done"


### PR DESCRIPTION
## Summary
- import research citation mode into `bmo-stack`
- add `scripts/bot-recover.sh` and `scripts/update-all.sh`
- make omni bridge scripts BMO-first while keeping legacy compatibility
- add consolidation docs for BMO as the only live runtime
- add `make recover-bmo` and `make update-all`

## Why
BMO is the only active runtime now, and council members are internal subagents. This pass moves operator parity and runtime naming toward that reality without trying to merge all donor repos at once.

## Notes
- additive only
- keeps a legacy compatibility fallback in bridge scripts
- makes BMO-first naming and docs the default going forward
