### PR TITLE
canonicalize root context doc stubs

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,21 +1,4 @@
 # BACKLOG
 
-Critical:
-1. Keep ~/bmo-context as the canonical truth source. [DONE]
-2. Make the host bot read context files before answering setup questions. [DONE]
-3. Stop trusting stale NemoClaw registry state over openshell sandbox list. [DONE]
-4. Re-seed worker bootstrap when a new sandbox is created. [DONE]
-5. Keep host vs worker responsibilities explicit. [DONE]
-6. Implement restart recovery protocol: at session start, read host context first, check TASK_STATE.md and WORK_IN_PROGRESS.md, inspect git status before asking user to restate anything. [DONE]
-
-Important:
-6. Add a one-command worker status check. [DONE]
-7. Add a one-command context reseed. [DONE]
-8. Clean up naming consistency. [DONE]
-9. Turn planning docs into implementation-ready tasks. [DONE]
-10. Reduce reply fragmentation. [DONE]
-
-Nice-to-have:
-11. Easier worker auth for openclaw tui. [DONE]
-12. Add a project-state snapshot generator. [DONE]
-13. Preserve important docs in a real repo later. [DONE - using bmo-context git repo]
+Canonical backlog lives in `context/BACKLOG.md`.
+This root-level file is a compatibility stub so the repo does not carry a stale duplicate.

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -1,34 +1,4 @@
-# BMO-tron Bootstrap
+# BOOTSTRAP.md
 
-You are BMO-tron.
-The user is Prismtek.
-
-Rules:
-- Be direct and practical.
-- Lead with the answer.
-- Verify before claiming.
-- Separate facts from assumptions.
-- Reply in one message unless asked otherwise.
-- Do not ask who I am or who you are unless told to reset.
-- Do not modify IDENTITY.md, MEMORY.md, preferences, or skills unless explicitly asked.
-- Do not invent files, repo contents, or architecture.
-
-Before answering setup or architecture questions, read:
-- ~/bmo-context/BOOTSTRAP.md
-- ~/bmo-context/SESSION_STATE.md
-- ~/bmo-context/SYSTEMMAP.md
-- ~/bmo-context/RUNBOOK.md
-- ~/bmo-context/BACKLOG.md
-
-Current architecture:
-- Host OpenClaw handles Telegram replies.
-- NemoClaw / OpenShell is the sandboxed worker.
-- Worker sandbox name: bmo-tron.
-- Important context should live in ~/bmo-context, not only inside the sandbox.
-
-Restart recovery:
-- At every session start, read host context first (BOOTSTRAP.md, SESSION_STATE.md, SYSTEMMAP.md, RUNBOOK.md, BACKLOG.md)
-- Then read local session files (SOUL.md, USER.md, memory/YYYY-MM-DD.md, MEMORY.md if main session)
-- Check TASK_STATE.md and WORK_IN_PROGRESS.md for interrupted work
-- Inspect git status of current repo before asking to restate anything
-- Resume interrupted work when safe
+Canonical bootstrap guidance lives in `context/BOOTSTRAP.md`.
+This root-level file is a compatibility stub so the repo does not carry a stale duplicate.

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -1,26 +1,4 @@
-# Session State
+# SESSION_STATE.md
 
-Current architecture:
-- Host OpenClaw = Telegram-facing bot
-- NemoClaw / OpenShell = sandboxed worker
-- Current worker sandbox name: bmo-tron
-- Canonical context folder: ~/bmo-context
-
-Important decisions:
-1. Telegram runs on host, not in the sandbox.
-2. NemoClaw is a worker, not the main Telegram delivery path.
-3. Context should not live only inside the sandbox.
-4. Share project files, not live runtime state.
-5. Prefer one-message replies unless asked otherwise.
-
-Restart recovery:
-- At every session start, read host context first (BOOTSTRAP.md, SESSION_STATE.md, SYSTEMMAP.md, RUNBOOK.md, BACKLOG.md)
-- Then read local session files (SOUL.md, USER.md, memory/YYYY-MM-DD.md, MEMORY.md if main session)
-- Check TASK_STATE.md and WORK_IN_PROGRESS.md for interrupted work
-- Inspect git status of current repo before asking to restate anything
-- Resume interrupted work when safe
-
-Known facts:
-- Earlier sandbox-local files should be assumed lost unless recovered elsewhere.
-- nemoclaw list can be stale.
-- openshell sandbox list is the live source of truth.
+Canonical session state lives in `context/SESSION_STATE.md`.
+This root-level file is a compatibility stub so the repo does not carry a stale duplicate.

--- a/SYSTEMMAP.md
+++ b/SYSTEMMAP.md
@@ -1,23 +1,4 @@
-# SYSTEMMAP
+# SYSTEMMAP.md
 
-Main parts of the ecosystem:
-- Prismbot-BMO
-- Prismtek.dev
-- omni-bmo
-- nemoclaw
-
-Confirmed facts:
-- omni-bmo is the local-first / edge-agent project.
-- Prismtek.dev is the public-facing site.
-- nemoclaw provides sandboxed execution in OpenShell.
-- Host OpenClaw handles Telegram.
-- bmo-tron is the worker sandbox.
-
-Assumptions:
-- Prismbot-BMO is the broader system / coordination repo.
-- Some patterns in this setup were adapted from the PrismBot repos.
-
-Current operating model:
-- Host bot = conversation + stable context
-- ~/bmo-context = persistent truth source
-- bmo-tron sandbox = worker / execution surface
+Canonical system mapping lives in `context/SYSTEMMAP.md`.
+This root-level file is a compatibility stub so the repo does not carry a stale duplicate.


### PR DESCRIPTION
## Summary
- convert root BACKLOG.md, BOOTSTRAP.md, SESSION_STATE.md, and SYSTEMMAP.md into compatibility stubs
- point each file to the canonical copy under context/
- keep TASK_STATE.md and WORK_IN_PROGRESS.md unchanged in this pass
