### PR TITLE
add priority route parity tracking for prismtek migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-donor-extract site-page-checklist site-parity-matrix site-react-template launchd-install
+.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host worker-create worker-upload-config worker-connect worker-status openclaw-start openclaw-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-donor-extract site-page-checklist site-parity-matrix site-parity-report site-parity-update site-react-template launchd-install
 
 # Docker Compose file
 COMPOSE_FILE=compose.yaml
@@ -180,6 +180,12 @@ site-page-checklist:
 
 site-parity-matrix:
 	@cat ./context/sites/prismtek.dev/FUNCTIONAL_PARITY_MATRIX.md
+
+site-parity-report:
+	@python3 ./scripts/prismtek_site_parity_report.py
+
+site-parity-update:
+	@python3 ./scripts/prismtek_site_parity_update.py $(if $(ARGS),$(ARGS))
 
 site-react-template:
 	@cat ./context/sites/prismtek.dev/REACT_TEMPLATE.md

--- a/context/sites/prismtek.dev/CONTINUATION.md
+++ b/context/sites/prismtek.dev/CONTINUATION.md
@@ -31,7 +31,7 @@ Known donor fact:
 3. Preserve CTA flow and editable copy blocks.
 4. Record route ownership and acceptance criteria before claiming a page is complete.
 5. Prefer reusable sections over page-specific hacks.
-6. Keep route status, ledger status, and acceptance state aligned.
+6. Keep route status, ledger status, acceptance state, and priority parity state aligned.
 
 ## Execution files
 
@@ -43,6 +43,8 @@ Known donor fact:
 - `context/sites/prismtek.dev/DEPLOY_NOTES.md`
 - `context/sites/prismtek.dev/WORK_LEDGER.json`
 - `context/sites/prismtek.dev/WORK_LEDGER.md`
+- `context/sites/prismtek.dev/PRIORITY_ROUTE_PARITY.json`
+- `context/sites/prismtek.dev/PRIORITY_ROUTE_PARITY.md`
 - `context/sites/prismtek.dev/work-items/`
 - `context/sites/prismtek.dev/intake/`
 - `context/council/NEPTR_WEBSITE_CHECKLIST.md`
@@ -68,4 +70,5 @@ A page is not done until:
 - link integrity is checked
 - page acceptance is updated
 - work ledger is updated
+- priority parity is updated for P0 routes
 - NEPTR website checklist passes

--- a/context/sites/prismtek.dev/FUNCTIONAL_PARITY_MATRIX.md
+++ b/context/sites/prismtek.dev/FUNCTIONAL_PARITY_MATRIX.md
@@ -49,7 +49,7 @@ Use this matrix to verify that the React migration is actually complete.
 - notes:
 ```
 
-## Starter row
+## Priority route starter rows
 
 ### /
 - navigation parity: partial
@@ -59,3 +59,39 @@ Use this matrix to verify that the React migration is actually complete.
 - functional parity: pending
 - deploy parity: pending
 - notes: Homepage is the first parity lock because its sections seed the rest of the React migration.
+
+### /arcade-games/
+- navigation parity: pending
+- visual parity: pending
+- content parity: pending
+- CTA parity: pending
+- functional parity: pending
+- deploy parity: pending
+- notes: Seed this route immediately after homepage CTA and section patterns are locked.
+
+### /projects/
+- navigation parity: pending
+- visual parity: pending
+- content parity: pending
+- CTA parity: pending
+- functional parity: pending
+- deploy parity: pending
+- notes: Projects must preserve showcase intent, not just route presence.
+
+### /downloads/
+- navigation parity: pending
+- visual parity: pending
+- content parity: pending
+- CTA parity: pending
+- functional parity: pending
+- deploy parity: pending
+- notes: Downloads must preserve actual file/link behavior in the React version.
+
+### /build-log/
+- navigation parity: pending
+- visual parity: pending
+- content parity: pending
+- CTA parity: pending
+- functional parity: pending
+- deploy parity: pending
+- notes: Build Log should preserve chronology and update expectations, not just archive cards.

--- a/context/sites/prismtek.dev/PRIORITY_ROUTE_PARITY.json
+++ b/context/sites/prismtek.dev/PRIORITY_ROUTE_PARITY.json
@@ -1,0 +1,66 @@
+{
+  "site": "prismtek.dev",
+  "lastUpdated": "2026-03-25T17:20:00Z",
+  "entries": [
+    {
+      "route": "/",
+      "label": "Home",
+      "priority": "P0",
+      "navigation_parity": "partial",
+      "visual_parity": "partial",
+      "content_parity": "partial",
+      "cta_parity": "pending",
+      "functional_parity": "pending",
+      "deploy_parity": "pending",
+      "notes": "Homepage is the first parity lock because its sections seed the React migration."
+    },
+    {
+      "route": "/arcade-games/",
+      "label": "Arcade Games",
+      "priority": "P0",
+      "navigation_parity": "pending",
+      "visual_parity": "pending",
+      "content_parity": "pending",
+      "cta_parity": "pending",
+      "functional_parity": "pending",
+      "deploy_parity": "pending",
+      "notes": "Needs donor intake and route brief before React implementation review."
+    },
+    {
+      "route": "/projects/",
+      "label": "Projects",
+      "priority": "P0",
+      "navigation_parity": "pending",
+      "visual_parity": "pending",
+      "content_parity": "pending",
+      "cta_parity": "pending",
+      "functional_parity": "pending",
+      "deploy_parity": "pending",
+      "notes": "Treat as a core content route after homepage parity is stronger."
+    },
+    {
+      "route": "/downloads/",
+      "label": "Downloads",
+      "priority": "P0",
+      "navigation_parity": "pending",
+      "visual_parity": "pending",
+      "content_parity": "pending",
+      "cta_parity": "pending",
+      "functional_parity": "pending",
+      "deploy_parity": "pending",
+      "notes": "Downloads route must preserve real functionality, not just card layout."
+    },
+    {
+      "route": "/build-log/",
+      "label": "Build Log",
+      "priority": "P0",
+      "navigation_parity": "pending",
+      "visual_parity": "pending",
+      "content_parity": "pending",
+      "cta_parity": "pending",
+      "functional_parity": "pending",
+      "deploy_parity": "pending",
+      "notes": "Build Log should preserve chronology and update expectations in the React version."
+    }
+  ]
+}

--- a/context/sites/prismtek.dev/PRIORITY_ROUTE_PARITY.md
+++ b/context/sites/prismtek.dev/PRIORITY_ROUTE_PARITY.md
@@ -1,0 +1,37 @@
+# prismtek.dev Priority Route Parity
+
+This file tracks the highest-priority route parity work for the React migration.
+The machine-readable source is `context/sites/prismtek.dev/PRIORITY_ROUTE_PARITY.json`.
+
+## Why this exists
+
+The top migration risk is shipping a React site that has routes but not parity.
+This tracker keeps the highest-value routes visible until they are genuinely complete.
+
+## Current P0 routes
+
+- `/`
+- `/arcade-games/`
+- `/projects/`
+- `/downloads/`
+- `/build-log/`
+
+## Parity meanings
+
+- `pending` = not yet reviewed
+- `partial` = some parity work done, but not enough to accept
+- `pass` = good enough for acceptance on that category
+- `fail` = broken or missing for that category
+
+## Workflow
+
+1. run `make site-parity-report`
+2. update a route with `make site-parity-update ARGS="..."`
+3. keep parity state aligned with:
+   - `WORK_LEDGER.json`
+   - `PAGE_ACCEPTANCE.md`
+   - `NEPTR_WEBSITE_CHECKLIST.md`
+
+## Acceptance rule
+
+A P0 route should not be marked accepted until its parity categories are all at least `pass` or explicitly justified.

--- a/context/sites/prismtek.dev/intake/arcade-games.md
+++ b/context/sites/prismtek.dev/intake/arcade-games.md
@@ -1,0 +1,30 @@
+# Arcade Games Donor Intake
+
+## Route
+
+- `/arcade-games/`
+- priority: P0
+- type: content
+
+## Donor sources
+
+- `prismtek-site` for recovered content and deploy assumptions
+- `prismtek-site-replica` for React implementation structure
+- live site for parity checks
+
+## Recovered content blocks
+
+- TODO
+
+## Asset references
+
+- TODO
+
+## CTA intent
+
+- primary CTA: TODO
+- secondary CTA: TODO
+
+## Parity notes
+
+- TODO

--- a/context/sites/prismtek.dev/intake/build-log.md
+++ b/context/sites/prismtek.dev/intake/build-log.md
@@ -1,0 +1,30 @@
+# Build Log Donor Intake
+
+## Route
+
+- `/build-log/`
+- priority: P0
+- type: content
+
+## Donor sources
+
+- `prismtek-site` for recovered content and deploy assumptions
+- `prismtek-site-replica` for React implementation structure
+- live site for parity checks
+
+## Recovered content blocks
+
+- TODO
+
+## Asset references
+
+- TODO
+
+## CTA intent
+
+- primary CTA: TODO
+- secondary CTA: TODO
+
+## Parity notes
+
+- TODO

--- a/context/sites/prismtek.dev/intake/downloads.md
+++ b/context/sites/prismtek.dev/intake/downloads.md
@@ -1,0 +1,30 @@
+# Downloads Donor Intake
+
+## Route
+
+- `/downloads/`
+- priority: P0
+- type: content
+
+## Donor sources
+
+- `prismtek-site` for recovered content and deploy assumptions
+- `prismtek-site-replica` for React implementation structure
+- live site for parity checks
+
+## Recovered content blocks
+
+- TODO
+
+## Asset references
+
+- TODO
+
+## CTA intent
+
+- primary CTA: TODO
+- secondary CTA: TODO
+
+## Parity notes
+
+- TODO

--- a/context/sites/prismtek.dev/intake/projects.md
+++ b/context/sites/prismtek.dev/intake/projects.md
@@ -1,0 +1,30 @@
+# Projects Donor Intake
+
+## Route
+
+- `/projects/`
+- priority: P0
+- type: content
+
+## Donor sources
+
+- `prismtek-site` for recovered content and deploy assumptions
+- `prismtek-site-replica` for React implementation structure
+- live site for parity checks
+
+## Recovered content blocks
+
+- TODO
+
+## Asset references
+
+- TODO
+
+## CTA intent
+
+- primary CTA: TODO
+- secondary CTA: TODO
+
+## Parity notes
+
+- TODO

--- a/context/sites/prismtek.dev/work-items/arcade-games.md
+++ b/context/sites/prismtek.dev/work-items/arcade-games.md
@@ -1,0 +1,20 @@
+# Arcade Games Route Work Item
+
+- route: `/arcade-games/`
+- owner: BMO
+- phase: discover
+- acceptance target: pass page acceptance, priority parity, and NEPTR website checklist
+
+## Goals
+
+- preserve the route as a primary navigation destination
+- retain the arcade/game exploration feel from the live site
+- define the React card/grid pattern for playable or featured game entries
+
+## Immediate next step
+
+Create the donor intake for `/arcade-games/` and identify the route's primary CTA and card pattern.
+
+## Blockers
+
+- none recorded yet

--- a/context/sites/prismtek.dev/work-items/build-log.md
+++ b/context/sites/prismtek.dev/work-items/build-log.md
@@ -1,0 +1,20 @@
+# Build Log Route Work Item
+
+- route: `/build-log/`
+- owner: BMO
+- phase: discover
+- acceptance target: pass page acceptance, priority parity, and NEPTR website checklist
+
+## Goals
+
+- preserve the route as a primary navigation destination
+- retain chronology and update expectations in the React version
+- define the React pattern for log entries, archive structure, or changelog-style presentation
+
+## Immediate next step
+
+Create the donor intake for `/build-log/` and identify the route's primary CTA and chronology structure.
+
+## Blockers
+
+- none recorded yet

--- a/context/sites/prismtek.dev/work-items/downloads.md
+++ b/context/sites/prismtek.dev/work-items/downloads.md
@@ -1,0 +1,20 @@
+# Downloads Route Work Item
+
+- route: `/downloads/`
+- owner: BMO
+- phase: discover
+- acceptance target: pass page acceptance, priority parity, and NEPTR website checklist
+
+## Goals
+
+- preserve the route as a primary navigation destination
+- retain real download and outbound-link functionality in the React version
+- define the React download card/list pattern for assets or files
+
+## Immediate next step
+
+Create the donor intake for `/downloads/` and identify the route's primary CTA and real download behavior.
+
+## Blockers
+
+- none recorded yet

--- a/context/sites/prismtek.dev/work-items/projects.md
+++ b/context/sites/prismtek.dev/work-items/projects.md
@@ -1,0 +1,20 @@
+# Projects Route Work Item
+
+- route: `/projects/`
+- owner: BMO
+- phase: discover
+- acceptance target: pass page acceptance, priority parity, and NEPTR website checklist
+
+## Goals
+
+- preserve the route as a primary navigation destination
+- retain showcase intent for projects and featured work
+- define reusable project cards or sections for the React version
+
+## Immediate next step
+
+Create the donor intake for `/projects/` and identify the route's primary CTA and showcase structure.
+
+## Blockers
+
+- none recorded yet

--- a/scripts/prismtek_site_parity_report.py
+++ b/scripts/prismtek_site_parity_report.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PARITY_FILE = ROOT / "context" / "sites" / "prismtek.dev" / "PRIORITY_ROUTE_PARITY.json"
+
+
+def main() -> None:
+    data = json.loads(PARITY_FILE.read_text(encoding="utf-8"))
+    print(f"Site: {data.get('site', 'unknown')}")
+    print(f"Last updated: {data.get('lastUpdated', 'unknown')}")
+    print("")
+    print("Priority route parity:")
+    for entry in data.get("entries", []):
+        print(f"- {entry['route']} | {entry['label']} | priority={entry['priority']}")
+        print(
+            "  navigation={navigation_parity} visual={visual_parity} "
+            "content={content_parity} cta={cta_parity} functional={functional_parity} "
+            "deploy={deploy_parity}".format(**entry)
+        )
+        print(f"  notes: {entry['notes']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prismtek_site_parity_update.py
+++ b/scripts/prismtek_site_parity_update.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PARITY_FILE = ROOT / "context" / "sites" / "prismtek.dev" / "PRIORITY_ROUTE_PARITY.json"
+
+VALID_PARITY = {"pending", "partial", "pass", "fail"}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update a prismtek.dev priority-route parity entry.")
+    parser.add_argument("--route", required=True)
+    parser.add_argument("--navigation", choices=sorted(VALID_PARITY))
+    parser.add_argument("--visual", choices=sorted(VALID_PARITY))
+    parser.add_argument("--content", choices=sorted(VALID_PARITY))
+    parser.add_argument("--cta", choices=sorted(VALID_PARITY))
+    parser.add_argument("--functional", choices=sorted(VALID_PARITY))
+    parser.add_argument("--deploy", choices=sorted(VALID_PARITY))
+    parser.add_argument("--notes")
+    args = parser.parse_args()
+
+    data = json.loads(PARITY_FILE.read_text(encoding="utf-8"))
+    for entry in data.get("entries", []):
+        if entry.get("route") == args.route:
+            if args.navigation is not None:
+                entry["navigation_parity"] = args.navigation
+            if args.visual is not None:
+                entry["visual_parity"] = args.visual
+            if args.content is not None:
+                entry["content_parity"] = args.content
+            if args.cta is not None:
+                entry["cta_parity"] = args.cta
+            if args.functional is not None:
+                entry["functional_parity"] = args.functional
+            if args.deploy is not None:
+                entry["deploy_parity"] = args.deploy
+            if args.notes is not None:
+                entry["notes"] = args.notes
+            data["lastUpdated"] = now_iso()
+            PARITY_FILE.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            print(f"Updated parity for {args.route}")
+            return
+
+    raise SystemExit(f"Route not found in PRIORITY_ROUTE_PARITY.json: {args.route}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a machine-readable and human-readable priority-route parity tracker for the top prismtek.dev migration routes
- add parity report and parity update helpers with matching Makefile targets
- seed P0 route work-items and donor-intake files for arcade games, projects, downloads, and build log
- tighten the continuation plan and functional parity matrix around P0 route execution

## Why
The next migration risk is not missing docs, it is losing focus on the highest-value routes. This PR gives BMO a concrete priority-route parity workflow so the React migration can be driven by route completeness instead of vague progress.

## New helper commands
- `make site-parity-report`
- `make site-parity-update ARGS="--route /arcade-games/ --visual partial --content partial"`

## Notes
This is intentionally migration-execution focused. It helps BMO keep the homepage and top content routes aligned while moving prismtek.dev into React format without losing route intent or user-facing completeness.