### PR TITLE
add React migration parity docs and donor extraction helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-page-checklist launchd-install
+.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-donor-extract site-page-checklist site-parity-matrix site-react-template launchd-install
 
 # Docker Compose file
 COMPOSE_FILE=compose.yaml
@@ -85,34 +85,27 @@ worker-connect:
 worker-status:
 	openshell sandbox list | grep bmo-tron || echo "Sandbox bmo-tron not found."
 
-# New target: worker-ready creates the sandbox and uploads config in one go
 worker-ready: worker-create worker-upload-config
 	@echo "Worker sandbox bmo-tron is ready for use."
 
-# Session recovery
 recover-session:
 	@./scripts/recover-session.sh
 
-# Checkpoint target
 checkpoint:
 	@./scripts/checkpoint.sh $(if $(ARGS),$(ARGS))
 
-# Health check target
 health-check:
 	@echo "Running BMO health check..."
 	@./scripts/bot-health.sh
 
-# BMO recovery target
 recover-bmo:
 	@echo "Running BMO recovery..."
 	@./scripts/bot-recover.sh
 
-# Multi-repo update target
 update-all:
 	@echo "Updating local BMO repos..."
 	@./scripts/update-all.sh
 
-# BMO native runtime targets
 runtime-doctor:
 	@bash ./scripts/bmo-runtime-doctor.sh
 
@@ -179,13 +172,21 @@ site-route-scaffold:
 site-route-update:
 	@python3 ./scripts/prismtek_site_route_update.py $(if $(ARGS),$(ARGS))
 
+site-donor-extract:
+	@python3 ./scripts/prismtek_site_donor_extract.py $(if $(ARGS),$(ARGS))
+
 site-page-checklist:
 	@cat ./context/council/NEPTR_WEBSITE_CHECKLIST.md
+
+site-parity-matrix:
+	@cat ./context/sites/prismtek.dev/FUNCTIONAL_PARITY_MATRIX.md
+
+site-react-template:
+	@cat ./context/sites/prismtek.dev/REACT_TEMPLATE.md
 
 launchd-install:
 	@python3 ./scripts/bmo-launchd-install.py $(if $(ARGS),$(ARGS))
 
-# omni-bmo bridge targets
 omni-sync:
 	@bash ./scripts/sync-omni-bmo.sh
 

--- a/context/council/NEPTR_WEBSITE_CHECKLIST.md
+++ b/context/council/NEPTR_WEBSITE_CHECKLIST.md
@@ -7,6 +7,13 @@ Use this checklist before claiming a prismtek.dev page or route is complete.
 - [ ] target route is recorded in `context/sites/prismtek.dev/ROUTES.json`
 - [ ] route status is updated correctly
 - [ ] route ownership is clear
+- [ ] work ledger status matches route status
+
+## Source-of-truth verification
+
+- [ ] live site parity target was considered
+- [ ] recovered donor content was considered
+- [ ] React donor was used only as the implementation shell
 
 ## Content verification
 
@@ -19,6 +26,13 @@ Use this checklist before claiming a prismtek.dev page or route is complete.
 - [ ] primary CTA is present and clear
 - [ ] secondary CTA or next-step path exists where appropriate
 - [ ] CTA destinations are valid
+
+## Parity verification
+
+- [ ] functional parity matrix row exists for the route
+- [ ] visual parity is acceptable for the route stage
+- [ ] content parity is acceptable for the route stage
+- [ ] functional parity is acceptable for the route stage
 
 ## UX verification
 

--- a/context/sites/prismtek.dev/FUNCTIONAL_PARITY_MATRIX.md
+++ b/context/sites/prismtek.dev/FUNCTIONAL_PARITY_MATRIX.md
@@ -1,0 +1,61 @@
+# prismtek.dev Functional Parity Matrix
+
+Use this matrix to verify that the React migration is actually complete.
+
+## Required parity categories
+
+### Navigation parity
+- same primary routes exposed
+- same or improved route discoverability
+- no missing critical nav destinations
+
+### Visual parity
+- same overall look and feel
+- comparable visual hierarchy
+- comparable homepage structure
+- route-specific sections remain recognizable to returning users
+
+### Content parity
+- donor content preserved or intentionally rewritten
+- no missing key blocks from live routes
+- no template filler shipped as final content
+
+### CTA parity
+- primary CTA preserved or intentionally improved
+- secondary CTA or next-step path preserved where needed
+- no dead-end buttons
+
+### Functional parity
+- interactive affordances behave as expected
+- account-oriented areas fail gracefully if not yet connected
+- downloads, links, and outbound routes work
+- route intent is complete, not just the layout
+
+### Deploy parity
+- route works in the React deployment target
+- static-hosting assumptions are respected
+- required redirects or path differences are documented
+
+## Per-route template
+
+```md
+### /route/
+- navigation parity: pass|partial|fail
+- visual parity: pass|partial|fail
+- content parity: pass|partial|fail
+- CTA parity: pass|partial|fail
+- functional parity: pass|partial|fail
+- deploy parity: pass|partial|fail
+- notes:
+```
+
+## Starter row
+
+### /
+- navigation parity: partial
+- visual parity: partial
+- content parity: partial
+- CTA parity: pending
+- functional parity: pending
+- deploy parity: pending
+- notes: Homepage is the first parity lock because its sections seed the rest of the React migration.

--- a/context/sites/prismtek.dev/MIGRATION_SOURCE_OF_TRUTH.md
+++ b/context/sites/prismtek.dev/MIGRATION_SOURCE_OF_TRUTH.md
@@ -1,0 +1,43 @@
+# prismtek.dev Migration Source of Truth
+
+## Core rule
+
+Use three distinct truths during the migration:
+
+1. **Live site** = parity truth
+2. **prismtek-site** = content and deploy donor
+3. **prismtek-site-replica** = React implementation donor
+
+## What this means
+
+- The live site defines what users currently see and expect.
+- The content donor helps recover routes, copy, assets, and static-hosting assumptions.
+- The React donor provides the implementation shell for the replacement site.
+
+## Non-negotiables
+
+- The site is being migrated into React format.
+- The React site must preserve the live site's look and visual hierarchy.
+- The React site must preserve route structure, CTA flow, and functional intent.
+- No route is complete until parity is recorded and verified.
+
+## Current known route set
+
+- `/`
+- `/arcade-games/`
+- `/pixel-studio/`
+- `/community-center/`
+- `/memory-wall/`
+- `/prism-creatures/`
+- `/my-account/`
+- `/school-safe/`
+- `/projects/`
+- `/downloads/`
+- `/links/`
+- `/build-log/`
+
+## Guardrails
+
+- Do not treat the React donor as the content truth.
+- Do not treat recovered content as proof of functional parity.
+- Do not mark a route accepted until the parity matrix and website checklist are both satisfied.

--- a/context/sites/prismtek.dev/REACT_SWAP_REQUIREMENTS.md
+++ b/context/sites/prismtek.dev/REACT_SWAP_REQUIREMENTS.md
@@ -1,0 +1,31 @@
+# prismtek.dev React Swap Requirements
+
+This file captures the hard requirement for the site migration.
+
+## Requirement
+
+The current prismtek.dev experience must be swapped from the current WordPress-formatted site into a React-format implementation.
+
+## Non-negotiables
+
+- retain the current site's overall look and feel
+- retain route structure and navigation
+- retain CTA flow and user intent
+- retain functional completeness for public-facing routes
+- do not ship a React shell that looks right but is missing the route's real purpose
+
+## Donor model
+
+- live site = parity truth
+- `prismtek-site` = content and deploy donor
+- `prismtek-site-replica` = React implementation donor
+
+## Completion rule
+
+A route is not complete just because it exists in React.
+A route is only complete when it satisfies:
+- visual parity
+- content parity
+- CTA parity
+- functional parity
+- deploy parity

--- a/context/sites/prismtek.dev/REACT_TEMPLATE.md
+++ b/context/sites/prismtek.dev/REACT_TEMPLATE.md
@@ -1,0 +1,31 @@
+# prismtek-site-replica React Template Notes
+
+Use `codysumpter-cloud/prismtek-site-replica` as the React implementation donor for prismtek.dev.
+
+## Known repo facts
+
+- default branch: `main`
+- package name: `prismtek-replica`
+- toolchain: React + Vite + TypeScript
+- routing library present: `wouter`
+- animation library present: `framer-motion`
+- preview and build scripts already exist
+
+## Use this donor for
+
+- React route shell
+- component and styling patterns
+- client-side navigation structure
+- page implementation landing zone for migrated routes
+
+## Do not use this donor for
+
+- deciding what content a route should contain
+- deciding parity requirements
+- replacing recovered content with template filler
+
+## Rule
+
+The live site defines parity.
+The content donor defines recovered content.
+The React replica defines implementation structure.

--- a/context/skills/SKILLS.md
+++ b/context/skills/SKILLS.md
@@ -11,11 +11,15 @@ Use it first instead of crawling the repo.
 
 - `context/skills/donor-ingest.skill.md`
   - Trigger: importing ideas, docs, routes, runtime behavior, or policy from old repos
-  - Use when work references `prismtek-site`, `omni-bmo`, or `PrismBot`
+  - Use when work references `prismtek-site`, `prismtek-site-replica`, `omni-bmo`, or `PrismBot`
 
 - `context/skills/site-migration.skill.md`
   - Trigger: prismtek.dev migration, page recreation, route inventory, asset parity
   - Use when building or continuing the website
+
+- `context/skills/react-parity-migration.skill.md`
+  - Trigger: swapping a live route into React while preserving the current site's look and functionality
+  - Use when implementing routes in the React template donor and checking parity against the live site
 
 - `context/skills/runtime-validation.skill.md`
   - Trigger: profile changes, runtime changes, release readiness, smoke checks

--- a/context/skills/react-parity-migration.skill.md
+++ b/context/skills/react-parity-migration.skill.md
@@ -1,0 +1,33 @@
+# Skill: React Parity Migration
+
+## Purpose
+
+Help BMO replace the current prismtek.dev implementation with a React-format site without losing the look, route structure, or functional intent of the live site.
+
+## Source-of-truth model
+
+- live site = parity truth
+- `prismtek-site` = content and deploy donor
+- `prismtek-site-replica` = React implementation donor
+
+## Procedure
+
+1. Identify the target route in `ROUTES.json`.
+2. Create or update the donor intake file for the route.
+3. Create or update the route work item.
+4. Compare the live route against the React implementation target.
+5. Record parity status in the functional parity matrix.
+6. Do not claim the route is done until the website checklist passes.
+
+## Required outputs
+
+- intake file for the route
+- work item for the route
+- parity matrix row for the route
+- acceptance state and ledger state kept in sync
+
+## Rules
+
+- Do not use the React donor as proof that the route is complete.
+- Do not accept a route on visual similarity alone.
+- Functional parity matters as much as layout parity.

--- a/context/skills/site-migration.skill.md
+++ b/context/skills/site-migration.skill.md
@@ -7,15 +7,24 @@ Help BMO continue building and migrating `https://prismtek.dev` safely.
 ## Donor sources
 
 - `prismtek-site` for content, routes, and deploy assumptions
-- `PrismBot` for website factory and conversion-minded section standards
+- `prismtek-site-replica` for the React/Vite UI template and route shell
+- `PrismBot` for website factory and section standards
+
+## Source-of-truth rule
+
+- The live site is the visual and functional truth for parity checks.
+- The current live site must be migrated from WordPress format into React format.
+- The migration target is React while retaining the live site's look, route structure, CTA flow, and functional intent.
+- `prismtek-site-replica` is a React donor, not the truth for content or parity requirements.
 
 ## Procedure
 
 1. Inventory the target page or route.
 2. Identify source content blocks, assets, and expected CTA flow.
-3. Rebuild using reusable sections instead of one-off page hacks.
-4. Preserve deployment assumptions and redirects.
-5. Emit acceptance criteria before claiming the page is done.
+3. Identify the React donor structure to receive the migrated page.
+4. Rebuild using reusable sections instead of one-off page hacks.
+5. Preserve deploy assumptions, redirects, and functional expectations.
+6. Emit acceptance criteria before claiming the page is done.
 
 ## Acceptance criteria
 
@@ -24,9 +33,12 @@ Help BMO continue building and migrating `https://prismtek.dev` safely.
 - editable copy blocks
 - no broken links or placeholder buttons left behind
 - explicit route ownership and deploy target noted
+- React route preserves the live site's functional intent
+- parity with the live route is recorded
 
 ## Rules
 
 - Do not blindly merge donor UI/runtime code into the live site.
 - Treat `prismtek-site` as a content donor, not a runtime donor.
+- Treat `prismtek-site-replica` as the React template donor, not as the content truth.
 - Prefer controlled migration with route-by-route acceptance checks.

--- a/scripts/prismtek_site_donor_extract.py
+++ b/scripts/prismtek_site_donor_extract.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SITE_DIR = ROOT / "context" / "sites" / "prismtek.dev"
+ROUTES_FILE = SITE_DIR / "ROUTES.json"
+INTAKE_DIR = SITE_DIR / "intake"
+
+
+def slug_from_route(route: str) -> str:
+    cleaned = route.strip().strip("/")
+    return cleaned.replace("/", "-") if cleaned else "home"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed a prismtek.dev donor intake file from route metadata.")
+    parser.add_argument("--route", required=True)
+    args = parser.parse_args()
+
+    route = args.route if args.route.startswith("/") else f"/{args.route}"
+    if route != "/" and not route.endswith("/"):
+        route += "/"
+
+    routes_data = json.loads(ROUTES_FILE.read_text(encoding="utf-8"))
+    selected = None
+    for entry in routes_data.get("routes", []):
+        if entry.get("route") == route:
+            selected = entry
+            break
+    if selected is None:
+        raise SystemExit(f"Route not found in ROUTES.json: {route}")
+
+    slug = slug_from_route(route)
+    out_path = INTAKE_DIR / f"{slug}.md"
+    if out_path.exists():
+        raise SystemExit(f"Intake file already exists: {out_path}")
+
+    content = f"# {selected['label']} Donor Intake\n\n" \
+        f"## Route\n\n- `{selected['route']}`\n- priority: {selected['priority']}\n- type: {selected['type']}\n\n" \
+        "## Donor sources\n\n" \
+        "- `prismtek-site` for recovered content and deploy assumptions\n" \
+        "- `prismtek-site-replica` for React implementation structure\n" \
+        "- live site for parity checks\n\n" \
+        "## Recovered content blocks\n\n- TODO\n\n" \
+        "## Asset references\n\n- TODO\n\n" \
+        "## CTA intent\n\n- primary CTA: TODO\n- secondary CTA: TODO\n\n" \
+        "## Parity notes\n\n- TODO\n"
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(content, encoding="utf-8")
+    print(f"Created donor intake: {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add React migration source-of-truth docs, swap requirements, and a functional parity matrix for prismtek.dev
- add a donor extraction helper and Makefile targets for React migration workflows
- add a dedicated React parity migration skill and expand the website verification checklist
- document `prismtek-site-replica` as the React implementation donor while keeping live-site parity as the acceptance truth

## Why
The current prismtek.dev migration needs a stricter model:
- live site = parity truth
- `prismtek-site` = content/deploy donor
- `prismtek-site-replica` = React implementation donor

This PR gives BMO concrete docs and helper commands for executing that swap safely.

## New helper commands
- `make site-donor-extract ARGS="--route /arcade-games/"`
- `make site-parity-matrix`
- `make site-react-template`

## Notes
This is intentionally migration-ops focused. It does not change the runtime; it makes BMO better at replacing the current site with a React version while preserving look, routes, and functional completeness.