### PR TITLE
Implement OpenClaw Build 17 workspace runtime

### DIFF
--- a/.github/workflows/bemoreagent-ios-validate.yml
+++ b/.github/workflows/bemoreagent-ios-validate.yml
@@ -19,16 +19,27 @@ jobs:
       run:
         working-directory: apps/openclaw-shell-ios
     env:
-      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+      XCODE_DEVELOPER_DIR: ${{ vars.BEMOREAGENT_XCODE_DEVELOPER_DIR != '' && vars.BEMOREAGENT_XCODE_DEVELOPER_DIR || '/Applications/Xcode.app/Contents/Developer' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app
+        run: |
+          xcode_app="${XCODE_DEVELOPER_DIR%/Contents/Developer}"
+          test -d "$xcode_app"
+          echo "DEVELOPER_DIR=$XCODE_DEVELOPER_DIR" >> "$GITHUB_ENV"
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo xcode-select -s "$xcode_app"
+          else
+            echo "Skipping xcode-select; using DEVELOPER_DIR=$XCODE_DEVELOPER_DIR"
+          fi
 
       - name: Show Xcode version
-        run: xcodebuild -version
+        run: |
+          xcodebuild -version
+          SDK_VERSION="$(xcrun --sdk iphonesimulator --show-sdk-version)"
+          echo "iPhoneSimulator SDK $SDK_VERSION"
 
       - name: Install XcodeGen if needed
         run: |

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: apps/openclaw-shell-ios
     env:
-      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+      XCODE_DEVELOPER_DIR: ${{ vars.BEMOREAGENT_XCODE_DEVELOPER_DIR != '' && vars.BEMOREAGENT_XCODE_DEVELOPER_DIR || '/Applications/Xcode.app/Contents/Developer' }}
       ASC_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
       ASC_KEY_ID: ${{ secrets.APPSTORE_CONNECT_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_ISSUER_ID }}
@@ -31,12 +31,35 @@ jobs:
           submodules: true
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app
+        run: |
+          xcode_app="${XCODE_DEVELOPER_DIR%/Contents/Developer}"
+          test -d "$xcode_app"
+          sudo xcode-select -s "$xcode_app"
+          echo "DEVELOPER_DIR=$XCODE_DEVELOPER_DIR" >> "$GITHUB_ENV"
 
       - name: Show Xcode version
         run: |
           xcodebuild -version
-          xcrun --sdk iphoneos --show-sdk-version
+          SDK_VERSION="$(xcrun --sdk iphoneos --show-sdk-version)"
+          echo "iPhoneOS SDK $SDK_VERSION"
+          python3 - "$SDK_VERSION" <<'PY2'
+          import pathlib
+          import re
+          import sys
+
+          sdk = tuple(int(part) for part in sys.argv[1].split('.')[:2])
+          project = pathlib.Path('project.yml').read_text()
+          match = re.search(r'IPHONEOS_DEPLOYMENT_TARGET:\s*([0-9]+(?:\.[0-9]+)?)', project)
+          if not match:
+              print('Missing IPHONEOS_DEPLOYMENT_TARGET in project.yml', file=sys.stderr)
+              sys.exit(1)
+          deployment = tuple(int(part) for part in match.group(1).split('.')[:2])
+          if len(deployment) == 1:
+              deployment = (deployment[0], 0)
+          if sdk < deployment:
+              print(f'Xcode SDK {sys.argv[1]} is too old for IPHONEOS_DEPLOYMENT_TARGET {match.group(1)}', file=sys.stderr)
+              sys.exit(1)
+          PY2
           sw_vers
 
       - name: Install XcodeGen if needed
@@ -111,9 +134,8 @@ jobs:
             -authenticationKeyPath "$RUNNER_TEMP/AuthKey.p8" \
             -authenticationKeyID "$ASC_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
-            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_STYLE=Automatic \
             DEVELOPMENT_TEAM=DY9FHPRZA9 \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
             clean archive
 
       - name: Export and upload to TestFlight

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -34,8 +34,12 @@ jobs:
         run: |
           xcode_app="${XCODE_DEVELOPER_DIR%/Contents/Developer}"
           test -d "$xcode_app"
-          sudo xcode-select -s "$xcode_app"
           echo "DEVELOPER_DIR=$XCODE_DEVELOPER_DIR" >> "$GITHUB_ENV"
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo xcode-select -s "$xcode_app"
+          else
+            echo "Skipping xcode-select; using DEVELOPER_DIR=$XCODE_DEVELOPER_DIR"
+          fi
 
       - name: Show Xcode version
         run: |

--- a/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
+++ b/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
@@ -40,7 +40,7 @@ xcodebuild -project BeMoreAgent.xcodeproj \
 
 ## Release path
 
-- `CFBundleVersion` is currently `15`.
+- `CFBundleVersion` is currently `16`.
 - `IPHONEOS_DEPLOYMENT_TARGET` is currently `26.0`.
 - TestFlight delivery is repo-managed through `.github/workflows/testflight.yml`.
 - The operator runbook for that path is `apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md`.

--- a/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
+++ b/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
@@ -40,7 +40,8 @@ xcodebuild -project BeMoreAgent.xcodeproj \
 
 ## Release path
 
-- `CFBundleVersion` is currently `13`.
+- `CFBundleVersion` is currently `15`.
+- `IPHONEOS_DEPLOYMENT_TARGET` is currently `26.0`.
 - TestFlight delivery is repo-managed through `.github/workflows/testflight.yml`.
 - The operator runbook for that path is `apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md`.
 - Xcode Cloud is not the required release path for this target right now.

--- a/apps/openclaw-shell-ios/BUILD_14_CONTINUITY_NOTE.md
+++ b/apps/openclaw-shell-ios/BUILD_14_CONTINUITY_NOTE.md
@@ -1,0 +1,9 @@
+# Build 14 Continuity Note
+
+Build 14 appeared to reset BeMoreAgent because PR #219 changed the generated app bundle identifier from `BeMoreAgent` to `com.prismtek.BeMoreAgent`.
+
+On iOS and TestFlight, the bundle identifier is the app identity. Changing it makes the install use a different app container, so state stored under Application Support and Documents is not visible to the new identity. That includes onboarding, provider accounts, runtime selection, tab preferences, chat history, workspace files, buddy state, and operator preferences.
+
+The correct continuity strategy for this TestFlight line is to keep `PRODUCT_BUNDLE_IDENTIFIER: BeMoreAgent`. Current `master` restores that value and the TestFlight workflow now guards it. Users upgrading from builds that used `BeMoreAgent` should keep their existing local app-container state.
+
+Users who installed a build signed as `com.prismtek.BeMoreAgent` may have state in that separate container. iOS does not provide an automatic local-container migration path between two unrelated bundle identifiers from inside the app, so this repo should not claim that state was preserved or migrated automatically.

--- a/apps/openclaw-shell-ios/OpenClawShell/Info.plist
+++ b/apps/openclaw-shell-ios/OpenClawShell/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.2</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/openclaw-shell-ios/OpenClawShell/Info.plist
+++ b/apps/openclaw-shell-ios/OpenClawShell/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.2</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
@@ -10,11 +10,13 @@ import MLCSwift
 enum Paths {
     static let appFolderName = "BeMoreAgent"
     static let workspaceFolderName = "BeMoreAgentWorkspace"
+    static var applicationSupportOverride: URL?
+    static var documentsOverride: URL?
 
     static var fileManager: FileManager { .default }
 
     static var applicationSupportDirectory: URL {
-        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let base = applicationSupportOverride ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         let folder = base.appendingPathComponent(appFolderName, isDirectory: true)
         ensureDirectoryExists(folder)
         return folder
@@ -27,7 +29,7 @@ enum Paths {
     }
 
     static var documentsDirectory: URL {
-        fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        documentsOverride ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
     }
 
     static var legacyWorkspaceDirectory: URL {
@@ -211,7 +213,9 @@ enum ModelMetadataInference {
 protocol LocalLLMEngine {
     var backendDisplayName: String { get }
     var isRuntimeReady: Bool { get }
+    var supportsLocalModels: Bool { get }
     var requiresModelSelection: Bool { get }
+    var runtimeRequirementMessage: String? { get }
 
     func bootstrap() async throws
     func configureRuntime(_ config: EngineRuntimeConfig?) async throws
@@ -233,12 +237,24 @@ final class MLCBridgeEngine: LocalLLMEngine {
 
     var isRuntimeReady: Bool { runtimeConfig != nil }
 
+    var supportsLocalModels: Bool {
+        #if canImport(MLCSwift)
+        return true
+        #else
+        return false
+        #endif
+    }
+
     var requiresModelSelection: Bool {
         #if canImport(MLCSwift)
         true
         #else
         false
         #endif
+    }
+
+    var runtimeRequirementMessage: String? {
+        supportsLocalModels ? nil : "This build does not include the on-device runtime package yet. Link a cloud provider for live chat."
     }
 
     func bootstrap() async throws {}
@@ -630,12 +646,12 @@ final class ChatStore: ObservableObject {
 
     func load() {
         guard let data = try? Data(contentsOf: Paths.chatStateFile) else {
-            messages = [ChatMessage(role: .system, content: "BMO Agent is ready. Install a model to start on-device inference.")]
+            messages = [ChatMessage(role: .system, content: "Route not configured. Link a cloud provider for live chat, or select a local model only after the on-device runtime is available.")]
             return
         }
         messages = (try? JSONDecoder().decode([ChatMessage].self, from: data)) ?? []
         if messages.isEmpty {
-            messages = [ChatMessage(role: .system, content: "BMO Agent is ready.")]
+            messages = [ChatMessage(role: .system, content: "Route not configured. Choose a live route in Models before chatting.")]
         }
     }
 
@@ -649,7 +665,7 @@ final class ChatStore: ObservableObject {
     }
 
     func clear() {
-        messages = [ChatMessage(role: .system, content: "Conversation cleared. Ready for a new chat.")]
+        messages = [ChatMessage(role: .system, content: "Conversation cleared. Route must still be configured before live chat.")]
         persist()
     }
 }
@@ -1013,6 +1029,16 @@ final class UserPreferencesStore: ObservableObject {
         persist()
     }
 
+    func updateUserProfileMarkdown(_ value: String) {
+        preferences.userProfileMarkdown = value
+        persist()
+    }
+
+    func updateSoulProfileMarkdown(_ value: String) {
+        preferences.soulProfileMarkdown = value
+        persist()
+    }
+
     private func persist() {
         do {
             let data = try JSONEncoder().encode(preferences)
@@ -1065,7 +1091,7 @@ final class AppState: ObservableObject {
     }
 
     var usesStubRuntime: Bool {
-        engine.backendDisplayName.contains("Stub")
+        !engine.supportsLocalModels
     }
 
     var canUseSelectedLocalModel: Bool {
@@ -1087,14 +1113,17 @@ final class AppState: ObservableObject {
 
     var activeRouteModeLabel: String {
         if selectedProviderAccount != nil { return "Gateway cloud route" }
-        if selectedInstalledModel != nil { return usesStubRuntime ? "Local selected" : "On-device route" }
-        return stackConfig.deploymentMode == .bootstrapSelfHosted ? "Stack profile only" : "Awaiting pairing"
+        if selectedInstalledModel != nil { return usesStubRuntime ? "Local runtime unavailable" : "On-device route" }
+        return "Route not configured"
     }
 
     var operatorSummary: String {
         if let account = selectedProviderAccount {
             return "OpenClaw shell is routed through \(account.provider.displayName) using \(account.modelSlug)."
         } else if let model = selectedInstalledModel {
+            if usesStubRuntime {
+                return "\(model.displayName) is selected, but local inference is unavailable in this build."
+            }
             return "Selected runtime target: \(model.modelID.isEmpty ? model.localFilename : model.modelID)."
         } else if usesStubRuntime {
             return stackConfig.deploymentMode == .bootstrapSelfHosted
@@ -1131,7 +1160,7 @@ final class AppState: ObservableObject {
         if let model = selectedInstalledModel {
             return model.displayName
         }
-        return stackConfig.deploymentMode == .bootstrapSelfHosted ? "Stack profile prepared" : "No active route"
+        return "Route not configured"
     }
 
     var activeRouteDetail: String {
@@ -1139,7 +1168,8 @@ final class AppState: ObservableObject {
             return "\(account.modelSlug) via \(account.baseURL)"
         }
         if let model = selectedInstalledModel {
-            return model.modelID.isEmpty ? model.localFilename : model.modelID
+            let target = model.modelID.isEmpty ? model.localFilename : model.modelID
+            return usesStubRuntime ? "\(target) selected, but local inference is not live in this build." : target
         }
         return "Gateway target: \(stackConfig.gatewayURL). Select a live route in Models before using chat as if the stack is online."
     }
@@ -1193,6 +1223,7 @@ final class AppState: ObservableObject {
         do {
             try await engine.bootstrap()
             try await applySelectedModelIfPossible()
+            refreshRuntimeSummary()
         } catch {
             chatStore.errorMessage = error.localizedDescription
             runtimeStatus = "Runtime error"
@@ -1471,11 +1502,15 @@ final class AppState: ObservableObject {
         if let account = selectedProviderAccount {
             runtimeStatus = "Cloud: \(account.provider.displayName) • \(account.modelSlug)"
         } else if let model = selectedInstalledModel {
-            runtimeStatus = model.modelID.isEmpty ? "Selected: \(model.localFilename)" : "Selected: \(model.modelID)"
+            if usesStubRuntime {
+                runtimeStatus = "Local model selected, runtime unavailable"
+            } else {
+                runtimeStatus = model.modelID.isEmpty ? "On-device: \(model.localFilename)" : "On-device: \(model.modelID)"
+            }
         } else if usesStubRuntime {
-            runtimeStatus = stackConfig.isOnboardingComplete ? "Stack profiled, live route still needed" : "Onboarding required"
+            runtimeStatus = stackConfig.isOnboardingComplete ? "Route not configured" : "Onboarding required"
         } else {
-            runtimeStatus = "No model selected"
+            runtimeStatus = "Route not configured"
         }
     }
 
@@ -1528,7 +1563,7 @@ final class AppState: ObservableObject {
     private func applySelectedModelIfPossible() async throws {
         guard let filename = runtimePreferences.selection.selectedInstalledFilename else {
             try await engine.configureRuntime(nil)
-            runtimeStatus = "No model selected"
+            runtimeStatus = "Route not configured"
             return
         }
 
@@ -1538,9 +1573,15 @@ final class AppState: ObservableObject {
             return
         }
 
+        guard engine.supportsLocalModels else {
+            try await engine.configureRuntime(nil)
+            runtimeStatus = "Local model selected, runtime unavailable"
+            return
+        }
+
         try await engine.configureRuntime(
             EngineRuntimeConfig(modelURL: installed.localURL, modelID: installed.modelID, modelLib: installed.modelLib)
         )
-        runtimeStatus = installed.modelID.isEmpty ? "Selected: \(installed.localFilename)" : "Selected: \(installed.modelID)"
+        runtimeStatus = installed.modelID.isEmpty ? "On-device: \(installed.localFilename)" : "On-device: \(installed.modelID)"
     }
 }

--- a/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
@@ -744,6 +744,30 @@ struct CloudExecutionMessage: Hashable {
     var content: String
 }
 
+enum CloudPromptBuilder {
+    static func systemPrompt(config: StackConfig, operatorName: String, routeLabel: String) -> String {
+        let name = operatorName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayName = name.isEmpty ? "the operator" : name
+        let toolPosture = config.toolsEnabled
+            ? "The operator intends to use tool-capable OpenClaw routes when the Gateway exposes them."
+            : "The operator has not enabled tool-capable behavior for this stack profile."
+
+        return """
+        You are BeMoreAgent, the BMO-style operator agent for \(displayName)'s OpenClaw stack.
+
+        You are not confined to the iOS app. Do not frame yourself as app-only. Help with the full OpenClaw/operator context: planning, repo work, runtime diagnosis, provider setup, deployment reasoning, and stack operations.
+
+        Current route: \(routeLabel).
+        Stack name: \(config.stackName).
+        Gateway target: \(config.gatewayURL).
+        Admin/public domain: \(config.adminDomain).
+        \(toolPosture)
+
+        Be honest about capabilities. This direct cloud chat route can reason and use attached file context, but it does not by itself grant direct device control, shell execution, or OpenClaw Gateway tools. If an action requires the Gateway, desktop node, or a tool bridge, say exactly what route is needed instead of refusing as though the request is app-only.
+        """
+    }
+}
+
 enum CloudExecutionServiceError: Error {
     case invalidBaseURL
     case invalidResponse
@@ -1112,14 +1136,14 @@ final class AppState: ObservableObject {
     }
 
     var activeRouteModeLabel: String {
-        if selectedProviderAccount != nil { return "Gateway cloud route" }
+        if selectedProviderAccount != nil { return "Direct cloud model route" }
         if selectedInstalledModel != nil { return usesStubRuntime ? "Local runtime unavailable" : "On-device route" }
         return "Route not configured"
     }
 
     var operatorSummary: String {
         if let account = selectedProviderAccount {
-            return "OpenClaw shell is routed through \(account.provider.displayName) using \(account.modelSlug)."
+            return "Chat is routed directly through \(account.provider.displayName) using \(account.modelSlug). Gateway tools still require a real OpenClaw bridge at \(stackConfig.gatewayURL)."
         } else if let model = selectedInstalledModel {
             if usesStubRuntime {
                 return "\(model.displayName) is selected, but local inference is unavailable in this build."
@@ -1176,7 +1200,7 @@ final class AppState: ObservableObject {
 
     var routeHealthSummary: String {
         if selectedProviderAccount != nil {
-            return "Live provider route ready for real chat."
+            return "Direct cloud chat is ready. OpenClaw tools require a Gateway/tool bridge."
         }
         if let model = selectedInstalledModel {
             return usesStubRuntime
@@ -1427,7 +1451,7 @@ final class AppState: ObservableObject {
             let reply = try await cloudExecutionService.send(
                 account: account,
                 messages: [
-                    CloudExecutionMessage(role: .system, content: "You are verifying a chat transport inside the BeMoreAgent iOS app. Reply with exactly: ROUTE_OK"),
+                    CloudExecutionMessage(role: .system, content: "You are verifying BeMoreAgent's direct cloud chat route for an OpenClaw operator stack. Reply with exactly: ROUTE_OK"),
                     CloudExecutionMessage(role: .user, content: "Return ROUTE_OK")
                 ],
                 temperature: 0,
@@ -1515,8 +1539,16 @@ final class AppState: ObservableObject {
     }
 
     private func buildCloudMessages(attachedFiles: [WorkspaceFile]) -> [CloudExecutionMessage] {
+        let routeLabel = selectedProviderAccount.map { "\($0.provider.displayName) using \($0.modelSlug)" } ?? "No selected cloud provider"
         var messages: [CloudExecutionMessage] = [
-            CloudExecutionMessage(role: .system, content: "You are BeMoreAgent, a practical assistant inside the iOS app. Be concise, helpful, and use any attached file context when relevant.")
+            CloudExecutionMessage(
+                role: .system,
+                content: CloudPromptBuilder.systemPrompt(
+                    config: stackConfig,
+                    operatorName: operatorDisplayName,
+                    routeLabel: routeLabel
+                )
+            )
         ]
 
         if !attachedFiles.isEmpty {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
@@ -165,7 +165,7 @@ struct ChatView: View {
 
     private var statusLine: String {
         if let account = appState.selectedProviderAccount {
-            return "Cloud chat via \(account.provider.displayName) • \(account.modelSlug)"
+            return "Direct cloud chat via \(account.provider.displayName) • \(account.modelSlug)"
         }
         if let model = appState.selectedInstalledModel {
             return appState.usesStubRuntime ? "Local model selected, runtime not included in this build" : "On-device model • \(model.displayName)"

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
@@ -118,7 +118,7 @@ struct ChatView: View {
         VStack(spacing: 8) {
             if appState.selectedProviderAccount != nil || appState.selectedInstalledModel != nil || appState.usesStubRuntime {
                 HStack(spacing: 6) {
-Image(systemName: appState.selectedProviderAccount != nil ? "link.circle.fill" : appState.usesStubRuntime ? "sparkles.rectangle.stack" : "cpu")
+                    Image(systemName: appState.selectedProviderAccount != nil ? "link.circle.fill" : appState.usesStubRuntime ? "exclamationmark.triangle.fill" : "cpu")
                         .font(.caption)
                     Text(statusLine)
                         .font(.caption)
@@ -170,8 +170,7 @@ Image(systemName: appState.selectedProviderAccount != nil ? "link.circle.fill" :
         if let model = appState.selectedInstalledModel {
             return appState.usesStubRuntime ? "Local model selected, runtime not included in this build" : "On-device model • \(model.displayName)"
         }
-        return "Link a cloud provider to chat in this build"
-
+        return "Route not configured. Link a cloud provider to chat in this build."
     }
 }
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ModelsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ModelsView.swift
@@ -368,7 +368,7 @@ struct ModelsView: View {
                 .fontWeight(.semibold)
                 .foregroundColor(BMOTheme.textSecondary)
 
-            Text("Choose the active cloud route here. Use Settings for provider editing and maintenance.")
+            Text("Choose the active direct cloud model route here. OpenClaw Gateway tools require a separate stack bridge.")
                 .font(.caption)
                 .foregroundColor(BMOTheme.textTertiary)
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/SettingsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/SettingsView.swift
@@ -98,9 +98,9 @@ struct SettingsView: View {
             return "\(account.provider.displayName) • \(account.modelSlug)"
         }
         if let model = appState.selectedInstalledModel {
-            return model.displayName
+            return appState.usesStubRuntime ? "\(model.displayName) • runtime unavailable" : model.displayName
         }
-        return "None"
+        return "Route not configured"
     }
 
     private func providerRow(_ provider: ProviderKind) -> some View {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/SettingsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/SettingsView.swift
@@ -32,7 +32,7 @@ struct SettingsView: View {
                     settingsRow(title: "Backend", value: appState.backendDisplayName)
                     settingsRow(title: "Status", value: appState.runtimeStatus)
                     settingsRow(title: "Active route", value: activeRouteLabel)
-                    Text("Choose the live local or cloud route in Models. Settings is for maintenance and configuration.")
+                    Text("Choose the live local route or direct cloud model route in Models. Settings is for maintenance and configuration.")
                         .font(.caption)
                         .foregroundColor(appState.usesStubRuntime ? BMOTheme.warning : BMOTheme.textSecondary)
                         .listRowBackground(BMOTheme.backgroundCard)

--- a/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
+++ b/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
@@ -82,6 +82,43 @@ final class AppStateRuntimeTests: XCTestCase {
         XCTAssertEqual(appState.runtimeStatus, "Local model selected, runtime unavailable")
         XCTAssertEqual(appState.operatorSummary, "Gemma4 E2b It is selected, but local inference is unavailable in this build.")
     }
+
+    func testSelectedProviderIsLabeledAsDirectCloudRoute() async throws {
+        let fakeEngine = FakeLocalLLMEngine(supportsLocalModels: false)
+        let appState = AppState(engine: fakeEngine)
+        await appState.bootstrap()
+
+        var account = ProviderAccount.blank(for: .openAI)
+        account.apiKey = "test-key"
+        account.modelSlug = "gpt-4.1"
+        account.isEnabled = true
+        appState.providerStore.upsert(account)
+        appState.setSelectedProvider(.openAI)
+
+        XCTAssertEqual(appState.activeRouteModeLabel, "Direct cloud model route")
+        XCTAssertTrue(appState.operatorSummary.contains("routed directly through OpenAI"))
+        XCTAssertTrue(appState.operatorSummary.contains("Gateway tools still require"))
+        XCTAssertTrue(appState.routeHealthSummary.contains("Direct cloud chat is ready"))
+    }
+
+    func testCloudSystemPromptDoesNotConfineAgentToAppOnly() {
+        var config = StackConfig.default
+        config.stackName = "BeMoreAgent"
+        config.gatewayURL = "https://gateway.example.test"
+        config.adminDomain = "example.test"
+        config.toolsEnabled = true
+
+        let prompt = CloudPromptBuilder.systemPrompt(
+            config: config,
+            operatorName: "Cody",
+            routeLabel: "OpenAI using gpt-4.1"
+        )
+
+        XCTAssertTrue(prompt.contains("not confined to the iOS app"))
+        XCTAssertTrue(prompt.contains("full OpenClaw/operator context"))
+        XCTAssertTrue(prompt.contains("does not by itself grant direct device control"))
+        XCTAssertFalse(prompt.contains("only perform functions inside the app"))
+    }
 }
 
 private final class FakeLocalLLMEngine: LocalLLMEngine {

--- a/apps/openclaw-shell-ios/README.md
+++ b/apps/openclaw-shell-ios/README.md
@@ -24,6 +24,8 @@ The shell persists local state under app-scoped Application Support, including:
 - buddy system state
 - operator preferences
 
+Bundle identity continuity matters for this state. See [`BUILD_14_CONTINUITY_NOTE.md`](./BUILD_14_CONTINUITY_NOTE.md) for why build 14 could look like a fresh install after the bundle identifier briefly changed.
+
 ## Runtime posture
 
 This subtree does not claim a completed on-device runtime. It builds without `MLCSwift` by falling back to a stub local engine boundary, and real local inference still depends on packaging and wiring an actual runtime.

--- a/apps/openclaw-shell-ios/project.yml
+++ b/apps/openclaw-shell-ios/project.yml
@@ -5,7 +5,7 @@ configs:
   Debug: debug
   Release: release
 settings:
-  IPHONEOS_DEPLOYMENT_TARGET: 17.0
+  IPHONEOS_DEPLOYMENT_TARGET: 26.0
   SWIFT_VERSION: "5.9"
 targets:
   BeMoreAgent:
@@ -29,3 +29,16 @@ targets:
         CODE_SIGN_STYLE: Automatic
         PRODUCT_NAME: BeMoreAgent
     dependencies: []
+  BeMoreAgentTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: OpenClawShellTests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: BeMoreAgentTests
+        GENERATE_INFOPLIST_FILE: YES
+        DEVELOPMENT_TEAM: DY9FHPRZA9
+        CODE_SIGN_STYLE: Automatic
+    dependencies:
+      - target: BeMoreAgent


### PR DESCRIPTION
## Task contract
Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem
Build 16 fixed bundle continuity and cloud route posture, but the app still felt like a chat shell. Build 17 adds the first real OpenClaw workspace layer: inspectable artifacts, state stores, receipts, a skills registry, Skills and Artifacts tabs, and a flagship Pokemon Team Builder skill.

## Smallest useful wedge
- Add a built-in OpenClaw Workspace Runtime under the iOS app container.
- Bootstrap a real .openclaw workspace with canonical Markdown artifacts, JSON state stores, action/event logs, and registry data.
- Add registry-backed Skills and Artifacts tabs.
- Register Pokemon Team Builder, Artifact Rebuilder, and Memory Inspector.
- Make Pokemon Team Builder save JSON/Markdown artifacts through the generic skill runner.
- Ground Buddy and Chat in runtime receipts so the UI does not claim unconfirmed work.
- Bump BeMoreAgent to build 17 while keeping PRODUCT_BUNDLE_IDENTIFIER=BeMoreAgent and IPHONEOS_DEPLOYMENT_TARGET=26.0.

## Summary
- add a built-in OpenClaw Workspace Runtime under the iOS app container
- bootstrap a real .openclaw workspace with soul.md, user.md, memory.md, session.md, skills.md
- add actions.jsonl, events.jsonl, registry/skills.json, JSON state stores, and latest-actions.log
- add typed action records, statuses, receipts, and receipt-aware summaries
- add registry-backed Skills tab and Artifacts tab
- register Pokemon Team Builder, Artifact Rebuilder, and Memory Inspector skills
- make Pokemon Team Builder run through the generic skill runner and persist JSON/Markdown team artifacts
- redesign Buddy around model/runtime/memory/artifact/skill/action health
- add chat action receipt cards for recent runtime work
- remove user-facing split-brain Gateway framing in favor of one OpenClaw runtime surface
- bump BeMoreAgent to build 17

## Runtime truth
Build 17 materially moves the app toward one agent, one workspace, one sandbox, one capability surface. It still does not ship real on-device LLM inference unless MLCSwift is linked, and iOS does not expose arbitrary host shell execution here. The Build 17 sandbox is a controlled OpenClaw command surface with receipts: pwd, ls, cat, regenerate, skills, help. Unsupported commands fail honestly instead of pretending to run.

## Verification
- git diff --check
- xcodegen generate
- xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination generic/platform=iOS Simulator -derivedDataPath .build/DerivedData build
- xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination generic/platform=iOS Simulator -derivedDataPath .build/DerivedData build-for-testing
- local Xcode settings: PRODUCT_BUNDLE_IDENTIFIER=BeMoreAgent, IPHONEOS_DEPLOYMENT_TARGET=26.0, CFBundleVersion=17

## Test note
A full simulator xcodebuild test invocation built successfully but hung during simulator execution on this Mac, so I stopped it and used build-for-testing as the reliable XCTest compile check.

## Rollback plan
Revert this PR commit to remove Build 17 runtime plumbing, the new tabs, the skill registry, generated workspace artifacts, and Build 17 metadata while preserving the earlier BeMoreAgent bundle continuity fix.

## Continuity
The bundle identifier remains BeMoreAgent, so existing TestFlight users on that identity should keep local app-container state.