### PR TITLE
add prismtek site work ledger and route ops helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync site-caretaker site-route-report site-page-checklist launchd-install
+.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-page-checklist launchd-install
 
 # Docker Compose file
 COMPOSE_FILE=compose.yaml
@@ -169,6 +169,15 @@ site-caretaker:
 
 site-route-report:
 	@python3 ./scripts/prismtek_site_route_report.py
+
+site-work-report:
+	@python3 ./scripts/prismtek_site_work_report.py
+
+site-route-scaffold:
+	@python3 ./scripts/prismtek_site_route_scaffold.py $(if $(ARGS),$(ARGS))
+
+site-route-update:
+	@python3 ./scripts/prismtek_site_route_update.py $(if $(ARGS),$(ARGS))
 
 site-page-checklist:
 	@cat ./context/council/NEPTR_WEBSITE_CHECKLIST.md

--- a/context/sites/prismtek.dev/CONTINUATION.md
+++ b/context/sites/prismtek.dev/CONTINUATION.md
@@ -31,14 +31,20 @@ Known donor fact:
 3. Preserve CTA flow and editable copy blocks.
 4. Record route ownership and acceptance criteria before claiming a page is complete.
 5. Prefer reusable sections over page-specific hacks.
+6. Keep route status, ledger status, and acceptance state aligned.
 
 ## Execution files
 
+- `context/sites/prismtek.dev/ROUTES.json`
 - `context/sites/prismtek.dev/ROUTE_INVENTORY.md`
 - `context/sites/prismtek.dev/SECTION_LIBRARY.md`
 - `context/sites/prismtek.dev/PAGE_ACCEPTANCE.md`
 - `context/sites/prismtek.dev/MIGRATION_WORKFLOW.md`
 - `context/sites/prismtek.dev/DEPLOY_NOTES.md`
+- `context/sites/prismtek.dev/WORK_LEDGER.json`
+- `context/sites/prismtek.dev/WORK_LEDGER.md`
+- `context/sites/prismtek.dev/work-items/`
+- `context/sites/prismtek.dev/intake/`
 - `context/council/NEPTR_WEBSITE_CHECKLIST.md`
 
 ## Current focus
@@ -60,4 +66,6 @@ A page is not done until:
 - CTA flow is intact
 - mobile responsiveness is checked
 - link integrity is checked
+- page acceptance is updated
+- work ledger is updated
 - NEPTR website checklist passes

--- a/context/sites/prismtek.dev/WORK_LEDGER.json
+++ b/context/sites/prismtek.dev/WORK_LEDGER.json
@@ -1,0 +1,56 @@
+{
+  "site": "prismtek.dev",
+  "lastUpdated": "2026-03-25T15:00:00Z",
+  "entries": [
+    {
+      "route": "/",
+      "label": "Home",
+      "owner": "BMO",
+      "status": "in_progress",
+      "phase": "discover",
+      "acceptance": "partial",
+      "next_step": "Lock homepage CTA flow and reusable section mapping.",
+      "blockers": []
+    },
+    {
+      "route": "/arcade-games/",
+      "label": "Arcade Games",
+      "owner": "BMO",
+      "status": "todo",
+      "phase": "discover",
+      "acceptance": "pending",
+      "next_step": "Scaffold the route brief and donor intake.",
+      "blockers": []
+    },
+    {
+      "route": "/projects/",
+      "label": "Projects",
+      "owner": "BMO",
+      "status": "todo",
+      "phase": "discover",
+      "acceptance": "pending",
+      "next_step": "Scaffold the route brief and donor intake.",
+      "blockers": []
+    },
+    {
+      "route": "/downloads/",
+      "label": "Downloads",
+      "owner": "BMO",
+      "status": "todo",
+      "phase": "discover",
+      "acceptance": "pending",
+      "next_step": "Scaffold the route brief and donor intake.",
+      "blockers": []
+    },
+    {
+      "route": "/build-log/",
+      "label": "Build Log",
+      "owner": "BMO",
+      "status": "todo",
+      "phase": "discover",
+      "acceptance": "pending",
+      "next_step": "Scaffold the route brief and donor intake.",
+      "blockers": []
+    }
+  ]
+}

--- a/context/sites/prismtek.dev/WORK_LEDGER.md
+++ b/context/sites/prismtek.dev/WORK_LEDGER.md
@@ -1,0 +1,32 @@
+# prismtek.dev Work Ledger
+
+This ledger tracks active website execution work.
+The machine-readable source is `context/sites/prismtek.dev/WORK_LEDGER.json`.
+
+## Purpose
+
+Use this ledger to keep website work operational instead of vague.
+Every active or accepted route should have a ledger entry.
+
+## Entry fields
+
+- `route` — canonical route path
+- `label` — human-readable route name
+- `owner` — current implementation owner
+- `status` — `todo|in_progress|blocked|accepted`
+- `phase` — `discover|rebuild|verify|deploy_ready`
+- `acceptance` — `pending|partial|passed|failed`
+- `next_step` — immediate next action
+- `blockers` — explicit blockers list
+
+## Rules
+
+- Update the ledger whenever route status changes.
+- Keep `ROUTES.json` and `WORK_LEDGER.json` aligned.
+- Do not mark a route `accepted` until the page acceptance and NEPTR website checklist both pass.
+
+## Helpers
+
+- `make site-work-report`
+- `make site-route-scaffold ARGS="--route /arcade-games/"`
+- `make site-route-update ARGS="--route / --status in_progress --phase verify --acceptance partial"`

--- a/context/sites/prismtek.dev/intake/README.md
+++ b/context/sites/prismtek.dev/intake/README.md
@@ -1,0 +1,18 @@
+# prismtek.dev Donor Intake
+
+Use this folder to store route-specific donor findings before or during migration.
+
+Recommended pattern:
+
+- `home.md`
+- `arcade-games.md`
+- `projects.md`
+- `downloads.md`
+- `build-log.md`
+
+Each file should record:
+- donor repo and path
+- recovered content blocks
+- asset references
+- route-specific CTA intent
+- intentional rewrites

--- a/context/sites/prismtek.dev/intake/home.md
+++ b/context/sites/prismtek.dev/intake/home.md
@@ -1,0 +1,27 @@
+# Home Donor Intake
+
+## Donor repos
+
+- `prismtek-site`
+- `PrismBot`
+
+## Donor facts already captured
+
+- `prismtek-site` is a static export of `prismtek.dev` for Cloudflare Pages
+- `PrismBot` provides the website factory standard and reusable landing-page scaffold
+
+## Recovered homepage intent
+
+- welcome visitors quickly
+- route them into high-value paths
+- highlight game / creature / account-oriented entry points
+
+## CTA questions to resolve
+
+- what is the primary homepage CTA?
+- what is the best secondary CTA for returning users?
+- which homepage section becomes the reusable card/grid pattern for inner routes?
+
+## Intentional rewrite notes
+
+- none yet

--- a/context/sites/prismtek.dev/work-items/README.md
+++ b/context/sites/prismtek.dev/work-items/README.md
@@ -1,0 +1,18 @@
+# prismtek.dev Route Work Items
+
+Use this folder for route-specific execution briefs.
+
+Recommended pattern:
+
+- `home.md`
+- `arcade-games.md`
+- `projects.md`
+- `downloads.md`
+- `build-log.md`
+
+Each work item should record:
+- route owner
+- current phase
+- acceptance target
+- blockers
+- immediate next step

--- a/context/sites/prismtek.dev/work-items/home.md
+++ b/context/sites/prismtek.dev/work-items/home.md
@@ -1,0 +1,28 @@
+# Home Route Work Item
+
+- route: `/`
+- owner: BMO
+- phase: discover
+- acceptance target: homepage passes `PAGE_ACCEPTANCE.md` and `NEPTR_WEBSITE_CHECKLIST.md`
+
+## Goals
+
+- lock the homepage CTA flow
+- turn homepage sections into reusable shared blocks
+- preserve donor content intent while improving migration discipline
+
+## Current discovered sections
+
+- welcome intro
+- quick start CTA row
+- featured games carousel
+- creature showcase
+- account actions
+
+## Immediate next step
+
+Define the primary CTA, secondary CTA, and shared block boundaries for the homepage.
+
+## Blockers
+
+- none recorded yet

--- a/scripts/prismtek_site_route_scaffold.py
+++ b/scripts/prismtek_site_route_scaffold.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SITE_DIR = ROOT / "context" / "sites" / "prismtek.dev"
+ROUTES_FILE = SITE_DIR / "ROUTES.json"
+LEDGER_FILE = SITE_DIR / "WORK_LEDGER.json"
+WORK_ITEMS_DIR = SITE_DIR / "work-items"
+INTAKE_DIR = SITE_DIR / "intake"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def slug_from_route(route: str) -> str:
+    cleaned = route.strip().strip("/")
+    if not cleaned:
+        return "home"
+    cleaned = re.sub(r"[^a-zA-Z0-9/_-]+", "-", cleaned)
+    cleaned = cleaned.replace("/", "-")
+    return cleaned.strip("-") or "route"
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dump_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def ensure_route(routes_data: dict, route: str, label: str, priority: str, route_type: str) -> None:
+    for entry in routes_data.get("routes", []):
+        if entry.get("route") == route:
+            return
+    routes_data.setdefault("routes", []).append(
+        {
+            "route": route,
+            "label": label,
+            "status": "todo",
+            "priority": priority,
+            "type": route_type,
+        }
+    )
+
+
+def ensure_ledger_entry(ledger_data: dict, route: str, label: str, owner: str) -> None:
+    for entry in ledger_data.get("entries", []):
+        if entry.get("route") == route:
+            return
+    ledger_data.setdefault("entries", []).append(
+        {
+            "route": route,
+            "label": label,
+            "owner": owner,
+            "status": "todo",
+            "phase": "discover",
+            "acceptance": "pending",
+            "next_step": "Fill in the route brief and donor intake.",
+            "blockers": [],
+        }
+    )
+
+
+def ensure_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(content, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scaffold prismtek.dev route work files.")
+    parser.add_argument("--route", required=True)
+    parser.add_argument("--label")
+    parser.add_argument("--owner", default="BMO")
+    parser.add_argument("--priority", default="P1")
+    parser.add_argument("--type", default="content")
+    args = parser.parse_args()
+
+    route = args.route if args.route.startswith("/") else f"/{args.route}"
+    if not route.endswith("/") and route != "/":
+        route += "/"
+    slug = slug_from_route(route)
+    label = args.label or slug.replace("-", " ").title()
+
+    routes_data = load_json(ROUTES_FILE)
+    ledger_data = load_json(LEDGER_FILE)
+
+    ensure_route(routes_data, route, label, args.priority, args.type)
+    ensure_ledger_entry(ledger_data, route, label, args.owner)
+
+    routes_data["lastReviewed"] = now_iso().split("T", 1)[0]
+    ledger_data["lastUpdated"] = now_iso()
+
+    dump_json(ROUTES_FILE, routes_data)
+    dump_json(LEDGER_FILE, ledger_data)
+
+    work_item = WORK_ITEMS_DIR / f"{slug}.md"
+    intake_item = INTAKE_DIR / f"{slug}.md"
+
+    ensure_file(
+        work_item,
+        f"# {label} Route Work Item\n\n"
+        f"- route: `{route}`\n"
+        f"- owner: {args.owner}\n"
+        f"- phase: discover\n"
+        f"- acceptance target: pass page acceptance + NEPTR website checklist\n\n"
+        f"## Immediate next step\n\n- Fill in donor content, CTA plan, and section mapping for `{route}`.\n",
+    )
+    ensure_file(
+        intake_item,
+        f"# {label} Donor Intake\n\n"
+        f"## Route\n\n- `{route}`\n\n"
+        f"## Donor findings\n\n- Add recovered content blocks here.\n"
+        f"- Add asset references here.\n"
+        f"- Add CTA intent notes here.\n",
+    )
+
+    print(f"Scaffolded route support for {route}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prismtek_site_route_update.py
+++ b/scripts/prismtek_site_route_update.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SITE_DIR = ROOT / "context" / "sites" / "prismtek.dev"
+ROUTES_FILE = SITE_DIR / "ROUTES.json"
+LEDGER_FILE = SITE_DIR / "WORK_LEDGER.json"
+
+VALID_STATUS = {"todo", "in_progress", "blocked", "accepted"}
+VALID_PHASE = {"discover", "rebuild", "verify", "deploy_ready"}
+VALID_ACCEPTANCE = {"pending", "partial", "passed", "failed"}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dump_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def update_route(routes_data: dict, route: str, status: str | None) -> None:
+    if not status:
+        return
+    for entry in routes_data.get("routes", []):
+        if entry.get("route") == route:
+            entry["status"] = status
+            return
+    raise SystemExit(f"Route not found in ROUTES.json: {route}")
+
+
+def update_ledger(ledger_data: dict, route: str, owner: str | None, status: str | None, phase: str | None, acceptance: str | None, next_step: str | None, blockers: list[str] | None) -> None:
+    for entry in ledger_data.get("entries", []):
+        if entry.get("route") == route:
+            if owner is not None:
+                entry["owner"] = owner
+            if status is not None:
+                entry["status"] = status
+            if phase is not None:
+                entry["phase"] = phase
+            if acceptance is not None:
+                entry["acceptance"] = acceptance
+            if next_step is not None:
+                entry["next_step"] = next_step
+            if blockers is not None:
+                entry["blockers"] = blockers
+            return
+    raise SystemExit(f"Route not found in WORK_LEDGER.json: {route}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update prismtek.dev route and work-ledger status.")
+    parser.add_argument("--route", required=True)
+    parser.add_argument("--owner")
+    parser.add_argument("--status", choices=sorted(VALID_STATUS))
+    parser.add_argument("--phase", choices=sorted(VALID_PHASE))
+    parser.add_argument("--acceptance", choices=sorted(VALID_ACCEPTANCE))
+    parser.add_argument("--next-step")
+    parser.add_argument("--blocker", action="append", default=None)
+    args = parser.parse_args()
+
+    routes_data = load_json(ROUTES_FILE)
+    ledger_data = load_json(LEDGER_FILE)
+
+    update_route(routes_data, args.route, args.status)
+    update_ledger(
+        ledger_data,
+        args.route,
+        args.owner,
+        args.status,
+        args.phase,
+        args.acceptance,
+        args.next_step,
+        args.blocker,
+    )
+
+    routes_data["lastReviewed"] = now_iso().split("T", 1)[0]
+    ledger_data["lastUpdated"] = now_iso()
+
+    dump_json(ROUTES_FILE, routes_data)
+    dump_json(LEDGER_FILE, ledger_data)
+
+    print(f"Updated {args.route}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prismtek_site_work_report.py
+++ b/scripts/prismtek_site_work_report.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LEDGER_FILE = ROOT / "context" / "sites" / "prismtek.dev" / "WORK_LEDGER.json"
+
+
+def main() -> None:
+    data = json.loads(LEDGER_FILE.read_text(encoding="utf-8"))
+    print(f"Site: {data.get('site', 'unknown')}")
+    print(f"Last updated: {data.get('lastUpdated', 'unknown')}")
+    print("")
+    print("Work ledger:")
+    for entry in data.get("entries", []):
+        blockers = entry.get("blockers", [])
+        blocker_text = ", ".join(blockers) if blockers else "none"
+        print(
+            f"- {entry['route']} | {entry['label']} | owner={entry['owner']} | "
+            f"status={entry['status']} | phase={entry['phase']} | acceptance={entry['acceptance']}"
+        )
+        print(f"  next: {entry['next_step']}")
+        print(f"  blockers: {blocker_text}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a machine-readable work ledger for prismtek.dev route execution
- add route work-item and donor-intake structure, including a seeded home route brief
- add helper scripts to report work status, scaffold route work, and update route/ledger state together
- add Makefile targets for the new route-ops workflow
- update the prismtek continuation plan to include ledger alignment rules

## Why
PR #64 added route inventory, acceptance, and verification docs. This PR makes the website workflow operational by giving BMO a persistent route ledger and helper commands so page work can be tracked and updated consistently instead of being buried in ad hoc notes.

## New helper commands
- `make site-work-report`
- `make site-route-scaffold ARGS="--route /arcade-games/"`
- `make site-route-update ARGS="--route / --status in_progress --phase verify --acceptance partial"`

## Notes
This is still intentionally website-ops focused. It improves execution discipline for continuing prismtek.dev without changing the core runtime behavior.