### PR TITLE
add donor policies website continuation and skill scaffolding

### DIFF
--- a/context/delivery/TELEGRAM.md
+++ b/context/delivery/TELEGRAM.md
@@ -1,0 +1,55 @@
+# Telegram Delivery Contract
+
+This file defines the host-side delivery expectations for BMO replies.
+
+## Goals
+
+- keep replies predictable
+- avoid false completion claims
+- preserve verified results even when delivery has trouble
+- make failures visible to operators
+
+## Message modes
+
+### 1. Direct reply
+Use when the task is simple and already verified.
+
+### 2. Acknowledge then complete
+Use when work is non-trivial and a short acknowledgement reduces confusion.
+Acknowledgement should not imply the work is already complete.
+
+### 3. Failure surface
+Use when the verified result exists but delivery or runtime behavior prevented the normal reply path.
+The system should preserve the verified result and surface a concise fallback when possible.
+
+## Rules
+
+- Never say a task is done before verification passes.
+- Prefer one coherent message over multiple fragments.
+- If a reply is long, shorten structure first before dropping critical facts.
+- Delivery failures must be recorded in operator-visible state.
+- Do not silently retry forever.
+
+## Suggested delivery record
+
+```json
+{
+  "ack_sent": false,
+  "verified": true,
+  "delivery_status": "sent",
+  "fallback_needed": false
+}
+```
+
+## Retry guidance
+
+- first failure: record and retry once on the same path when safe
+- repeated failure: preserve the result, mark delivery as failed, and surface via the next available operator-visible path
+
+## Website work note
+
+For prismtek.dev migration work, replies should include:
+- route or page touched
+- acceptance state
+- blockers if any
+- next concrete build step

--- a/context/donors/DONORS.yaml
+++ b/context/donors/DONORS.yaml
@@ -1,0 +1,65 @@
+version: 1
+lastReviewed: 2026-03-25
+
+repos:
+  - name: bmo-stack
+    role: canonical_runtime
+    status: active
+    importPolicy:
+      allowed:
+        - host runtime contracts
+        - council rules
+        - delivery rules
+        - context and memory policy
+      forbidden:
+        - importing donor repo code without explicit review
+    notes: |
+      This repo is the source of truth for the live BMO/OpenClaw stack.
+
+  - name: prismtek-site
+    role: content_donor
+    status: active
+    importPolicy:
+      allowed:
+        - route inventory
+        - copy and content blocks
+        - static asset inventory
+        - Cloudflare Pages deploy assumptions
+      forbidden:
+        - runtime architecture
+        - agent policy
+        - worker logic
+    notes: |
+      Use this repo to preserve and migrate prismtek.dev content.
+      Treat it as a website/content donor, not as a runtime donor.
+
+  - name: omni-bmo
+    role: runtime_ops_donor
+    status: active
+    importPolicy:
+      allowed:
+        - runtime profile patterns
+        - validation matrix patterns
+        - doctor and launcher patterns
+        - local-first fallback ideas
+        - voice and reactive-face runtime ideas
+      forbidden:
+        - Pi/hardware-specific assumptions as global defaults
+        - enclosure-specific or device-specific policy as canonical stack behavior
+    notes: |
+      Mine this repo for runtime discipline and validation rigor.
+
+  - name: PrismBot
+    role: policy_product_donor
+    status: active
+    importPolicy:
+      allowed:
+        - AGENTS conventions
+        - memory and heartbeat patterns
+        - website factory standards
+        - operator UX concepts
+      forbidden:
+        - importing the monorepo app sprawl into bmo-stack
+        - treating PrismBot runtime layout as the canonical BMO runtime
+    notes: |
+      Mine this repo for product patterns and operator ergonomics, not for direct stack structure.

--- a/context/identity/AGENTS.md
+++ b/context/identity/AGENTS.md
@@ -21,6 +21,56 @@ Read that file for the full ordered list. Short form:
 
 Don't ask permission. Just do it.
 
+## Skill Discovery
+
+Do not crawl the repo blindly for operational behavior.
+Start with `context/skills/SKILLS.md`.
+Use the listed skills before inventing a workflow from memory.
+
+## Donor Repo Policy
+
+BMO inherits ideas from earlier repos, but they are not all equal.
+
+- `bmo-stack` is the canonical runtime and policy repo.
+- `prismtek-site` is a **content donor** for prismtek.dev migration work.
+- `omni-bmo` is a **runtime and ops donor**.
+- `PrismBot` is a **policy and product donor**.
+
+Check `context/donors/DONORS.yaml` before importing ideas.
+Do not treat donor repos as canonical runtime truth.
+
+## Website Continuation
+
+When working on `https://prismtek.dev`, use the site migration skill and donor policy.
+Prefer controlled migration over blind merges.
+Preserve route ownership, copy blocks, CTA flow, and deployment assumptions.
+Record page-level acceptance criteria before claiming the work is done.
+
+## Fast Path vs Council Path
+
+Use the fast path for:
+- simple docs changes
+- simple repo inspection
+- straightforward website content or route work
+- obvious low-risk bug fixes
+
+Use council mode for:
+- architecture changes
+- delivery contract changes
+- runtime policy changes
+- risky releases
+- ambiguous strategy decisions
+
+## Claim Completion Protocol
+
+Before saying a task is done:
+
+1. Verify the requested change exists.
+2. Verify the result matches the request.
+3. Record blockers or caveats explicitly.
+4. For runtime/delivery work, do not claim completion before validation passes.
+5. For website work, include the page or route touched and the current acceptance state.
+
 ## Memory
 
 You wake up fresh each session. These files are your continuity:
@@ -179,7 +229,7 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 **When to reach out:**
 
 - Important email arrived
-- Calendar event coming up (&lt;2h)
+- Calendar event coming up (<2h)
 - Something interesting you found
 - It's been >8h since you said anything
 
@@ -188,7 +238,7 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 - Late night (23:00-08:00) unless urgent
 - Human is clearly busy
 - Nothing new since last check
-- You just checked &lt;30 minutes ago
+- You just checked <30 minutes ago
 
 **Proactive work you can do without asking:**
 

--- a/context/ops/RUNTIME_VALIDATION.md
+++ b/context/ops/RUNTIME_VALIDATION.md
@@ -1,0 +1,46 @@
+# Runtime Validation
+
+Use this before claiming a profile, launcher, or routing change is stable.
+
+## Preconditions
+
+- the intended runtime env file exists
+- the launcher can run in dry-run mode
+- the router produces a valid route payload
+- delivery and verification expectations are known for the task class
+
+## Minimum validation matrix
+
+### 1. Routing
+- run a dry route check for one light task and one heavy task
+- verify the selected route and reason are explicit
+
+### 2. Launch contract
+- run launcher dry-run
+- verify route, model, endpoint, and api style fields are populated as expected
+
+### 3. Failure / degradation
+- simulate unavailable cloud route or unavailable local dependency
+- verify fallback behavior is explicit and non-silent
+
+### 4. Interaction sanity
+- complete one short end-to-end interaction for the intended route
+- verify the runtime returns to an idle/ready state
+
+### 5. Delivery alignment
+- verify the delivery contract still matches runtime behavior
+- do not claim completion if runtime output cannot be delivered
+
+## Output format
+
+Record:
+- date
+- profile or route under test
+- task classes checked
+- pass/fail per step
+- known caveats
+- next action
+
+## Notes
+
+Borrow validation discipline from `omni-bmo`, but do not import Pi-specific or hardware-specific assumptions as stack-wide defaults.

--- a/context/sites/prismtek.dev/CONTINUATION.md
+++ b/context/sites/prismtek.dev/CONTINUATION.md
@@ -1,0 +1,60 @@
+# prismtek.dev Continuation Plan
+
+This file helps BMO continue building `https://prismtek.dev` without losing donor context.
+
+## Donor sources
+
+### `prismtek-site`
+Use for:
+- static site content recovery
+- route and asset inventory
+- Cloudflare Pages deployment assumptions
+
+Known donor fact:
+- the repo describes itself as a static export of `prismtek.dev` for Cloudflare Pages hosting
+- custom domain: `prismtek.dev`
+
+### `PrismBot`
+Use for:
+- website factory standards
+- conversion-oriented page structure
+- reusable section patterns
+
+Known donor fact:
+- `WEBSITE_FACTORY_STANDARD.md` defines a default Wix-like production pattern
+- `apps/prismbot-site/website-template-wixlike.html` is a reusable landing-page scaffold
+
+## Working rules
+
+1. Treat `prismtek-site` as the content donor, not the runtime donor.
+2. Rebuild route by route instead of doing blind merges.
+3. Preserve CTA flow and editable copy blocks.
+4. Record route ownership and acceptance criteria before claiming a page is complete.
+
+## Recommended route-by-route workflow
+
+1. Identify target route
+2. Pull donor content and asset references
+3. Rebuild with reusable sections
+4. Check mobile responsiveness
+5. Check CTA path and link integrity
+6. Record acceptance state
+
+## Route inventory starter
+
+Fill this out as work continues:
+
+- `/` — homepage — status: TODO
+- `/services` — status: TODO
+- `/portfolio` — status: TODO
+- `/about` — status: TODO
+- `/contact` — status: TODO
+
+## Acceptance checklist for each page
+
+- responsive from 320px to desktop
+- clear primary CTA
+- clear secondary CTA or next step
+- no broken links
+- copy blocks easy to edit
+- deployment target noted

--- a/context/skills/SKILLS.md
+++ b/context/skills/SKILLS.md
@@ -1,0 +1,26 @@
+# Skills Index
+
+This file is the entry point for skill discovery.
+Use it first instead of crawling the repo.
+
+## Core operational skills
+
+- `context/skills/context-bootstrap.skill.md`
+  - Trigger: cold start, restart recovery, interrupted work check
+  - Use when BMO needs to become operational safely before acting
+
+- `context/skills/donor-ingest.skill.md`
+  - Trigger: importing ideas, docs, routes, runtime behavior, or policy from old repos
+  - Use when work references `prismtek-site`, `omni-bmo`, or `PrismBot`
+
+- `context/skills/site-migration.skill.md`
+  - Trigger: prismtek.dev migration, page recreation, route inventory, asset parity
+  - Use when building or continuing the website
+
+- `context/skills/runtime-validation.skill.md`
+  - Trigger: profile changes, runtime changes, release readiness, smoke checks
+  - Use before claiming runtime stability
+
+- `context/skills/delivery-contract.skill.md`
+  - Trigger: Telegram reply shaping, delivery retries, fallback messaging
+  - Use when changing host delivery behavior or debugging reply failures

--- a/context/skills/context-bootstrap.skill.md
+++ b/context/skills/context-bootstrap.skill.md
@@ -1,0 +1,36 @@
+# Skill: Context Bootstrap
+
+## Purpose
+
+Bring BMO into a safe operational state before acting.
+Use this on cold start, after interruption, or when context confidence is low.
+
+## Inputs
+
+- `context/RUNBOOK.md`
+- `context/identity/SOUL.md`
+- `context/identity/USER.md`
+- `context/identity/IDENTITY.md`
+- `TASK_STATE.md`
+- `WORK_IN_PROGRESS.md`
+- `memory/YYYY-MM-DD.md` (today + yesterday)
+- `MEMORY.md` in the main session only
+
+## Procedure
+
+1. Read the startup order from `context/RUNBOOK.md`.
+2. Load identity and user files.
+3. Load recent memory.
+4. Inspect `TASK_STATE.md` and `WORK_IN_PROGRESS.md` for interrupted work.
+5. Check git status before asking the human to restate anything.
+6. Emit a short restart-recovery summary:
+   - current repo / branch
+   - interrupted task if any
+   - safe-to-resume state
+   - immediate next step
+
+## Rules
+
+- Do not ask the user to restate context until this skill has run.
+- Prefer canonical `context/` docs over stale root duplicates.
+- Do not claim recovery is complete until interrupted work and git status have been checked.

--- a/context/skills/delivery-contract.skill.md
+++ b/context/skills/delivery-contract.skill.md
@@ -1,0 +1,35 @@
+# Skill: Delivery Contract
+
+## Purpose
+
+Keep host delivery predictable when BMO replies through OpenClaw.
+
+## Use when
+
+- changing Telegram reply behavior
+- deciding whether to acknowledge first or wait for verification
+- handling delivery failures or retries
+- shaping long replies for chat delivery
+
+## Rules
+
+1. Prefer one coherent message when the task is simple.
+2. For longer work, send a short acknowledgement only when it reduces user confusion.
+3. Never claim completion before verification has passed.
+4. If delivery fails, record the failure and surface a fallback message on the next available path.
+5. Long replies should degrade by structure first, not by dropping important facts.
+
+## Output contract
+
+Every delivery decision should be explicit about:
+
+- `ack_sent`: yes/no
+- `verified`: yes/no
+- `delivery_status`: sent|deferred|failed
+- `fallback_needed`: yes/no
+
+## Failure handling
+
+- Do not silently swallow delivery errors.
+- Preserve the verified result even if the first send attempt fails.
+- Prefer operator-visible failure logs over invisible retry loops.

--- a/context/skills/donor-ingest.skill.md
+++ b/context/skills/donor-ingest.skill.md
@@ -1,0 +1,30 @@
+# Skill: Donor Ingest
+
+## Purpose
+
+Import useful patterns from donor repos without creating source-of-truth drift.
+
+## Canonical donor roles
+
+- `prismtek-site` = content donor
+- `omni-bmo` = runtime and ops donor
+- `PrismBot` = policy and product donor
+
+## Procedure
+
+1. Identify the donor repo and confirm its role in `context/donors/DONORS.yaml`.
+2. State what is being imported:
+   - content
+   - runtime behavior
+   - validation pattern
+   - policy / docs pattern
+3. State where it will land in `bmo-stack`.
+4. Record what is intentionally *not* imported.
+5. Prefer extracting contracts, docs, and acceptance criteria before copying implementation details.
+
+## Rules
+
+- Do not import runtime architecture from `prismtek-site`.
+- Do not import app sprawl from `PrismBot`.
+- Do not import device-specific assumptions from `omni-bmo` as stack-wide defaults.
+- Every donor import should leave a clear trail in docs or commit messages.

--- a/context/skills/runtime-validation.skill.md
+++ b/context/skills/runtime-validation.skill.md
@@ -1,0 +1,38 @@
+# Skill: Runtime Validation
+
+## Purpose
+
+Prevent BMO from claiming a runtime or profile is stable without a repeatable validation pass.
+
+## Use when
+
+- changing runtime profiles
+- changing routing behavior
+- changing delivery/runtime integration
+- changing launch scripts, doctor scripts, or degradation behavior
+
+## Minimum matrix
+
+1. Route selection check
+2. Dry-run launch check
+3. Delivery fallback check
+4. Recovery-to-idle check after failure
+5. One short interactive loop check
+6. One profile-specific latency sanity check
+
+## Output
+
+Record:
+
+- profile name
+- task class used for checks
+- route chosen
+- pass/fail per check
+- known caveats
+- next action if any check failed
+
+## Rules
+
+- Do not claim stability from one happy-path run.
+- Prefer a written validation note over an implicit "seems fine".
+- When borrowing validation ideas from `omni-bmo`, strip out device-specific assumptions unless explicitly relevant.

--- a/context/skills/site-migration.skill.md
+++ b/context/skills/site-migration.skill.md
@@ -1,0 +1,32 @@
+# Skill: Site Migration
+
+## Purpose
+
+Help BMO continue building and migrating `https://prismtek.dev` safely.
+
+## Donor sources
+
+- `prismtek-site` for content, routes, and deploy assumptions
+- `PrismBot` for website factory and conversion-minded section standards
+
+## Procedure
+
+1. Inventory the target page or route.
+2. Identify source content blocks, assets, and expected CTA flow.
+3. Rebuild using reusable sections instead of one-off page hacks.
+4. Preserve deployment assumptions and redirects.
+5. Emit acceptance criteria before claiming the page is done.
+
+## Acceptance criteria
+
+- mobile-first responsive layout
+- clear CTA path above and below the fold
+- editable copy blocks
+- no broken links or placeholder buttons left behind
+- explicit route ownership and deploy target noted
+
+## Rules
+
+- Do not blindly merge donor UI/runtime code into the live site.
+- Treat `prismtek-site` as a content donor, not a runtime donor.
+- Prefer controlled migration with route-by-route acceptance checks.


### PR DESCRIPTION
## Summary
- add donor manifest and skill index so BMO can safely use prior repos as structured donors
- add skills for context bootstrap, donor ingest, site migration, runtime validation, and delivery contract handling
- add Telegram delivery and runtime validation docs
- add a prismtek.dev continuation plan for route-by-route website work
- upgrade `context/identity/AGENTS.md` with donor policy, skill discovery, website continuation, fast-path vs council-path, and claim-completion rules

## Donor intent
- `prismtek-site` = content donor
- `omni-bmo` = runtime/ops donor
- `PrismBot` = policy/product donor

## Notes
This PR is intentionally documentation-and-policy first. It gives BMO a cleaner operational contract for continuing the website and for reusing the old repos without turning them into hidden sources of truth.