### PR TITLE
Guard BeMoreAgent bundle identifier

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -74,6 +74,32 @@ jobs:
           test -d BeMoreAgent.xcodeproj
           test -f exportOptions-upload.plist
 
+      - name: Verify bundle identifier contract
+        run: |
+          python3 - <<'PY2'
+          import pathlib
+          import re
+          import sys
+
+          project = pathlib.Path('project.yml').read_text()
+          expected = 'BeMoreAgent'
+          match = re.search(r'PRODUCT_BUNDLE_IDENTIFIER:\s*([^\n]+)', project)
+          if not match:
+              print('Missing PRODUCT_BUNDLE_IDENTIFIER in project.yml', file=sys.stderr)
+              sys.exit(1)
+          actual = match.group(1).strip()
+          if actual != expected:
+              print(f'Bundle identifier drifted: expected {expected}, got {actual}', file=sys.stderr)
+              sys.exit(1)
+
+          info = pathlib.Path('OpenClawShell/Info.plist').read_text()
+          if '$(PRODUCT_BUNDLE_IDENTIFIER)' not in info:
+              print('Info.plist must inherit PRODUCT_BUNDLE_IDENTIFIER', file=sys.stderr)
+              sys.exit(1)
+
+          print(f'Bundle identifier verified: {actual}')
+          PY2
+
       - name: Build and archive release
         run: |
           xcodebuild -project BeMoreAgent.xcodeproj \

--- a/apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md
+++ b/apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md
@@ -34,7 +34,8 @@ Current expected value:
 
 1. `apps/openclaw-shell-ios/project.yml` generates cleanly with `xcodegen generate`.
 2. `BeMoreAgent` builds for `generic/platform=iOS Simulator`.
-3. The PR body includes the required task contract:
+3. `apps/openclaw-shell-ios/project.yml` keeps `PRODUCT_BUNDLE_IDENTIFIER: BeMoreAgent` exactly. Do not change it to a reverse-DNS id unless the Apple identifier itself is changed first.
+4. The PR body includes the required task contract:
 
 ```md
 ## Task contract
@@ -43,8 +44,8 @@ Current expected value:
 - Rollback: yes
 ```
 
-4. The PR is mergeable and the relevant checks are green.
-5. `CFBundleVersion` is higher than the last uploaded build.
+5. The PR is mergeable and the relevant checks are green.
+6. `CFBundleVersion` is higher than the last uploaded build.
 
 ## How to ship the next build
 

--- a/apps/openclaw-shell-ios/project.yml
+++ b/apps/openclaw-shell-ios/project.yml
@@ -23,6 +23,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: BeMoreAgent
+        INFOPLIST_KEY_CFBundleIdentifier: BeMoreAgent
         INFOPLIST_FILE: OpenClawShell/Info.plist
         DEVELOPMENT_TEAM: DY9FHPRZA9
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- enforce the PRODUCT_BUNDLE_IDENTIFIER contract (must be `BeMoreAgent`)
- add guard step in TestFlight workflow
- update docs and runbook to reflect the rule

## Task contract
- Verification: yes
- Rollback: yes

Plan: `context/plans/2026-04-09-ios-build-11-testflight-runbook.md`

## Problem
- without a guard, the bundle identifier could be mistakenly changed back to a reverse‑DNS form, breaking CI and TestFlight uploads

## Smallest useful wedge
- add a simple python check in the CI workflow that aborts if the identifier drifts

## Verification plan
- CI will now fail fast on drift
- run the workflow manually to confirm the step passes

## Rollback plan
- revert this PR if the bundle identifier needs to change in the future