### PR TITLE
feat: improve site caretaker path discovery

### DIFF
--- a/docs/BMO_SITE_CARETAKER.md
+++ b/docs/BMO_SITE_CARETAKER.md
@@ -1,0 +1,42 @@
+# BMO Site Caretaker
+
+## Purpose
+
+Inventory the legacy `prismtek-site` donor and the `prismtek-site-replica` React/Vite candidate, then emit a controlled migration plan artifact.
+
+## Commands
+
+Basic run:
+
+```bash
+python3 scripts/bmo-site-caretaker.py
+```
+
+Explicit paths:
+
+```bash
+python3 scripts/bmo-site-caretaker.py \
+  --site-dir ~/prismtek-site \
+  --replica-dir ~/prismtek-site-replica
+```
+
+If the default paths do not exist, the helper searches under the discovery root and reports candidate paths:
+
+```bash
+python3 scripts/bmo-site-caretaker.py --discovery-root ~
+```
+
+You can also set:
+
+- `BMO_SITE_DIR`
+- `BMO_SITE_REPLICA_DIR`
+- `BMO_SITE_DISCOVERY_ROOT`
+
+## Output
+
+Writes `workflows/bmo-site-caretaker.json` containing:
+
+- site inventory
+- replica inventory
+- discovery candidates when paths are missing
+- route-level migration plan

--- a/scripts/bmo-site-caretaker.py
+++ b/scripts/bmo-site-caretaker.py
@@ -3,11 +3,32 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 DEFAULT_SITE_DIR = Path.home() / "prismtek-site"
 DEFAULT_REPLICA_DIR = Path.home() / "prismtek-site-replica"
 DEFAULT_OUTPUT = Path("workflows") / "bmo-site-caretaker.json"
+DEFAULT_DISCOVERY_ROOT = Path.home()
+MAX_DISCOVERY_DEPTH = 4
+
+
+def within_depth(base: Path, candidate: Path, max_depth: int) -> bool:
+    try:
+        rel = candidate.relative_to(base)
+    except ValueError:
+        return False
+    return len(rel.parts) <= max_depth
+
+
+def discover_repo(root: Path, name: str) -> list[str]:
+    if not root.exists():
+        return []
+    matches: list[str] = []
+    for path in root.rglob(name):
+        if path.is_dir() and within_depth(root, path, MAX_DISCOVERY_DEPTH):
+            matches.append(str(path))
+    return sorted(set(matches))[:20]
 
 
 def scan_site(root: Path) -> dict[str, object]:
@@ -86,18 +107,33 @@ def build_plan(site: dict[str, object], replica: dict[str, object]) -> list[dict
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Inventory prismtek-site and prismtek-site-replica for BMO caretaker routing.")
-    parser.add_argument("--site-dir", default=str(DEFAULT_SITE_DIR))
-    parser.add_argument("--replica-dir", default=str(DEFAULT_REPLICA_DIR))
+    parser.add_argument("--site-dir", default=os.environ.get("BMO_SITE_DIR", str(DEFAULT_SITE_DIR)))
+    parser.add_argument("--replica-dir", default=os.environ.get("BMO_SITE_REPLICA_DIR", str(DEFAULT_REPLICA_DIR)))
+    parser.add_argument("--discovery-root", default=os.environ.get("BMO_SITE_DISCOVERY_ROOT", str(DEFAULT_DISCOVERY_ROOT)))
     parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
     args = parser.parse_args()
 
-    site = scan_site(Path(args.site_dir).expanduser())
-    replica = scan_replica(Path(args.replica_dir).expanduser())
+    site_path = Path(args.site_dir).expanduser()
+    replica_path = Path(args.replica_dir).expanduser()
+    discovery_root = Path(args.discovery_root).expanduser()
+
+    site = scan_site(site_path)
+    replica = scan_replica(replica_path)
     payload = {
         "site": site,
         "replica": replica,
+        "discovery": {
+            "root": str(discovery_root),
+            "site_candidates": [] if site["exists"] else discover_repo(discovery_root, "prismtek-site"),
+            "replica_candidates": [] if replica["exists"] else discover_repo(discovery_root, "prismtek-site-replica"),
+        },
         "migration_plan": build_plan(site, replica),
     }
+
+    if not site["exists"] and payload["discovery"]["site_candidates"]:
+        payload["site"]["hint"] = "Use --site-dir with one of discovery.site_candidates."
+    if not replica["exists"] and payload["discovery"]["replica_candidates"]:
+        payload["replica"]["hint"] = "Use --replica-dir with one of discovery.replica_candidates."
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add discovery-root scanning to the site caretaker helper when default paths are missing
- support environment-based site and replica path overrides
- add docs for site caretaker usage and discovery behavior

## Why
The first site caretaker pass reported missing site repos because the default host paths were not present. This pass makes the helper usable across real host layouts without guesswork.

## Notes
- additive only
- does not publish or mutate site repos
- focused on discovery and operator visibility
