### PR TITLE
add prismtek website execution support and checklists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync site-caretaker launchd-install
+.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync site-caretaker site-route-report site-page-checklist launchd-install
 
 # Docker Compose file
 COMPOSE_FILE=compose.yaml
@@ -166,6 +166,12 @@ workspace-sync:
 
 site-caretaker:
 	@python3 ./scripts/bmo-site-caretaker.py $(if $(ARGS),$(ARGS))
+
+site-route-report:
+	@python3 ./scripts/prismtek_site_route_report.py
+
+site-page-checklist:
+	@cat ./context/council/NEPTR_WEBSITE_CHECKLIST.md
 
 launchd-install:
 	@python3 ./scripts/bmo-launchd-install.py $(if $(ARGS),$(ARGS))

--- a/context/council/NEPTR_WEBSITE_CHECKLIST.md
+++ b/context/council/NEPTR_WEBSITE_CHECKLIST.md
@@ -1,0 +1,38 @@
+# NEPTR Website Checklist
+
+Use this checklist before claiming a prismtek.dev page or route is complete.
+
+## Route verification
+
+- [ ] target route is recorded in `context/sites/prismtek.dev/ROUTES.json`
+- [ ] route status is updated correctly
+- [ ] route ownership is clear
+
+## Content verification
+
+- [ ] donor content was preserved or intentionally rewritten
+- [ ] page purpose is obvious above the fold
+- [ ] placeholders are explicit and not disguised as finished content
+
+## CTA verification
+
+- [ ] primary CTA is present and clear
+- [ ] secondary CTA or next-step path exists where appropriate
+- [ ] CTA destinations are valid
+
+## UX verification
+
+- [ ] responsive check completed
+- [ ] link check completed
+- [ ] section parity is acceptable for the route stage
+
+## Delivery / reporting verification
+
+- [ ] acceptance result is recorded in `PAGE_ACCEPTANCE.md`
+- [ ] blockers or caveats are recorded if the route is not accepted
+- [ ] final report names the route touched and the current acceptance state
+
+## Rule
+
+If any required item above is not satisfied, do not claim the route is done.
+Mark it `in_progress` or `blocked` instead.

--- a/context/sites/prismtek.dev/CONTINUATION.md
+++ b/context/sites/prismtek.dev/CONTINUATION.md
@@ -30,31 +30,34 @@ Known donor fact:
 2. Rebuild route by route instead of doing blind merges.
 3. Preserve CTA flow and editable copy blocks.
 4. Record route ownership and acceptance criteria before claiming a page is complete.
+5. Prefer reusable sections over page-specific hacks.
 
-## Recommended route-by-route workflow
+## Execution files
 
-1. Identify target route
-2. Pull donor content and asset references
-3. Rebuild with reusable sections
-4. Check mobile responsiveness
-5. Check CTA path and link integrity
-6. Record acceptance state
+- `context/sites/prismtek.dev/ROUTE_INVENTORY.md`
+- `context/sites/prismtek.dev/SECTION_LIBRARY.md`
+- `context/sites/prismtek.dev/PAGE_ACCEPTANCE.md`
+- `context/sites/prismtek.dev/MIGRATION_WORKFLOW.md`
+- `context/sites/prismtek.dev/DEPLOY_NOTES.md`
+- `context/council/NEPTR_WEBSITE_CHECKLIST.md`
 
-## Route inventory starter
+## Current focus
 
-Fill this out as work continues:
+Use the live homepage and donor repos to drive a controlled migration.
+Start with high-traffic pages and shared section blocks first:
 
-- `/` — homepage — status: TODO
-- `/services` — status: TODO
-- `/portfolio` — status: TODO
-- `/about` — status: TODO
-- `/contact` — status: TODO
+1. home
+2. arcade games
+3. projects
+4. downloads
+5. build log
 
-## Acceptance checklist for each page
+## Done rule for website work
 
-- responsive from 320px to desktop
-- clear primary CTA
-- clear secondary CTA or next step
-- no broken links
-- copy blocks easy to edit
-- deployment target noted
+A page is not done until:
+- route ownership is explicit
+- section parity is recorded
+- CTA flow is intact
+- mobile responsiveness is checked
+- link integrity is checked
+- NEPTR website checklist passes

--- a/context/sites/prismtek.dev/DEPLOY_NOTES.md
+++ b/context/sites/prismtek.dev/DEPLOY_NOTES.md
@@ -1,0 +1,27 @@
+# prismtek.dev Deploy Notes
+
+## Target
+
+- static deploy target: Cloudflare Pages
+- custom domain: `prismtek.dev`
+
+## Deployment assumptions
+
+These assumptions come from the donor repo and should be preserved unless intentionally changed.
+
+1. route output should be compatible with static hosting
+2. redirects or path normalization should be captured explicitly
+3. asset paths should remain stable across route-by-route migration
+
+## Route deploy guidance
+
+For each accepted route, record:
+- final route path
+- whether the route is static-only or expects account/gated behavior
+- whether a redirect is required from an old path
+- any asset path caveats
+
+## Operator notes
+
+- do not change deployment assumptions silently while doing page migration work
+- if a route requires behavior that is not compatible with static hosting, record that as a blocker instead of pretending the route is complete

--- a/context/sites/prismtek.dev/MIGRATION_WORKFLOW.md
+++ b/context/sites/prismtek.dev/MIGRATION_WORKFLOW.md
@@ -1,0 +1,38 @@
+# prismtek.dev Migration Workflow
+
+Use this workflow for controlled route-by-route migration.
+
+## Phase 1 — Discover
+
+1. confirm the target route in `ROUTES.json`
+2. gather donor content from `prismtek-site`
+3. identify reusable sections from `SECTION_LIBRARY.md`
+4. identify CTA intent and route priority
+
+## Phase 2 — Rebuild
+
+1. create or update the target page
+2. reuse shared sections instead of one-off layout fragments
+3. keep copy blocks easy to edit
+4. record any intentional rewrites of donor content
+
+## Phase 3 — Verify
+
+1. run the page against `PAGE_ACCEPTANCE.md`
+2. run the website-specific verification checklist in `context/council/NEPTR_WEBSITE_CHECKLIST.md`
+3. update route status in `ROUTES.json`
+4. update task/checkpoint state with blockers or acceptance result
+
+## Phase 4 — Deploy readiness
+
+1. confirm route ownership and target deployment path
+2. confirm links and CTA destinations
+3. note any redirects or path changes needed for Cloudflare Pages
+4. only then mark the route `accepted`
+
+## Rules
+
+- do not migrate multiple unrelated routes in one unverified jump
+- homepage sections should be reused across other pages where possible
+- unfinished account or gated features must fail gracefully
+- route acceptance should be explicit, not implied by a code diff

--- a/context/sites/prismtek.dev/PAGE_ACCEPTANCE.md
+++ b/context/sites/prismtek.dev/PAGE_ACCEPTANCE.md
@@ -1,0 +1,58 @@
+# prismtek.dev Page Acceptance
+
+Use this file before claiming any page is done.
+
+## Per-page acceptance template
+
+```md
+### /route/
+- owner:
+- status: todo|in_progress|blocked|accepted
+- donor source:
+- primary CTA:
+- secondary CTA:
+- mobile check: pass|fail|not_run
+- link check: pass|fail|not_run
+- section parity: pass|partial|fail
+- notes:
+```
+
+## Required checks
+
+### Structure
+- route exists and is linked correctly
+- page has a clear above-the-fold purpose
+- page uses reusable sections where appropriate
+
+### CTA flow
+- primary CTA is obvious
+- CTA copy matches the page goal
+- there is a sensible next step below the fold
+
+### Content
+- key donor copy or content blocks are preserved or intentionally rewritten
+- placeholders are explicit, not disguised as finished content
+- account or gated features fail gracefully
+
+### UX
+- responsive from 320px to desktop
+- no broken buttons or dead-end CTAs
+- visual hierarchy is clear
+
+### Operator checks
+- deploy target or route owner is known
+- known blockers are recorded
+- page status is updated in `ROUTES.json`
+
+## Starter records
+
+### /
+- owner: BMO
+- status: in_progress
+- donor source: prismtek-site + PrismBot website factory standard
+- primary CTA: TODO
+- secondary CTA: TODO
+- mobile check: not_run
+- link check: not_run
+- section parity: partial
+- notes: Homepage is the design-system seed for shared sections.

--- a/context/sites/prismtek.dev/ROUTES.json
+++ b/context/sites/prismtek.dev/ROUTES.json
@@ -1,0 +1,29 @@
+{
+  "site": "prismtek.dev",
+  "lastReviewed": "2026-03-25",
+  "discoverySource": {
+    "live_homepage": "navigation + homepage sections",
+    "donor_repo": "prismtek-site"
+  },
+  "routes": [
+    {"route": "/", "label": "Home", "status": "in_progress", "priority": "P0", "type": "homepage"},
+    {"route": "/arcade-games/", "label": "Arcade Games", "status": "todo", "priority": "P0", "type": "content"},
+    {"route": "/pixel-studio/", "label": "Pixel Studio", "status": "todo", "priority": "P1", "type": "content"},
+    {"route": "/community-center/", "label": "Community Center", "status": "todo", "priority": "P1", "type": "community"},
+    {"route": "/memory-wall/", "label": "Memory Wall", "status": "todo", "priority": "P2", "type": "community"},
+    {"route": "/prism-creatures/", "label": "Prism Creatures", "status": "todo", "priority": "P1", "type": "feature"},
+    {"route": "/my-account/", "label": "My Account", "status": "todo", "priority": "P1", "type": "account"},
+    {"route": "/school-safe/", "label": "School Safe", "status": "todo", "priority": "P2", "type": "policy"},
+    {"route": "/projects/", "label": "Projects", "status": "todo", "priority": "P0", "type": "content"},
+    {"route": "/downloads/", "label": "Downloads", "status": "todo", "priority": "P0", "type": "content"},
+    {"route": "/links/", "label": "Links", "status": "todo", "priority": "P2", "type": "utility"},
+    {"route": "/build-log/", "label": "Build Log", "status": "todo", "priority": "P0", "type": "content"}
+  ],
+  "homepageSections": [
+    "welcome intro",
+    "quick start CTA row",
+    "featured games carousel",
+    "creature showcase",
+    "account actions"
+  ]
+}

--- a/context/sites/prismtek.dev/ROUTE_INVENTORY.md
+++ b/context/sites/prismtek.dev/ROUTE_INVENTORY.md
@@ -1,0 +1,52 @@
+# prismtek.dev Route Inventory
+
+This file is the human-readable route map for continuing `https://prismtek.dev`.
+The machine-readable source is `context/sites/prismtek.dev/ROUTES.json`.
+
+## Priority order
+
+### P0 — build first
+
+- `/` — Home
+- `/arcade-games/` — Arcade Games
+- `/projects/` — Projects
+- `/downloads/` — Downloads
+- `/build-log/` — Build Log
+
+### P1 — build after core content routes
+
+- `/pixel-studio/` — Pixel Studio
+- `/community-center/` — Community Center
+- `/prism-creatures/` — Prism Creatures
+- `/my-account/` — My Account
+
+### P2 — build after core parity is stable
+
+- `/memory-wall/` — Memory Wall
+- `/school-safe/` — School Safe
+- `/links/` — Links
+
+## Homepage sections currently discovered
+
+- global header / nav
+- welcome intro
+- quick-start CTA row
+- featured games carousel
+- creature showcase
+- account actions
+- footer
+
+## Execution rule
+
+When working a route, update all of the following together:
+
+1. route status in `ROUTES.json`
+2. acceptance state in `PAGE_ACCEPTANCE.md`
+3. blocker or caveat notes in the active task state
+
+## Status meanings
+
+- `todo` = not yet migrated or reviewed
+- `in_progress` = active migration work
+- `blocked` = cannot finish without input or dependency
+- `accepted` = route passes the page acceptance checklist

--- a/context/sites/prismtek.dev/SECTION_LIBRARY.md
+++ b/context/sites/prismtek.dev/SECTION_LIBRARY.md
@@ -1,0 +1,91 @@
+# prismtek.dev Section Library
+
+Use this file to keep page builds reusable instead of rebuilding every screen from scratch.
+
+## Core sections
+
+### 1. Global header / nav
+
+Expected links discovered from the live site navigation:
+- Home
+- Arcade Games
+- Pixel Studio
+- Community Center
+- Memory Wall
+- Prism Creatures
+- My Account
+- School Safe
+- Projects
+- Downloads
+- Links
+- Build Log
+
+### 2. Welcome / intro hero
+
+Purpose:
+- orient the visitor immediately
+- explain what Prismtek is
+- route the visitor to the right next step
+
+Required elements:
+- short welcome copy
+- primary CTA row
+- visual identity that can survive route-by-route migration
+
+### 3. Quick-start CTA row
+
+Purpose:
+- push visitors into the highest-value paths fast
+
+Current homepage-derived CTA themes:
+- play / explore
+- build / create
+- download / get started
+- account / return user action
+
+### 4. Featured games block
+
+Purpose:
+- highlight playable or visit-worthy game content
+- provide reusable card layout for arcade/game routes
+
+Required elements:
+- thumbnail or artwork slot
+- short description
+- CTA button
+- metadata slot for platform / status / age band if needed
+
+### 5. Creature showcase block
+
+Purpose:
+- highlight Prism Creatures or similar collectible/showcase content
+- serve as reusable gallery/list pattern
+
+Required elements:
+- image slot
+- title
+- short flavor copy
+- CTA to detail page or collection view
+
+### 6. Account actions block
+
+Purpose:
+- support returning users with account-oriented next steps
+
+Required elements:
+- sign in / continue CTA
+- account status placeholder
+- safe fallback copy if account features are not yet wired
+
+### 7. Footer
+
+Required elements:
+- utility links
+- policy/safety links where relevant
+- deployment/version note if useful for operator debugging
+
+## Reuse rules
+
+- Prefer shared section variants instead of page-specific one-offs.
+- Every new section should declare where else it can be reused.
+- Homepage sections should become the canonical design system seed for the rest of prismtek.dev.

--- a/scripts/prismtek_site_route_report.py
+++ b/scripts/prismtek_site_route_report.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ROUTES_FILE = ROOT / "context" / "sites" / "prismtek.dev" / "ROUTES.json"
+
+
+def main() -> None:
+    data = json.loads(ROUTES_FILE.read_text(encoding="utf-8"))
+    site = data.get("site", "unknown")
+    last_reviewed = data.get("lastReviewed", "unknown")
+    homepage_sections = data.get("homepageSections", [])
+    routes = data.get("routes", [])
+
+    print(f"Site: {site}")
+    print(f"Last reviewed: {last_reviewed}")
+    print("")
+    print("Routes:")
+    for route in routes:
+        print(
+            f"- {route['route']} | {route['label']} | priority={route['priority']} | "
+            f"status={route['status']} | type={route['type']}"
+        )
+
+    if homepage_sections:
+        print("")
+        print("Homepage sections:")
+        for section in homepage_sections:
+            print(f"- {section}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add prismtek.dev route inventory, section library, page acceptance, migration workflow, and deploy notes
- add a website-specific NEPTR checklist so route work is verified before completion is claimed
- add a simple route-report helper script and Makefile targets for website execution support
- update the continuation plan to point at the new execution files

## Why
PR #63 established donor policy and skill scaffolding. This PR adds the next layer: concrete execution support so BMO can continue building prismtek.dev route-by-route with explicit route status, reusable section planning, acceptance criteria, and verification.

## Notes
- this is intentionally website-execution focused, not a broad runtime change
- the route inventory is based on current live-site navigation and the existing donor repos
- Cloudflare Pages remains the documented static deploy target from the donor repo