### PR TITLE
Implement OpenClaw Build 17 workspace runtime

### DIFF
--- a/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
+++ b/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
@@ -13,7 +13,9 @@ Current shipped shell surfaces include:
 - first-run onboarding with persisted stack config
 - Mission Control as the post-onboarding landing surface
 - Models as the route-control surface for local and cloud selection
-- Chat, Buddy, Files, and Settings tabs
+- Chat, Skills, Artifacts, Buddy, Files, and Settings tabs
+- `.openclaw/` workspace artifacts, JSON state stores, action/event logs, and a skills registry
+- Pokémon Team Builder as a registry-backed skill that saves JSON and Markdown artifacts
 - persisted tab ordering and visibility
 - persisted buddy rename and active selection
 - bundled repo-backed surface briefs inside Mission Control
@@ -24,6 +26,10 @@ Current shipped shell surfaces include:
 - Relaunch returns to the main tab shell after onboarding is complete.
 - The local runtime is still stubbed unless `MLCSwift` is actually present and wired.
 - Cloud routes can be configured in Settings and switched in Models.
+- Workspace actions run through OpenClaw runtime receipts. The UI should not claim files, memory,
+  skills, or sandbox work completed unless the runtime returns a completed or persisted receipt.
+- The iOS sandbox currently exposes controlled OpenClaw commands (`pwd`, `ls`, `cat`, `regenerate`,
+  `skills`, `help`) rather than arbitrary host shell execution.
 
 ## Local build path
 
@@ -40,7 +46,7 @@ xcodebuild -project BeMoreAgent.xcodeproj \
 
 ## Release path
 
-- `CFBundleVersion` is currently `16`.
+- `CFBundleVersion` is currently `17`.
 - `IPHONEOS_DEPLOYMENT_TARGET` is currently `26.0`.
 - TestFlight delivery is repo-managed through `.github/workflows/testflight.yml`.
 - The operator runbook for that path is `apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md`.
@@ -52,9 +58,13 @@ xcodebuild -project BeMoreAgent.xcodeproj \
 - `project.yml` still has `dependencies: []`.
 - When `MLCSwift` is not importable, the app still uses the stub local-runtime path and cannot claim
   real on-device inference.
+- Arbitrary codex-style shell/process execution is not available on-device in this build. Build 17
+  provides a receipt-backed controlled sandbox surface and leaves real hardened process execution for
+  a future platform/runtime integration.
 
 ## Next native work
 
 1. keep the shell truth and docs aligned with what is actually shipped
 2. preserve simulator build + relaunch verification on every PR
 3. only land local-runtime work as a separate PR if it is real on-device inference, not a stub
+4. expand Pokémon Team Builder with simulator/type data once a bundled dataset is selected

--- a/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
@@ -252,7 +252,7 @@ enum StackDeploymentMode: String, Codable, CaseIterable, Hashable, Identifiable 
 
     var title: String {
         switch self {
-        case .pairToExistingGateway: return "Pair to an existing Gateway"
+        case .pairToExistingGateway: return "Pair to an existing runtime"
         case .bootstrapSelfHosted: return "Set up a self-hosted OpenClaw stack"
         }
     }
@@ -260,9 +260,9 @@ enum StackDeploymentMode: String, Codable, CaseIterable, Hashable, Identifiable 
     var subtitle: String {
         switch self {
         case .pairToExistingGateway:
-            return "Connect this iPhone to a Gateway you already run elsewhere."
+            return "Connect this iPhone to an OpenClaw runtime endpoint you already run elsewhere."
         case .bootstrapSelfHosted:
-            return "Use onboarding answers to generate the exact stack profile, Gateway target, and next setup steps for a self-hosted deployment."
+            return "Use onboarding answers to generate the exact stack profile, runtime target, and next setup steps for a self-hosted deployment."
         }
     }
 }
@@ -355,6 +355,8 @@ enum AppTab: String, Codable, CaseIterable, Hashable, Identifiable {
     case missionControl
     case models
     case chat
+    case skills
+    case artifacts
     case buddy
     case files
     case settings
@@ -366,6 +368,8 @@ enum AppTab: String, Codable, CaseIterable, Hashable, Identifiable {
         case .missionControl: return "Control"
         case .models: return "Models"
         case .chat: return "Chat"
+        case .skills: return "Skills"
+        case .artifacts: return "Artifacts"
         case .buddy: return "Buddy"
         case .files: return "Files"
         case .settings: return "Settings"
@@ -377,6 +381,8 @@ enum AppTab: String, Codable, CaseIterable, Hashable, Identifiable {
         case .missionControl: return "switch.2"
         case .models: return "cpu"
         case .chat: return "message.fill"
+        case .skills: return "sparkles.rectangle.stack.fill"
+        case .artifacts: return "doc.richtext.fill"
         case .buddy: return "person.2.fill"
         case .files: return "folder.fill"
         case .settings: return "gearshape.fill"

--- a/apps/openclaw-shell-ios/OpenClawShell/ContentView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/ContentView.swift
@@ -50,6 +50,10 @@ struct MainTabView: View {
             ModelsView()
         case .chat:
             ChatView()
+        case .skills:
+            SkillsView()
+        case .artifacts:
+            ArtifactsView()
         case .buddy:
             BuddyView()
         case .files:

--- a/apps/openclaw-shell-ios/OpenClawShell/Info.plist
+++ b/apps/openclaw-shell-ios/OpenClawShell/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.2</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
@@ -86,7 +86,7 @@ struct OnboardingFlow: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 featureRow("Generate a concrete stack profile instead of fake setup copy")
-                featureRow("Target a real Gateway and node pairing flow")
+                featureRow("Target a real OpenClaw runtime and node pairing flow")
                 featureRow("Show honest readiness for local runtime, providers, and shell surfaces")
             }
             .padding(.horizontal, BMOTheme.spacingXL)
@@ -150,7 +150,7 @@ struct OnboardingFlow: View {
 
                 labeledField(title: "Stack name", text: $config.stackName, placeholder: "BeMoreAgent")
                 labeledField(title: "Primary goal", text: $config.goal, placeholder: "Run my own OpenClaw stack")
-                labeledField(title: "Gateway URL", text: $config.gatewayURL, placeholder: "https://gateway.example.com")
+                labeledField(title: "Runtime endpoint", text: $config.gatewayURL, placeholder: "https://openclaw.example.com")
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                 labeledField(title: "Admin / public domain", text: $config.adminDomain, placeholder: "example.com")
@@ -251,7 +251,7 @@ struct OnboardingFlow: View {
 
                 toggleCard(icon: "iphone", title: "Install node on this phone", subtitle: "Treat iPhone capabilities as part of the self-hosted stack surface", isOn: $config.installNodeOnThisPhone)
                     .padding(.horizontal, BMOTheme.spacingLG)
-                toggleCard(icon: "desktopcomputer", title: "Expect desktop / server node", subtitle: "Assume a host Gateway or desktop companion is part of the stack", isOn: $config.installDesktopNode)
+                toggleCard(icon: "desktopcomputer", title: "Expect desktop / server node", subtitle: "Assume a host runtime or desktop companion is part of the stack", isOn: $config.installDesktopNode)
                     .padding(.horizontal, BMOTheme.spacingLG)
 
                 VStack(alignment: .leading, spacing: 12) {
@@ -328,9 +328,9 @@ struct OnboardingFlow: View {
 
         let steps = [
             (0.2, "Saving operator profile for \(trimmed(config.operatorName).isEmpty ? "this device" : trimmed(config.operatorName))"),
-            (0.4, "Targeting Gateway \(trimmed(config.gatewayURL))"),
+            (0.4, "Targeting runtime endpoint \(trimmed(config.gatewayURL))"),
             (0.6, config.installNodeOnThisPhone ? "Marking this iPhone as a node-capable surface" : "Skipping local node install on this phone"),
-            (0.8, config.installDesktopNode ? "Expecting a desktop or server Gateway companion" : "Running in phone-only pairing mode"),
+            (0.8, config.installDesktopNode ? "Expecting a desktop or server runtime companion" : "Running in phone-only mode"),
             (1.0, "Stack profile ready. The shell will show actual readiness instead of pretending setup is complete.")
         ]
 
@@ -370,7 +370,7 @@ struct OnboardingFlow: View {
                 VStack(spacing: 12) {
                     summaryRow(icon: "person.crop.circle", label: "Operator", value: trimmed(config.operatorName))
                     summaryRow(icon: "briefcase", label: "Role", value: trimmed(config.role))
-                    summaryRow(icon: "link", label: "Gateway", value: trimmed(config.gatewayURL))
+                    summaryRow(icon: "link", label: "Runtime", value: trimmed(config.gatewayURL))
                     summaryRow(icon: "switch.2", label: "Mode", value: config.deploymentMode.title)
                     summaryRow(icon: "gauge.open.with.lines.needle.33percent", label: "Autonomy", value: "\(config.autonomyLevel)/5")
                     summaryRow(icon: "brain", label: "Memory", value: config.memoryEnabled ? "On" : "Off")
@@ -549,10 +549,10 @@ struct OnboardingFlow: View {
     private var generatedChecklist: [String] {
         var items: [String] = []
         if config.deploymentMode == .bootstrapSelfHosted {
-            items.append("Provision or verify an OpenClaw Gateway at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
-            items.append("Set gateway.remote.url and pairing/public URL values to match \(fallback(config.adminDomain, defaultValue: "prismtek.dev")).")
+            items.append("Provision or verify an OpenClaw runtime endpoint at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
+            items.append("Set runtime and pairing/public URL values to match \(fallback(config.adminDomain, defaultValue: "prismtek.dev")).")
         } else {
-            items.append("Pair this app to the existing Gateway at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
+            items.append("Pair this app to the existing OpenClaw runtime endpoint at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
         }
         if config.installNodeOnThisPhone {
             items.append("Treat this iPhone as a node surface with notification, camera, and device capability permissions.")

--- a/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
@@ -1,0 +1,816 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Action receipts
+
+enum OpenClawActionStatus: String, Codable, CaseIterable, Hashable {
+    case planned
+    case queued
+    case running
+    case completed
+    case failed
+    case persisted
+
+    var label: String { rawValue.capitalized }
+
+    var color: Color {
+        switch self {
+        case .planned, .queued: return BMOTheme.warning
+        case .running: return BMOTheme.accent
+        case .completed, .persisted: return BMOTheme.success
+        case .failed: return BMOTheme.error
+        }
+    }
+}
+
+enum OpenClawActionKind: String, Codable, CaseIterable, Hashable {
+    case skillRun = "skill.run"
+    case artifactRegenerate = "artifact.regenerate"
+    case memoryRefresh = "memory.refresh"
+    case sandboxRun = "sandbox.run"
+    case workspaceWrite = "workspace.write"
+    case workspaceRead = "workspace.read"
+}
+
+struct OpenClawActionRecord: Identifiable, Codable, Hashable {
+    var id: UUID
+    var kind: OpenClawActionKind
+    var source: String
+    var title: String
+    var status: OpenClawActionStatus
+    var createdAt: Date
+    var updatedAt: Date
+    var input: [String: String]
+    var output: [String: String]
+    var error: String?
+    var artifacts: [String]
+    var logs: [String]
+}
+
+struct OpenClawReceipt: Identifiable, Codable, Hashable {
+    var id: UUID { actionId }
+    var actionId: UUID
+    var status: OpenClawActionStatus
+    var title: String
+    var summary: String
+    var output: [String: String]
+    var artifacts: [String]
+    var logs: [String]
+    var error: String?
+}
+
+enum ReceiptFormatter {
+    static func confirmedSummary(for receipt: OpenClawReceipt) -> String {
+        switch receipt.status {
+        case .persisted:
+            let artifacts = receipt.artifacts.isEmpty ? "" : " Artifacts: \(receipt.artifacts.joined(separator: ", "))."
+            return "Persisted: \(receipt.summary).\(artifacts)"
+        case .completed:
+            return "Completed: \(receipt.summary)."
+        case .failed:
+            return "Failed: \(receipt.error ?? receipt.summary)."
+        case .planned:
+            return "Planned: \(receipt.summary)."
+        case .queued:
+            return "Queued: \(receipt.summary)."
+        case .running:
+            return "Running: \(receipt.summary)."
+        }
+    }
+}
+
+// MARK: - Artifacts
+
+struct OpenClawArtifactMetadata: Identifiable, Codable, Hashable {
+    enum Freshness: String, Codable, Hashable {
+        case fresh
+        case stale
+        case missing
+    }
+
+    var id: String { path }
+    var path: String
+    var kind: String
+    var updatedAt: Date?
+    var size: Int
+    var freshness: Freshness
+}
+
+struct OpenClawEventRecord: Codable, Hashable {
+    var id: UUID = UUID()
+    var type: String
+    var message: String
+    var createdAt: Date = .now
+    var metadata: [String: String] = [:]
+}
+
+// MARK: - Skills
+
+struct SkillManifest: Identifiable, Codable, Hashable {
+    struct UIMetadata: Codable, Hashable {
+        var route: String
+        var systemImage: String
+        var accent: String
+    }
+
+    var id: String
+    var name: String
+    var description: String
+    var version: String
+    var category: String
+    var tags: [String]
+    var permissions: [String]
+    var inputSchema: [String: String]
+    var outputSchema: [String: String]
+    var ui: UIMetadata
+    var entrypoint: String
+    var enabled: Bool
+}
+
+struct PokemonTeamMember: Identifiable, Codable, Hashable {
+    var id: UUID = UUID()
+    var name: String
+    var role: String
+    var notes: String
+}
+
+struct PokemonTeamOutput: Codable, Hashable {
+    var teamMembers: [PokemonTeamMember]
+    var roleBreakdown: [String]
+    var summary: String
+    var weaknesses: [String]
+    var suggestions: [String]
+    var artifactPath: String?
+}
+
+enum BuiltInSkillRegistry {
+    static let pokemonTeamBuilderID = "pokemon-team-builder"
+    static let artifactRebuilderID = "artifact-rebuilder"
+    static let memoryInspectorID = "memory-inspector"
+
+    static var manifests: [SkillManifest] {
+        [
+            SkillManifest(
+                id: pokemonTeamBuilderID,
+                name: "Pokemon Team Builder",
+                description: "Draft, analyze, save, and export structured Pokemon teams as OpenClaw artifacts.",
+                version: "1.0.0",
+                category: "Games",
+                tags: ["pokemon", "team-builder", "strategy"],
+                permissions: ["workspace.write", "workspace.read", "actions.write"],
+                inputSchema: [
+                    "format": "string",
+                    "strategy": "string",
+                    "mustInclude": "comma-separated string",
+                    "avoid": "comma-separated string"
+                ],
+                outputSchema: [
+                    "teamMembers": "array",
+                    "summary": "string",
+                    "artifactPath": "string"
+                ],
+                ui: .init(route: "/skills/pokemon-team-builder", systemImage: "gamecontroller.fill", accent: "accent"),
+                entrypoint: "builtin.pokemonTeamBuilder",
+                enabled: true
+            ),
+            SkillManifest(
+                id: artifactRebuilderID,
+                name: "Artifact Rebuilder",
+                description: "Regenerate canonical soul, user, memory, session, and skills artifacts from current OpenClaw state.",
+                version: "1.0.0",
+                category: "System",
+                tags: ["artifacts", "memory", "workspace"],
+                permissions: ["workspace.write", "state.read", "actions.write"],
+                inputSchema: ["target": "all or artifact path"],
+                outputSchema: ["paths": "array"],
+                ui: .init(route: "/skills/artifact-rebuilder", systemImage: "arrow.triangle.2.circlepath", accent: "accent"),
+                entrypoint: "builtin.artifactRebuilder",
+                enabled: true
+            ),
+            SkillManifest(
+                id: memoryInspectorID,
+                name: "Memory Inspector",
+                description: "Read current facts, preferences, session state, and recent memory-derived changes.",
+                version: "1.0.0",
+                category: "System",
+                tags: ["memory", "facts", "session"],
+                permissions: ["state.read", "workspace.read"],
+                inputSchema: [:],
+                outputSchema: ["summary": "string"],
+                ui: .init(route: "/skills/memory-inspector", systemImage: "brain.head.profile", accent: "accent"),
+                entrypoint: "builtin.memoryInspector",
+                enabled: true
+            )
+        ]
+    }
+}
+
+// MARK: - Workspace Runtime
+
+@MainActor
+final class OpenClawWorkspaceRuntime: ObservableObject {
+    @Published private(set) var skills: [SkillManifest] = []
+    @Published private(set) var artifacts: [OpenClawArtifactMetadata] = []
+    @Published private(set) var recentActions: [OpenClawActionRecord] = []
+    @Published private(set) var recentEvents: [OpenClawEventRecord] = []
+    @Published var lastError: String?
+
+    private let fileManager = FileManager.default
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    var rootURL: URL { Paths.openClawDirectory }
+    var isBootstrapped: Bool { fileManager.fileExists(atPath: rootURL.appendingPathComponent("soul.md").path) }
+
+    func bootstrap(config: StackConfig, preferences: UserPreferences, routeSummary: String) {
+        ensureWorkspaceTree()
+        skills = BuiltInSkillRegistry.manifests
+        writeJSON(skills, to: rootURL.appendingPathComponent("registry/skills.json"))
+        ensureStateStores(config: config, preferences: preferences, routeSummary: routeSummary)
+        regenerateCanonicalArtifactsIfMissing(config: config, preferences: preferences, routeSummary: routeSummary)
+        refreshMetadata()
+        appendEvent(type: "workspace.bootstrapped", message: "OpenClaw workspace runtime bootstrapped.")
+    }
+
+    func readFile(_ path: String) throws -> String {
+        let url = try resolve(path)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    func writeFile(_ path: String, content: String, source: String = "runtime") throws -> OpenClawReceipt {
+        let action = begin(kind: .workspaceWrite, source: source, title: "Write \(path)", input: ["path": path])
+        do {
+            let url = try resolve(path)
+            try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try content.write(to: url, atomically: true, encoding: .utf8)
+            appendEvent(type: "artifact.written", message: "Wrote \(path).", metadata: ["path": path])
+            return finish(action, status: .persisted, summary: "Wrote \(path)", output: ["path": path], artifacts: [path])
+        } catch {
+            return finish(action, status: .failed, summary: "Could not write \(path)", error: error.localizedDescription)
+        }
+    }
+
+    func listFiles(_ path: String = "") -> [String] {
+        let start = (try? resolve(path)) ?? rootURL
+        guard let enumerator = fileManager.enumerator(at: start, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles]) else {
+            return []
+        }
+        return enumerator.compactMap { item in
+            guard let url = item as? URL else { return nil }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+            guard values?.isRegularFile == true else { return nil }
+            return relativePath(for: url)
+        }.sorted()
+    }
+
+    func regenerateArtifacts(target: String = "all", config: StackConfig, preferences: UserPreferences, routeSummary: String, source: String = "runtime") -> OpenClawReceipt {
+        let action = begin(kind: .artifactRegenerate, source: source, title: "Regenerate artifacts", input: ["target": target])
+        let targets = target == "all" ? canonicalArtifactPaths : [target]
+        do {
+            let generated = artifactContents(config: config, preferences: preferences, routeSummary: routeSummary)
+            var written: [String] = []
+            for path in targets {
+                guard let content = generated[path] else { continue }
+                let url = try resolve(path)
+                try content.write(to: url, atomically: true, encoding: .utf8)
+                written.append(path)
+                appendEvent(type: "artifact.written", message: "Regenerated \(path).", metadata: ["path": path])
+            }
+            refreshMetadata()
+            let status: OpenClawActionStatus = written.isEmpty ? .failed : .persisted
+            let summary = written.isEmpty ? "No matching canonical artifacts were regenerated" : "Regenerated \(written.count) canonical artifact\(written.count == 1 ? "" : "s")"
+            return finish(action, status: status, summary: summary, output: ["paths": written.joined(separator: ", ")], artifacts: written, error: written.isEmpty ? "Unknown artifact target: \(target)" : nil)
+        } catch {
+            return finish(action, status: .failed, summary: "Artifact regeneration failed", error: error.localizedDescription)
+        }
+    }
+
+    func refreshMemory(config: StackConfig, preferences: UserPreferences, routeSummary: String, source: String = "runtime") -> OpenClawReceipt {
+        let action = begin(kind: .memoryRefresh, source: source, title: "Refresh memory", input: [:])
+        ensureStateStores(config: config, preferences: preferences, routeSummary: routeSummary)
+        let receipt = regenerateArtifacts(target: "memory.md", config: config, preferences: preferences, routeSummary: routeSummary, source: source)
+        appendEvent(type: "memory.refreshed", message: "Memory stores refreshed.", metadata: ["artifact": "memory.md"])
+        return finish(action, status: receipt.status, summary: "Memory stores refreshed", output: receipt.output, artifacts: receipt.artifacts, error: receipt.error)
+    }
+
+    func runSkill(id: String, input: [String: String], config: StackConfig, preferences: UserPreferences, routeSummary: String) -> OpenClawReceipt {
+        guard let manifest = skills.first(where: { $0.id == id }), manifest.enabled else {
+            let action = begin(kind: .skillRun, source: "skills", title: "Run skill", input: ["skillId": id])
+            return finish(action, status: .failed, summary: "Skill is not registered or enabled", error: "Unknown skill: \(id)")
+        }
+
+        appendEvent(type: "skill.invoked", message: "Invoked \(manifest.name).", metadata: ["skillId": id])
+        switch id {
+        case BuiltInSkillRegistry.pokemonTeamBuilderID:
+            return runPokemonTeamBuilder(input: input, manifest: manifest)
+        case BuiltInSkillRegistry.artifactRebuilderID:
+            return regenerateArtifacts(target: input["target"]?.nilIfBlank ?? "all", config: config, preferences: preferences, routeSummary: routeSummary, source: "skill.\(id)")
+        case BuiltInSkillRegistry.memoryInspectorID:
+            return runMemoryInspector(manifest: manifest)
+        default:
+            let action = begin(kind: .skillRun, source: "skills", title: manifest.name, input: input)
+            return finish(action, status: .failed, summary: "Entrypoint is not implemented", error: "Missing entrypoint: \(manifest.entrypoint)")
+        }
+    }
+
+    func runSandbox(command: String, config: StackConfig, preferences: UserPreferences, routeSummary: String) -> OpenClawReceipt {
+        let cleaned = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        let action = begin(kind: .sandboxRun, source: "sandbox", title: "Run sandbox command", input: ["command": cleaned])
+        let parts = cleaned.split(separator: " ").map(String.init)
+        guard let op = parts.first else {
+            return finish(action, status: .failed, summary: "No command supplied", error: "Empty sandbox command")
+        }
+
+        appendEvent(type: "sandbox.command.executed", message: "Sandbox command requested: \(cleaned)", metadata: ["command": cleaned])
+
+        switch op {
+        case "pwd":
+            return finish(action, status: .completed, summary: "Printed workspace root", output: ["stdout": "/.openclaw", "exitCode": "0"])
+        case "ls":
+            let target = parts.dropFirst().first ?? ""
+            return finish(action, status: .completed, summary: "Listed \(target.isEmpty ? "/.openclaw" : target)", output: ["stdout": listFiles(target).joined(separator: "\n"), "exitCode": "0"])
+        case "cat":
+            guard let target = parts.dropFirst().first else {
+                return finish(action, status: .failed, summary: "cat requires a file path", error: "Usage: cat soul.md")
+            }
+            do {
+                return finish(action, status: .completed, summary: "Read \(target)", output: ["stdout": try readFile(target), "exitCode": "0"], artifacts: [target])
+            } catch {
+                return finish(action, status: .failed, summary: "Could not read \(target)", error: error.localizedDescription)
+            }
+        case "regenerate":
+            return regenerateArtifacts(target: parts.dropFirst().first ?? "all", config: config, preferences: preferences, routeSummary: routeSummary, source: "sandbox")
+        case "skills":
+            return finish(action, status: .completed, summary: "Listed registered skills", output: ["stdout": skills.map { "\($0.id) - \($0.name)" }.joined(separator: "\n"), "exitCode": "0"])
+        case "help":
+            return finish(action, status: .completed, summary: "Printed sandbox help", output: ["stdout": "Supported commands: pwd, ls [path], cat <path>, regenerate [all|artifact], skills, help", "exitCode": "0"])
+        default:
+            return finish(
+                action,
+                status: .failed,
+                summary: "Arbitrary shell execution is unavailable in the iOS sandbox",
+                output: ["exitCode": "127"],
+                error: "Unsupported command '\(op)'. Build 17 exposes a controlled OpenClaw command surface; TODO: connect a hardened process runner where platform policy allows it."
+            )
+        }
+    }
+
+    func refreshMetadata() {
+        artifacts = listArtifactMetadata()
+        recentActions = loadRecentActions()
+        recentEvents = loadRecentEvents()
+    }
+
+    func buddyStatus(activeModelAdapter: String, brainConnected: Bool, runtimeAvailable: Bool) -> BuddyRuntimeStatus {
+        refreshMetadata()
+        let canonical = artifacts.filter { canonicalArtifactPaths.contains($0.path) }
+        let failed = recentActions.filter { $0.status == .failed }
+        let missing = canonical.filter { $0.freshness == .missing }.map(\.path)
+        var suggestions: [String] = []
+        if missing.isEmpty {
+            suggestions.append("Open Skills and run Pokemon Team Builder to create a saved team artifact.")
+        } else {
+            suggestions.append("Regenerate missing artifacts: \(missing.joined(separator: ", ")).")
+        }
+        if failed.isEmpty == false {
+            suggestions.append("Review failed action receipts before trusting generated summaries.")
+        }
+        if skills.isEmpty {
+            suggestions.append("Rebuild the skills registry.")
+        }
+
+        return BuddyRuntimeStatus(
+            activeModelAdapter: activeModelAdapter,
+            brainConnected: brainConnected,
+            runtimeAvailable: runtimeAvailable,
+            memoryHealthy: missing.isEmpty && fileManager.fileExists(atPath: rootURL.appendingPathComponent("state/facts.json").path),
+            artifacts: canonical,
+            registeredSkillCount: skills.count,
+            recentChanges: Array(recentEvents.prefix(5)),
+            failedActions: Array(failed.prefix(5)),
+            suggestedNextActions: suggestions
+        )
+    }
+
+    // MARK: Private workspace
+
+    private var canonicalArtifactPaths: [String] {
+        ["soul.md", "user.md", "memory.md", "session.md", "skills.md"]
+    }
+
+    private func ensureWorkspaceTree() {
+        [
+            rootURL,
+            rootURL.appendingPathComponent("registry", isDirectory: true),
+            rootURL.appendingPathComponent("state", isDirectory: true),
+            rootURL.appendingPathComponent("skills/pokemon-team-builder/teams", isDirectory: true),
+            rootURL.appendingPathComponent("skills/pokemon-team-builder/presets", isDirectory: true),
+            rootURL.appendingPathComponent("logs", isDirectory: true)
+        ].forEach { try? fileManager.createDirectory(at: $0, withIntermediateDirectories: true) }
+
+        let cacheURL = rootURL.appendingPathComponent("skills/pokemon-team-builder/cache.json")
+        if !fileManager.fileExists(atPath: cacheURL.path) {
+            writeJSON(["lastRun": "never"], to: cacheURL)
+        }
+        let latestLog = rootURL.appendingPathComponent("logs/latest-actions.log")
+        if !fileManager.fileExists(atPath: latestLog.path) {
+            try? "OpenClaw action log initialized.\n".write(to: latestLog, atomically: true, encoding: .utf8)
+        }
+    }
+
+    private func ensureStateStores(config: StackConfig, preferences: UserPreferences, routeSummary: String) {
+        writeJSON([
+            "identity": [preferences.preferredName.nilIfBlank ?? config.operatorName.nilIfBlank ?? "operator"],
+            "project": [config.stackName],
+            "workflow": [config.goal.nilIfBlank ?? "Build and operate an OpenClaw workspace"],
+            "tooling": ["OpenClaw iOS workspace runtime", routeSummary],
+            "game": ["Pokemon Team Builder is a registered skill"]
+        ], to: rootURL.appendingPathComponent("state/facts.json"))
+
+        writeJSON([
+            "preferredName": preferences.preferredName,
+            "theme": preferences.theme.rawValue,
+            "optimizationMode": config.optimizationMode,
+            "memoryEnabled": String(config.memoryEnabled),
+            "toolsEnabled": String(config.toolsEnabled)
+        ], to: rootURL.appendingPathComponent("state/preferences.json"))
+
+        writeJSON([
+            "openTasks": [
+                "Ship a real on-device inference runtime or hardened host process runner when available."
+            ],
+            "completedTasks": [
+                "Created .openclaw workspace runtime structure.",
+                "Registered Pokemon Team Builder as a skill."
+            ]
+        ], to: rootURL.appendingPathComponent("state/tasks.json"))
+
+        writeJSON([
+            "stackName": config.stackName,
+            "role": config.role,
+            "goal": config.goal,
+            "route": routeSummary,
+            "updatedAt": ISO8601DateFormatter().string(from: .now)
+        ], to: rootURL.appendingPathComponent("state/session.json"))
+    }
+
+    private func regenerateCanonicalArtifactsIfMissing(config: StackConfig, preferences: UserPreferences, routeSummary: String) {
+        let generated = artifactContents(config: config, preferences: preferences, routeSummary: routeSummary)
+        for path in canonicalArtifactPaths {
+            let url = rootURL.appendingPathComponent(path)
+            if !fileManager.fileExists(atPath: url.path), let content = generated[path] {
+                try? content.write(to: url, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+
+    private func artifactContents(config: StackConfig, preferences: UserPreferences, routeSummary: String) -> [String: String] {
+        [
+            "soul.md": """
+            # soul.md
+
+            OpenClaw is one agent, one workspace, one sandbox, and one capability surface.
+
+            ## Operating posture
+            - Prefer confirmed runtime receipts over fluent claims.
+            - Treat local and cloud model adapters as callers of the same Workspace Runtime.
+            - Save durable work into inspectable artifacts.
+            - Say planned, unavailable, or failed when no receipt confirms completion.
+
+            ## Stack
+            - Name: \(config.stackName)
+            - Role: \(config.role.nilIfBlank ?? "operator")
+            - Goal: \(config.goal.nilIfBlank ?? "not set")
+            - Active route: \(routeSummary)
+            """,
+            "user.md": """
+            # user.md
+
+            ## Operator
+            - Preferred name: \(preferences.preferredName.nilIfBlank ?? config.operatorName.nilIfBlank ?? "not set")
+            - Role: \(config.role.nilIfBlank ?? "not set")
+            - Goal: \(config.goal.nilIfBlank ?? "not set")
+
+            ## Preferences
+            - Theme: \(preferences.theme.rawValue)
+            - Optimization: \(config.optimizationMode)
+            - Memory enabled: \(config.memoryEnabled ? "yes" : "no")
+            - Tools enabled: \(config.toolsEnabled ? "yes" : "no")
+            """,
+            "memory.md": """
+            # memory.md
+
+            ## Durable facts
+            - OpenClaw should feel like a real agent workspace, not a chat-only shell.
+            - Canonical artifacts live under `.openclaw/`.
+            - Pokemon Team Builder is a first-class skill and saves artifacts.
+            - Completion language must be receipt-aware.
+
+            ## Current project
+            - Stack: \(config.stackName)
+            - Runtime route: \(routeSummary)
+            """,
+            "session.md": """
+            # session.md
+
+            ## Current state
+            - Updated: \(ISO8601DateFormatter().string(from: .now))
+            - Active route: \(routeSummary)
+            - Registered skills: \(skills.count)
+            - Recent actions: \(recentActions.count)
+
+            ## Next useful moves
+            - Run Pokemon Team Builder from Skills and save a team artifact.
+            - Review Artifacts to inspect generated workspace files.
+            - Use the controlled sandbox commands for workspace reads/regeneration.
+            """,
+            "skills.md": """
+            # skills.md
+
+            \(skills.map { "- **\($0.name)** (`\($0.id)`): \($0.description)" }.joined(separator: "\n"))
+            """
+        ]
+    }
+
+    private func runPokemonTeamBuilder(input: [String: String], manifest: SkillManifest) -> OpenClawReceipt {
+        let action = begin(kind: .skillRun, source: "skill.\(manifest.id)", title: manifest.name, input: input)
+        let format = input["format"].nilIfBlank ?? "Singles"
+        let strategy = input["strategy"].nilIfBlank ?? "balanced offense"
+        let mustInclude = splitList(input["mustInclude"])
+        let avoid = Set(splitList(input["avoid"]).map { $0.lowercased() })
+        let candidates = ["Pikachu", "Charizard", "Venusaur", "Blastoise", "Gengar", "Dragonite", "Lucario", "Garchomp", "Rotom-Wash", "Corviknight", "Togekiss", "Snorlax"]
+        let roles = ["Lead / speed control", "Physical breaker", "Special attacker", "Defensive pivot", "Utility support", "Late-game cleaner"]
+        var selected: [String] = []
+        for name in mustInclude where !avoid.contains(name.lowercased()) {
+            if !selected.contains(name) { selected.append(name) }
+        }
+        for candidate in candidates where selected.count < 6 {
+            guard !avoid.contains(candidate.lowercased()), !selected.contains(candidate) else { continue }
+            selected.append(candidate)
+        }
+        let team = selected.prefix(6).enumerated().map { index, name in
+            PokemonTeamMember(name: name, role: roles[index % roles.count], notes: "\(format) pick for \(strategy).")
+        }
+        let weaknesses = [
+            "Validate exact legality, moves, items, and EVs against the target format before competitive use.",
+            "This MVP uses curated role coverage rather than a full damage calculator or matchup database."
+        ]
+        let suggestions = [
+            "Add exact movesets after choosing the battle format.",
+            "Run a future simulator-backed pass for type chart and usage data."
+        ]
+        let output = PokemonTeamOutput(
+            teamMembers: Array(team),
+            roleBreakdown: team.map { "\($0.name): \($0.role)" },
+            summary: "Drafted a \(format) team around \(strategy).",
+            weaknesses: weaknesses,
+            suggestions: suggestions,
+            artifactPath: nil
+        )
+
+        do {
+            let slug = safeSlug([format, strategy, String(Int(Date().timeIntervalSince1970))].joined(separator: "-"))
+            let jsonPath = "skills/pokemon-team-builder/teams/\(slug).json"
+            let mdPath = "skills/pokemon-team-builder/teams/\(slug).md"
+            var saved = output
+            saved.artifactPath = mdPath
+            let jsonData = try encoder.encode(saved)
+            try jsonData.write(to: resolve(jsonPath), options: [.atomic])
+            try pokemonMarkdown(output: saved, format: format, strategy: strategy).write(to: resolve(mdPath), atomically: true, encoding: .utf8)
+            appendEvent(type: "skill.completed", message: "Pokemon Team Builder saved \(mdPath).", metadata: ["skillId": manifest.id, "artifact": mdPath])
+            refreshMetadata()
+            return finish(
+                action,
+                status: .persisted,
+                summary: "Pokemon team drafted and saved",
+                output: ["summary": saved.summary, "members": saved.teamMembers.map(\.name).joined(separator: ", ")],
+                artifacts: [jsonPath, mdPath]
+            )
+        } catch {
+            return finish(action, status: .failed, summary: "Pokemon team draft failed to save", error: error.localizedDescription)
+        }
+    }
+
+    private func runMemoryInspector(manifest: SkillManifest) -> OpenClawReceipt {
+        let action = begin(kind: .skillRun, source: "skill.\(manifest.id)", title: manifest.name, input: [:])
+        let paths = ["state/facts.json", "state/preferences.json", "state/session.json"]
+        let body = paths.compactMap { path -> String? in
+            guard let value = try? readFile(path) else { return nil }
+            return "## \(path)\n\(value)"
+        }.joined(separator: "\n\n")
+        return finish(action, status: .completed, summary: "Read memory stores", output: ["summary": body], artifacts: paths)
+    }
+
+    private func pokemonMarkdown(output: PokemonTeamOutput, format: String, strategy: String) -> String {
+        """
+        # Pokemon Team
+
+        - Format: \(format)
+        - Strategy: \(strategy)
+        - Receipt-backed: yes
+
+        ## Team
+        \(output.teamMembers.map { "- **\($0.name)** - \($0.role): \($0.notes)" }.joined(separator: "\n"))
+
+        ## Summary
+        \(output.summary)
+
+        ## Weaknesses
+        \(output.weaknesses.map { "- \($0)" }.joined(separator: "\n"))
+
+        ## Suggestions
+        \(output.suggestions.map { "- \($0)" }.joined(separator: "\n"))
+        """
+    }
+
+    private func begin(kind: OpenClawActionKind, source: String, title: String, input: [String: String]) -> OpenClawActionRecord {
+        let action = OpenClawActionRecord(id: UUID(), kind: kind, source: source, title: title, status: .queued, createdAt: .now, updatedAt: .now, input: input, output: [:], error: nil, artifacts: [], logs: [])
+        persistAction(action)
+        var running = action
+        running.status = .running
+        running.updatedAt = .now
+        upsertRecent(running)
+        persistAction(running)
+        return running
+    }
+
+    private func finish(_ action: OpenClawActionRecord, status: OpenClawActionStatus, summary: String, output: [String: String] = [:], artifacts: [String] = [], logs: [String] = [], error: String? = nil) -> OpenClawReceipt {
+        var finished = action
+        finished.status = status
+        finished.updatedAt = .now
+        finished.output = output.merging(["summary": summary]) { current, _ in current }
+        finished.artifacts = artifacts
+        finished.logs = logs
+        finished.error = error
+        upsertRecent(finished)
+        persistAction(finished)
+        if let error {
+            appendEvent(type: "action.failed", message: error, metadata: ["actionId": action.id.uuidString])
+        } else {
+            appendEvent(type: "action.\(status.rawValue)", message: summary, metadata: ["actionId": action.id.uuidString])
+        }
+        refreshMetadata()
+        return OpenClawReceipt(actionId: action.id, status: status, title: action.title, summary: summary, output: output, artifacts: artifacts, logs: logs, error: error)
+    }
+
+    private func upsertRecent(_ action: OpenClawActionRecord) {
+        recentActions.removeAll { $0.id == action.id }
+        recentActions.insert(action, at: 0)
+        recentActions = Array(recentActions.prefix(30))
+    }
+
+    private func persistAction(_ action: OpenClawActionRecord) {
+        appendJSONLine(action, to: rootURL.appendingPathComponent("actions.jsonl"))
+        let line = "[\(action.status.rawValue)] \(action.title) \(action.error ?? action.output["summary"] ?? "")\n"
+        appendText(line, to: rootURL.appendingPathComponent("logs/latest-actions.log"))
+    }
+
+    private func appendEvent(type: String, message: String, metadata: [String: String] = [:]) {
+        let event = OpenClawEventRecord(type: type, message: message, metadata: metadata)
+        recentEvents.insert(event, at: 0)
+        recentEvents = Array(recentEvents.prefix(30))
+        appendJSONLine(event, to: rootURL.appendingPathComponent("events.jsonl"))
+    }
+
+    private func appendJSONLine<T: Encodable>(_ value: T, to url: URL) {
+        guard let data = try? encoder.encode(value), let line = String(data: data, encoding: .utf8)?.replacingOccurrences(of: "\n", with: "") else { return }
+        appendText(line + "\n", to: url)
+    }
+
+    private func appendText(_ value: String, to url: URL) {
+        if !fileManager.fileExists(atPath: url.path) {
+            fileManager.createFile(atPath: url.path, contents: nil)
+        }
+        guard let handle = try? FileHandle(forWritingTo: url) else { return }
+        defer { try? handle.close() }
+        try? handle.seekToEnd()
+        if let data = value.data(using: .utf8) {
+            handle.write(data)
+        }
+    }
+
+    private func writeJSON<T: Encodable>(_ value: T, to url: URL) {
+        try? fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if let data = try? encoder.encode(value) {
+            try? data.write(to: url, options: [.atomic])
+        }
+    }
+
+    private func resolve(_ path: String) throws -> URL {
+        let cleaned = path.replacingOccurrences(of: "\\", with: "/").trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !cleaned.isEmpty else { return rootURL }
+        let components = cleaned.split(separator: "/").map(String.init)
+        guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+            throw NSError(domain: "OpenClawWorkspaceRuntime", code: 400, userInfo: [NSLocalizedDescriptionKey: "Unsafe workspace path: \(path)"])
+        }
+        let url = components.reduce(rootURL) { $0.appendingPathComponent($1) }
+        let standardizedRoot = rootURL.standardizedFileURL.path
+        let standardizedPath = url.standardizedFileURL.path
+        guard standardizedPath == standardizedRoot || standardizedPath.hasPrefix(standardizedRoot + "/") else {
+            throw NSError(domain: "OpenClawWorkspaceRuntime", code: 401, userInfo: [NSLocalizedDescriptionKey: "Path escapes .openclaw workspace: \(path)"])
+        }
+        return url
+    }
+
+    private func relativePath(for url: URL) -> String {
+        let root = rootURL.standardizedFileURL.path
+        let path = url.standardizedFileURL.path
+        return path.hasPrefix(root + "/") ? String(path.dropFirst(root.count + 1)) : url.lastPathComponent
+    }
+
+    private func listArtifactMetadata() -> [OpenClawArtifactMetadata] {
+        let allPaths = Set(canonicalArtifactPaths + listFiles())
+        return allPaths.sorted().map { path in
+            let url = rootURL.appendingPathComponent(path)
+            let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            let exists = fileManager.fileExists(atPath: url.path)
+            return OpenClawArtifactMetadata(
+                path: path,
+                kind: path.pathExtensionKind,
+                updatedAt: values?.contentModificationDate,
+                size: values?.fileSize ?? 0,
+                freshness: exists ? .fresh : .missing
+            )
+        }
+    }
+
+    private func loadRecentActions() -> [OpenClawActionRecord] {
+        let url = rootURL.appendingPathComponent("actions.jsonl")
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return recentActions }
+        var latest: [UUID: OpenClawActionRecord] = [:]
+        for line in text.split(separator: "\n").suffix(120) {
+            if let data = String(line).data(using: .utf8), let action = try? decoder.decode(OpenClawActionRecord.self, from: data) {
+                latest[action.id] = action
+            }
+        }
+        return latest.values.sorted { $0.updatedAt > $1.updatedAt }.prefix(30).map { $0 }
+    }
+
+    private func loadRecentEvents() -> [OpenClawEventRecord] {
+        let url = rootURL.appendingPathComponent("events.jsonl")
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return recentEvents }
+        return text.split(separator: "\n").suffix(30).compactMap { line in
+            guard let data = String(line).data(using: .utf8) else { return nil }
+            return try? decoder.decode(OpenClawEventRecord.self, from: data)
+        }.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    private func splitList(_ value: String?) -> [String] {
+        (value ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func safeSlug(_ value: String) -> String {
+        value.lowercased().map { character in
+            character.isLetter || character.isNumber ? character : "-"
+        }.reduce("") { partial, character in
+            if character == "-", partial.last == "-" { return partial }
+            return partial + String(character)
+        }.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}
+
+struct BuddyRuntimeStatus {
+    var activeModelAdapter: String
+    var brainConnected: Bool
+    var runtimeAvailable: Bool
+    var memoryHealthy: Bool
+    var artifacts: [OpenClawArtifactMetadata]
+    var registeredSkillCount: Int
+    var recentChanges: [OpenClawEventRecord]
+    var failedActions: [OpenClawActionRecord]
+    var suggestedNextActions: [String]
+}
+
+private extension String? {
+    var nilIfBlank: String? {
+        guard let value = self?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    var pathExtensionKind: String {
+        let ext = URL(fileURLWithPath: self).pathExtension.lowercased()
+        if ext == "md" { return "markdown" }
+        if ext == "json" { return "json" }
+        if ext == "jsonl" { return "log" }
+        return ext.isEmpty ? "file" : ext
+    }
+}

--- a/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
@@ -42,6 +42,12 @@ enum Paths {
         return folder
     }
 
+    static var openClawDirectory: URL {
+        let folder = workspaceDirectory.appendingPathComponent(".openclaw", isDirectory: true)
+        ensureDirectoryExists(folder)
+        return folder
+    }
+
     static var stateDirectory: URL {
         let folder = applicationSupportDirectory.appendingPathComponent("State", isDirectory: true)
         ensureDirectoryExists(folder)
@@ -749,7 +755,7 @@ enum CloudPromptBuilder {
         let name = operatorName.trimmingCharacters(in: .whitespacesAndNewlines)
         let displayName = name.isEmpty ? "the operator" : name
         let toolPosture = config.toolsEnabled
-            ? "The operator intends to use tool-capable OpenClaw routes when the Gateway exposes them."
+            ? "The operator intends to use tool-capable OpenClaw routes through the built-in Workspace Runtime as capabilities become available."
             : "The operator has not enabled tool-capable behavior for this stack profile."
 
         return """
@@ -759,11 +765,11 @@ enum CloudPromptBuilder {
 
         Current route: \(routeLabel).
         Stack name: \(config.stackName).
-        Gateway target: \(config.gatewayURL).
+        Runtime endpoint: \(config.gatewayURL).
         Admin/public domain: \(config.adminDomain).
         \(toolPosture)
 
-        Be honest about capabilities. This direct cloud chat route can reason and use attached file context, but it does not by itself grant direct device control, shell execution, or OpenClaw Gateway tools. If an action requires the Gateway, desktop node, or a tool bridge, say exactly what route is needed instead of refusing as though the request is app-only.
+        Be honest about capabilities. This direct cloud chat route can reason and use attached file context. Real filesystem, memory, skill, and sandbox changes must go through OpenClaw Workspace Runtime receipts. If a capability is unavailable in this iOS runtime, say unavailable or failed instead of claiming completion.
         """
     }
 }
@@ -1091,6 +1097,7 @@ final class AppState: ObservableObject {
     @Published var providerModels: [ProviderKind: [CloudModel]] = [:]
     @Published var providerModelLoading = Set<ProviderKind>()
     @Published var providerModelErrors: [ProviderKind: String] = [:]
+    @Published var workspaceRuntime = OpenClawWorkspaceRuntime()
 
     // MARK: Initializer – now placed after property declarations
     init(engine: LocalLLMEngine) {
@@ -1143,7 +1150,7 @@ final class AppState: ObservableObject {
 
     var operatorSummary: String {
         if let account = selectedProviderAccount {
-            return "Chat is routed directly through \(account.provider.displayName) using \(account.modelSlug). Gateway tools still require a real OpenClaw bridge at \(stackConfig.gatewayURL)."
+            return "Chat is routed through \(account.provider.displayName) using \(account.modelSlug). Workspace actions use the built-in OpenClaw runtime and receipts."
         } else if let model = selectedInstalledModel {
             if usesStubRuntime {
                 return "\(model.displayName) is selected, but local inference is unavailable in this build."
@@ -1151,8 +1158,8 @@ final class AppState: ObservableObject {
             return "Selected runtime target: \(model.modelID.isEmpty ? model.localFilename : model.modelID)."
         } else if usesStubRuntime {
             return stackConfig.deploymentMode == .bootstrapSelfHosted
-                ? "Stack profile is configured, but real chat still depends on a linked provider or a working on-device runtime bridge."
-                : "Pair the app to a real Gateway or link a provider before claiming the shell is ready."
+                ? "Stack profile is configured, but real chat still depends on a linked provider or a working on-device inference runtime."
+                : "Link a provider or local runtime before claiming the shell is ready."
         } else if engine.requiresModelSelection {
             return "Runtime bridge is present, but no packaged model is selected yet."
         } else {
@@ -1195,12 +1202,12 @@ final class AppState: ObservableObject {
             let target = model.modelID.isEmpty ? model.localFilename : model.modelID
             return usesStubRuntime ? "\(target) selected, but local inference is not live in this build." : target
         }
-        return "Gateway target: \(stackConfig.gatewayURL). Select a live route in Models before using chat as if the stack is online."
+        return "Runtime endpoint: \(stackConfig.gatewayURL). Select a live route in Models before using chat as if the stack is online."
     }
 
     var routeHealthSummary: String {
         if selectedProviderAccount != nil {
-            return "Direct cloud chat is ready. OpenClaw tools require a Gateway/tool bridge."
+            return "Cloud chat is ready. Workspace actions require OpenClaw runtime receipts."
         }
         if let model = selectedInstalledModel {
             return usesStubRuntime
@@ -1239,6 +1246,7 @@ final class AppState: ObservableObject {
         runtimePreferences.load()
         tabPreferencesStore.load()
         userPreferencesStore.load()
+        workspaceRuntime.bootstrap(config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
         refreshGemmaState()
         refreshRuntimeSummary()
         for account in providerStore.enabledProviders() {
@@ -1263,6 +1271,7 @@ final class AppState: ObservableObject {
             userPreferencesStore.updatePreferredName(config.operatorName)
         }
         persistStackConfig()
+        workspaceRuntime.bootstrap(config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
         buddyProfileStore?.load(for: config)
         refreshRuntimeSummary()
     }
@@ -1354,10 +1363,12 @@ final class AppState: ObservableObject {
 
     func updatePreferredOperatorName(_ value: String) {
         userPreferencesStore.updatePreferredName(value)
+        workspaceRuntime.bootstrap(config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
     }
 
     func updateTheme(_ theme: AppColorTheme) {
         userPreferencesStore.updateTheme(theme)
+        workspaceRuntime.bootstrap(config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
     }
 
     func setTabVisibility(_ tab: AppTab, isVisible: Bool) {
@@ -1490,6 +1501,7 @@ final class AppState: ObservableObject {
         }
 
         chatStore.messages.append(ChatMessage(role: .user, content: cleaned))
+        workspaceRuntime.refreshMetadata()
         chatStore.persist()
         chatStore.isGenerating = true
 
@@ -1508,6 +1520,7 @@ final class AppState: ObservableObject {
                 reply = try await engine.generate(prompt: cleaned, fileContexts: attachedFiles, chatHistory: chatStore.messages)
             }
             chatStore.messages.append(ChatMessage(role: .assistant, content: reply))
+            workspaceRuntime.refreshMetadata()
             chatStore.persist()
         } catch CloudExecutionServiceError.upstreamFailure(let message) {
             chatStore.errorMessage = message
@@ -1518,6 +1531,35 @@ final class AppState: ObservableObject {
         refreshRuntimeSummary()
 
         chatStore.isGenerating = false
+    }
+
+    func runSkill(id: String, input: [String: String] = [:]) -> OpenClawReceipt {
+        let receipt = workspaceRuntime.runSkill(id: id, input: input, config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
+        chatStore.messages.append(ChatMessage(role: .system, content: ReceiptFormatter.confirmedSummary(for: receipt)))
+        chatStore.persist()
+        return receipt
+    }
+
+    func regenerateArtifacts(target: String = "all") -> OpenClawReceipt {
+        let receipt = workspaceRuntime.regenerateArtifacts(target: target, config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
+        chatStore.messages.append(ChatMessage(role: .system, content: ReceiptFormatter.confirmedSummary(for: receipt)))
+        chatStore.persist()
+        return receipt
+    }
+
+    func runSandbox(command: String) -> OpenClawReceipt {
+        let receipt = workspaceRuntime.runSandbox(command: command, config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
+        chatStore.messages.append(ChatMessage(role: .system, content: ReceiptFormatter.confirmedSummary(for: receipt)))
+        chatStore.persist()
+        return receipt
+    }
+
+    var buddyRuntimeStatus: BuddyRuntimeStatus {
+        workspaceRuntime.buddyStatus(
+            activeModelAdapter: backendDisplayName,
+            brainConnected: selectedProviderAccount != nil || canUseSelectedLocalModel,
+            runtimeAvailable: workspaceRuntime.isBootstrapped,
+        )
     }
 
     // MARK: - Private
@@ -1547,7 +1589,7 @@ final class AppState: ObservableObject {
                     config: stackConfig,
                     operatorName: operatorDisplayName,
                     routeLabel: routeLabel
-                )
+                ) + "\n\nWorkspace Runtime: Available inside OpenClaw. Ask for actions through the runtime contract; do not claim files, memory, skills, or sandbox commands changed unless an OpenClaw receipt confirms it. Registered skills: \(workspaceRuntime.skills.map(\.name).joined(separator: ", ")). Canonical artifacts: soul.md, user.md, memory.md, session.md, skills.md."
             )
         ]
 
@@ -1574,10 +1616,10 @@ final class AppState: ObservableObject {
     private func generatedSetupChecklist(for config: StackConfig) -> [String] {
         var items: [String] = []
         if config.deploymentMode == .bootstrapSelfHosted {
-            items.append("Provision or verify an OpenClaw Gateway at \(config.gatewayURL).")
-            items.append("Set gateway.remote.url and pairing/public URL values to match \(config.adminDomain).")
+            items.append("Provision or verify the OpenClaw runtime endpoint at \(config.gatewayURL).")
+            items.append("Set runtime and pairing/public URL values to match \(config.adminDomain).")
         } else {
-            items.append("Pair this app to the existing Gateway at \(config.gatewayURL).")
+            items.append("Pair this app to the existing OpenClaw runtime endpoint at \(config.gatewayURL).")
         }
         if config.installNodeOnThisPhone {
             items.append("Treat this iPhone as a node surface and grant notification or device permissions as needed.")

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ArtifactsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ArtifactsView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+struct ArtifactsView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var selectedArtifact: OpenClawArtifactMetadata?
+    @State private var lastReceipt: OpenClawReceipt?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
+                    header
+                    if let lastReceipt {
+                        ActionReceiptCard(receipt: lastReceipt)
+                    }
+                    ForEach(appState.workspaceRuntime.artifacts) { artifact in
+                        Button {
+                            selectedArtifact = artifact
+                        } label: {
+                            artifactRow(artifact)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, BMOTheme.spacingMD)
+                .padding(.bottom, BMOTheme.spacingXL)
+            }
+            .background(BMOTheme.backgroundPrimary)
+            .navigationTitle("")
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Artifacts")
+                        .font(.headline)
+                        .foregroundColor(BMOTheme.textPrimary)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        lastReceipt = appState.regenerateArtifacts(target: "all")
+                    } label: {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                            .foregroundColor(BMOTheme.accent)
+                    }
+                }
+            }
+            .toolbarBackground(BMOTheme.backgroundPrimary, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .onAppear { appState.workspaceRuntime.refreshMetadata() }
+            .navigationDestination(item: $selectedArtifact) { artifact in
+                ArtifactPreviewView(artifact: artifact)
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(".openclaw")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundColor(BMOTheme.textPrimary)
+                Spacer()
+                StatusBadge(label: "\(appState.workspaceRuntime.artifacts.count) files", color: BMOTheme.accent)
+            }
+            Text("Canonical files, state stores, action receipts, event logs, registry data, and saved skill outputs live here.")
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+        }
+        .bmoCard()
+    }
+
+    private func artifactRow(_ artifact: OpenClawArtifactMetadata) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: artifact.kind == "markdown" ? "doc.text.fill" : "curlybraces.square.fill")
+                .foregroundColor(BMOTheme.accent)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(artifact.path)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(BMOTheme.textPrimary)
+                Text("\(artifact.kind) • \(artifact.size) bytes")
+                    .font(.caption)
+                    .foregroundColor(BMOTheme.textTertiary)
+                if let updatedAt = artifact.updatedAt {
+                    Text(updatedAt, style: .relative)
+                        .font(.caption2)
+                        .foregroundColor(BMOTheme.textTertiary)
+                }
+            }
+
+            Spacer()
+            StatusBadge(label: artifact.freshness.rawValue.capitalized, color: artifact.freshness == .missing ? BMOTheme.error : BMOTheme.success)
+        }
+        .bmoCard()
+    }
+}
+
+struct ArtifactPreviewView: View {
+    @EnvironmentObject private var appState: AppState
+    let artifact: OpenClawArtifactMetadata
+    @State private var content = ""
+    @State private var error: String?
+    @State private var receipt: OpenClawReceipt?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
+                header
+                if let receipt {
+                    ActionReceiptCard(receipt: receipt)
+                }
+                if let error {
+                    Text(error)
+                        .font(.subheadline)
+                        .foregroundColor(BMOTheme.error)
+                        .bmoCard()
+                } else {
+                    Text(content.isEmpty ? "Empty artifact." : content)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundColor(BMOTheme.textPrimary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .bmoCard()
+                }
+            }
+            .padding(.horizontal, BMOTheme.spacingMD)
+            .padding(.bottom, BMOTheme.spacingXL)
+        }
+        .background(BMOTheme.backgroundPrimary)
+        .navigationTitle(artifact.path)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                if ["soul.md", "user.md", "memory.md", "session.md", "skills.md"].contains(artifact.path) {
+                    Button("Regenerate") {
+                        receipt = appState.regenerateArtifacts(target: artifact.path)
+                        load()
+                    }
+                    .foregroundColor(BMOTheme.accent)
+                }
+            }
+        }
+        .onAppear(perform: load)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(artifact.path)
+                .font(.headline)
+                .foregroundColor(BMOTheme.textPrimary)
+            Text("Preview is read from the persisted `.openclaw` artifact.")
+                .font(.caption)
+                .foregroundColor(BMOTheme.textTertiary)
+        }
+        .bmoCard()
+    }
+
+    private func load() {
+        do {
+            content = try appState.workspaceRuntime.readFile(artifact.path)
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
@@ -473,6 +473,8 @@ struct BuddyView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: BMOTheme.spacingMD) {
+                    systemStatusCard
+                    recentRuntimeCard
                     if let buddy = store.activeBuddy {
                         header(for: buddy)
                         sourceProfileCard(for: buddy)
@@ -575,6 +577,65 @@ struct BuddyView: View {
                 renameTarget = buddy
             }
             .buttonStyle(.bordered)
+        }
+        .bmoCard()
+    }
+
+    private var systemStatusCard: some View {
+        let status = appState.buddyRuntimeStatus
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("OpenClaw Buddy")
+                        .font(.system(size: 28, weight: .bold))
+                        .foregroundColor(BMOTheme.textPrimary)
+                    Text("Grounded in runtime, memory, artifacts, and receipts.")
+                        .font(.subheadline)
+                        .foregroundColor(BMOTheme.textSecondary)
+                }
+                Spacer()
+                StatusBadge(label: status.runtimeAvailable ? "Runtime Ready" : "Runtime Missing", color: status.runtimeAvailable ? BMOTheme.success : BMOTheme.error)
+            }
+
+            statusRow("Model adapter", value: status.activeModelAdapter, ok: status.brainConnected)
+            statusRow("Workspace runtime", value: status.runtimeAvailable ? "Bootstrapped" : "Not bootstrapped", ok: status.runtimeAvailable)
+            statusRow("Memory artifacts", value: status.memoryHealthy ? "Healthy" : "Needs regeneration", ok: status.memoryHealthy)
+            statusRow("Registered skills", value: "\(status.registeredSkillCount)", ok: status.registeredSkillCount > 0)
+            statusRow("Failed actions", value: "\(status.failedActions.count)", ok: status.failedActions.isEmpty)
+        }
+        .bmoCard()
+    }
+
+    private var recentRuntimeCard: some View {
+        let status = appState.buddyRuntimeStatus
+        return VStack(alignment: .leading, spacing: 12) {
+            Text("Suggested next actions")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundColor(BMOTheme.textSecondary)
+
+            ForEach(status.suggestedNextActions, id: \.self) { action in
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "arrow.right.circle.fill")
+                        .foregroundColor(BMOTheme.accent)
+                    Text(action)
+                        .font(.caption)
+                        .foregroundColor(BMOTheme.textPrimary)
+                    Spacer()
+                }
+            }
+
+            if !status.recentChanges.isEmpty {
+                Divider().overlay(BMOTheme.divider)
+                Text("Recent changes")
+                    .font(.caption)
+                    .foregroundColor(BMOTheme.textTertiary)
+                ForEach(status.recentChanges.prefix(3), id: \.id) { event in
+                    Text(event.message)
+                        .font(.caption)
+                        .foregroundColor(BMOTheme.textSecondary)
+                }
+            }
         }
         .bmoCard()
     }
@@ -821,6 +882,23 @@ struct BuddyView: View {
             Spacer()
             Text(value.isEmpty ? "—" : value)
                 .foregroundColor(BMOTheme.textPrimary)
+        }
+        .font(.caption)
+    }
+
+    private func statusRow(_ label: String, value: String, ok: Bool) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .foregroundColor(BMOTheme.textTertiary)
+            Spacer()
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(ok ? BMOTheme.success : BMOTheme.warning)
+                    .frame(width: 7, height: 7)
+                Text(value.isEmpty ? "Unavailable" : value)
+                    .multilineTextAlignment(.trailing)
+                    .foregroundColor(BMOTheme.textPrimary)
+            }
         }
         .font(.caption)
     }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
@@ -16,6 +16,10 @@ struct ChatView: View {
                                     .id(message.id)
                             }
 
+                            ForEach(appState.workspaceRuntime.recentActions.prefix(3)) { action in
+                                ActionRecordCard(action: action)
+                            }
+
                             if appState.chatStore.isGenerating {
                                 HStack(spacing: 8) {
                                     ProgressView()
@@ -78,6 +82,9 @@ struct ChatView: View {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text(appState.chatStore.errorMessage ?? "Unknown error")
+            }
+            .onAppear {
+                appState.workspaceRuntime.refreshMetadata()
             }
         }
     }
@@ -171,6 +178,35 @@ struct ChatView: View {
             return appState.usesStubRuntime ? "Local model selected, runtime not included in this build" : "On-device model • \(model.displayName)"
         }
         return "Route not configured. Link a cloud provider to chat in this build."
+    }
+}
+
+private struct ActionRecordCard: View {
+    let action: OpenClawActionRecord
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(action.title)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(BMOTheme.textPrimary)
+                    Spacer()
+                    StatusBadge(label: action.status.label, color: action.status.color)
+                }
+                Text(action.output["summary"] ?? action.error ?? action.kind.rawValue)
+                    .font(.caption)
+                    .foregroundColor(BMOTheme.textSecondary)
+                if !action.artifacts.isEmpty {
+                    Text(action.artifacts.joined(separator: ", "))
+                        .font(.caption2)
+                        .foregroundColor(BMOTheme.accent)
+                }
+            }
+            Spacer(minLength: 32)
+        }
+        .bmoCard()
     }
 }
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/HomeView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/HomeView.swift
@@ -88,7 +88,7 @@ struct HomeView: View {
                 }
 
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(appState.stackConfig.deploymentMode == .bootstrapSelfHosted ? "Self-hosted OpenClaw stack" : "Gateway pairing shell")
+                    Text(appState.stackConfig.deploymentMode == .bootstrapSelfHosted ? "Self-hosted OpenClaw stack" : "Runtime pairing shell")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
                     Text(appState.operatorDisplayName)
@@ -105,7 +105,7 @@ struct HomeView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                infoLine(title: "Gateway", value: appState.stackConfig.gatewayURL)
+                infoLine(title: "Runtime", value: appState.stackConfig.gatewayURL)
                 infoLine(title: "Goal", value: appState.stackConfig.goal)
                 infoLine(title: "Role", value: appState.stackConfig.role)
             }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
@@ -66,7 +66,7 @@ struct MissionControlView: View {
                 .foregroundColor(BMOTheme.textSecondary)
 
             detailRow("Mode", value: appState.stackConfig.deploymentMode.title)
-            detailRow("Gateway", value: appState.stackConfig.gatewayURL)
+            detailRow("Runtime endpoint", value: appState.stackConfig.gatewayURL)
             detailRow("Role", value: appState.stackConfig.role)
             detailRow("Goal", value: appState.stackConfig.goal)
             detailRow("Node on iPhone", value: appState.stackConfig.installNodeOnThisPhone ? "Expected" : "Not expected")

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ModelsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ModelsView.swift
@@ -368,7 +368,7 @@ struct ModelsView: View {
                 .fontWeight(.semibold)
                 .foregroundColor(BMOTheme.textSecondary)
 
-            Text("Choose the active direct cloud model route here. OpenClaw Gateway tools require a separate stack bridge.")
+            Text("Choose the active model route here. Workspace actions run through OpenClaw runtime receipts, not unconfirmed model claims.")
                 .font(.caption)
                 .foregroundColor(BMOTheme.textTertiary)
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
@@ -1,0 +1,265 @@
+import SwiftUI
+
+struct SkillsView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var lastReceipt: OpenClawReceipt?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
+                    headerCard
+
+                    if let lastReceipt {
+                        ActionReceiptCard(receipt: lastReceipt)
+                    }
+
+                    ForEach(appState.workspaceRuntime.skills) { skill in
+                        skillCard(skill)
+                    }
+                }
+                .padding(.horizontal, BMOTheme.spacingMD)
+                .padding(.bottom, BMOTheme.spacingXL)
+            }
+            .background(BMOTheme.backgroundPrimary)
+            .navigationTitle("")
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Skills")
+                        .font(.headline)
+                        .foregroundColor(BMOTheme.textPrimary)
+                }
+            }
+            .toolbarBackground(BMOTheme.backgroundPrimary, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .onAppear { appState.workspaceRuntime.refreshMetadata() }
+        }
+    }
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("OpenClaw Skills")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundColor(BMOTheme.textPrimary)
+                Spacer()
+                StatusBadge(label: "\(appState.workspaceRuntime.skills.count) registered", color: BMOTheme.accent)
+            }
+            Text("Skills are loaded from `.openclaw/registry/skills.json` and run through the same receipt-backed Workspace Runtime used by local and cloud routes.")
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+        }
+        .bmoCard()
+    }
+
+    private func skillCard(_ skill: SkillManifest) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: skill.ui.systemImage)
+                    .font(.title3)
+                    .foregroundColor(BMOTheme.accent)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(skill.name)
+                            .font(.headline)
+                            .foregroundColor(BMOTheme.textPrimary)
+                        Spacer()
+                        StatusBadge(label: skill.enabled ? "Enabled" : "Disabled", color: skill.enabled ? BMOTheme.success : BMOTheme.warning)
+                    }
+                    Text(skill.description)
+                        .font(.subheadline)
+                        .foregroundColor(BMOTheme.textSecondary)
+                    Text("\(skill.category) • \(skill.tags.joined(separator: ", "))")
+                        .font(.caption)
+                        .foregroundColor(BMOTheme.textTertiary)
+                }
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(skill.permissions, id: \.self) { permission in
+                        Text(permission)
+                            .font(.caption2)
+                            .foregroundColor(BMOTheme.accent)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(BMOTheme.accent.opacity(0.12))
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+
+            if skill.id == BuiltInSkillRegistry.pokemonTeamBuilderID {
+                NavigationLink {
+                    PokemonTeamBuilderView()
+                } label: {
+                    HStack {
+                        Image(systemName: "arrow.right.circle.fill")
+                        Text("Launch Team Builder")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(BMOButtonStyle())
+            } else {
+                Button {
+                    let input = skill.id == BuiltInSkillRegistry.artifactRebuilderID ? ["target": "all"] : [:]
+                    lastReceipt = appState.runSkill(id: skill.id, input: input)
+                } label: {
+                    HStack {
+                        Image(systemName: "play.fill")
+                        Text("Run Skill")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+            }
+        }
+        .bmoCard()
+    }
+}
+
+struct PokemonTeamBuilderView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var format = "Singles"
+    @State private var strategy = "balanced offense"
+    @State private var mustInclude = "Pikachu"
+    @State private var avoid = ""
+    @State private var receipt: OpenClawReceipt?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
+                header
+                formCard
+                if let receipt {
+                    ActionReceiptCard(receipt: receipt)
+                    if let members = receipt.output["members"] {
+                        analysisCard(members: members)
+                    }
+                }
+            }
+            .padding(.horizontal, BMOTheme.spacingMD)
+            .padding(.bottom, BMOTheme.spacingXL)
+        }
+        .background(BMOTheme.backgroundPrimary)
+        .navigationTitle("Pokemon Team Builder")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Flagship Skill")
+                .font(.caption)
+                .foregroundColor(BMOTheme.textTertiary)
+            Text("Draft a team, save artifacts, get a receipt.")
+                .font(.title2)
+                .fontWeight(.bold)
+                .foregroundColor(BMOTheme.textPrimary)
+            Text("This MVP uses curated role coverage. Exact legality, moves, EVs, and simulator-backed matchup data are still TODOs.")
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+        }
+        .bmoCard()
+    }
+
+    private var formCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Picker("Format", selection: $format) {
+                Text("Singles").tag("Singles")
+                Text("Doubles").tag("Doubles")
+                Text("Story Run").tag("Story Run")
+                Text("Draft League").tag("Draft League")
+            }
+            .pickerStyle(.segmented)
+
+            labeledField("Strategy / theme", text: $strategy, placeholder: "rain balance, cute chaos, bulky offense")
+            labeledField("Must include", text: $mustInclude, placeholder: "Pikachu, Gengar")
+            labeledField("Avoid", text: $avoid, placeholder: "Legendaries, Charizard")
+
+            Button {
+                receipt = appState.runSkill(
+                    id: BuiltInSkillRegistry.pokemonTeamBuilderID,
+                    input: [
+                        "format": format,
+                        "strategy": strategy,
+                        "mustInclude": mustInclude,
+                        "avoid": avoid
+                    ]
+                )
+            } label: {
+                HStack {
+                    Image(systemName: "square.and.arrow.down.fill")
+                    Text("Generate and Save Team")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(BMOButtonStyle())
+        }
+        .bmoCard()
+    }
+
+    private func analysisCard(members: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Saved roster")
+                .font(.headline)
+                .foregroundColor(BMOTheme.textPrimary)
+            Text(members)
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+            Text("Open Artifacts to inspect the saved JSON and Markdown team files.")
+                .font(.caption)
+                .foregroundColor(BMOTheme.textTertiary)
+        }
+        .bmoCard()
+    }
+
+    private func labeledField(_ title: String, text: Binding<String>, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(BMOTheme.textTertiary)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .foregroundColor(BMOTheme.textPrimary)
+                .padding(12)
+                .background(BMOTheme.backgroundSecondary)
+                .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusSmall, style: .continuous))
+        }
+    }
+}
+
+struct ActionReceiptCard: View {
+    let receipt: OpenClawReceipt
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(receipt.title)
+                    .font(.headline)
+                    .foregroundColor(BMOTheme.textPrimary)
+                Spacer()
+                StatusBadge(label: receipt.status.label, color: receipt.status.color)
+            }
+
+            Text(ReceiptFormatter.confirmedSummary(for: receipt))
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+
+            if !receipt.artifacts.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Artifacts")
+                        .font(.caption)
+                        .foregroundColor(BMOTheme.textTertiary)
+                    ForEach(receipt.artifacts, id: \.self) { artifact in
+                        Text(artifact)
+                            .font(.caption)
+                            .foregroundColor(BMOTheme.accent)
+                    }
+                }
+            }
+        }
+        .bmoCard()
+    }
+}

--- a/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
+++ b/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
@@ -119,6 +119,59 @@ final class AppStateRuntimeTests: XCTestCase {
         XCTAssertTrue(prompt.contains("does not by itself grant direct device control"))
         XCTAssertFalse(prompt.contains("only perform functions inside the app"))
     }
+
+    func testWorkspaceBootstrapCreatesCanonicalOpenClawArtifacts() throws {
+        let runtime = OpenClawWorkspaceRuntime()
+        var config = StackConfig.default
+        config.stackName = "OpenClaw"
+        config.role = "operator"
+        config.goal = "build a real workspace"
+
+        runtime.bootstrap(config: config, preferences: .default, routeSummary: "Route not configured")
+
+        for path in ["soul.md", "user.md", "memory.md", "session.md", "skills.md", "registry/skills.json", "state/facts.json", "state/preferences.json", "state/tasks.json", "state/session.json"] {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: Paths.openClawDirectory.appendingPathComponent(path).path), path)
+        }
+
+        let soul = try runtime.readFile("soul.md")
+        XCTAssertTrue(soul.contains("one agent, one workspace"))
+        XCTAssertTrue(runtime.skills.contains(where: { $0.id == BuiltInSkillRegistry.pokemonTeamBuilderID }))
+    }
+
+    func testPokemonTeamBuilderPersistsArtifactsThroughGenericRunner() throws {
+        let runtime = OpenClawWorkspaceRuntime()
+        runtime.bootstrap(config: .default, preferences: .default, routeSummary: "Direct cloud model route")
+
+        let receipt = runtime.runSkill(
+            id: BuiltInSkillRegistry.pokemonTeamBuilderID,
+            input: [
+                "format": "Singles",
+                "strategy": "electric balance",
+                "mustInclude": "Pikachu, Gengar",
+                "avoid": "Charizard"
+            ],
+            config: .default,
+            preferences: .default,
+            routeSummary: "Direct cloud model route"
+        )
+
+        XCTAssertEqual(receipt.status, .persisted)
+        XCTAssertEqual(receipt.artifacts.count, 2)
+        XCTAssertTrue(receipt.output["members"]?.contains("Pikachu") == true)
+        XCTAssertTrue(receipt.artifacts.allSatisfy { FileManager.default.fileExists(atPath: Paths.openClawDirectory.appendingPathComponent($0).path) })
+        XCTAssertTrue(ReceiptFormatter.confirmedSummary(for: receipt).hasPrefix("Persisted:"))
+    }
+
+    func testSandboxRejectsUnsupportedShellWithoutFakeCompletion() {
+        let runtime = OpenClawWorkspaceRuntime()
+        runtime.bootstrap(config: .default, preferences: .default, routeSummary: "Route not configured")
+
+        let receipt = runtime.runSandbox(command: "rm -rf /", config: .default, preferences: .default, routeSummary: "Route not configured")
+
+        XCTAssertEqual(receipt.status, .failed)
+        XCTAssertTrue(receipt.error?.contains("Unsupported command") == true)
+        XCTAssertTrue(ReceiptFormatter.confirmedSummary(for: receipt).hasPrefix("Failed:"))
+    }
 }
 
 private final class FakeLocalLLMEngine: LocalLLMEngine {


### PR DESCRIPTION
## Task contract
Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem
Build 16 fixed bundle continuity and cloud route posture, but the app still felt like a chat shell. Build 17 adds the first real OpenClaw workspace layer: inspectable artifacts, state stores, receipts, a skills registry, Skills and Artifacts tabs, and a flagship Pokemon Team Builder skill.

## Smallest useful wedge
- Add a built-in OpenClaw Workspace Runtime under the iOS app container.
- Bootstrap a real .openclaw workspace with canonical Markdown artifacts, JSON state stores, action/event logs, and registry data.
- Add registry-backed Skills and Artifacts tabs.
- Register Pokemon Team Builder, Artifact Rebuilder, and Memory Inspector.
- Make Pokemon Team Builder save JSON/Markdown artifacts through the generic skill runner.
- Ground Buddy and Chat in runtime receipts so the UI does not claim unconfirmed work.
- Bump BeMoreAgent to build 17 while keeping PRODUCT_BUNDLE_IDENTIFIER=BeMoreAgent and IPHONEOS_DEPLOYMENT_TARGET=26.0.

## Verification plan
- Regenerate the Xcode project.
- Build the app for the iOS simulator.
- Build the XCTest bundle for testing.
- Verify bundle identifier, iOS deployment target, and CFBundleVersion.
- Let PR checks run on GitHub.

## Summary
- add a built-in OpenClaw Workspace Runtime under the iOS app container
- bootstrap a real .openclaw workspace with soul.md, user.md, memory.md, session.md, skills.md
- add actions.jsonl, events.jsonl, registry/skills.json, JSON state stores, and latest-actions.log
- add typed action records, statuses, receipts, and receipt-aware summaries
- add registry-backed Skills tab and Artifacts tab
- register Pokemon Team Builder, Artifact Rebuilder, and Memory Inspector skills
- make Pokemon Team Builder run through the generic skill runner and persist JSON/Markdown team artifacts
- redesign Buddy around model/runtime/memory/artifact/skill/action health
- add chat action receipt cards for recent runtime work
- remove user-facing split-brain Gateway framing in favor of one OpenClaw runtime surface
- bump BeMoreAgent to build 17

## Runtime truth
Build 17 materially moves the app toward one agent, one workspace, one sandbox, one capability surface. It still does not ship real on-device LLM inference unless MLCSwift is linked, and iOS does not expose arbitrary host shell execution here. The Build 17 sandbox is a controlled OpenClaw command surface with receipts: pwd, ls, cat, regenerate, skills, help. Unsupported commands fail honestly instead of pretending to run.

## Verification
- git diff --check
- xcodegen generate
- xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination generic/platform=iOS Simulator -derivedDataPath .build/DerivedData build
- xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination generic/platform=iOS Simulator -derivedDataPath .build/DerivedData build-for-testing
- local Xcode settings: PRODUCT_BUNDLE_IDENTIFIER=BeMoreAgent, IPHONEOS_DEPLOYMENT_TARGET=26.0, CFBundleVersion=17

## Test note
A full simulator xcodebuild test invocation built successfully but hung during simulator execution on this Mac, so I stopped it and used build-for-testing as the reliable XCTest compile check.

## Rollback plan
Revert this PR to remove Build 17 runtime plumbing, the new tabs, the skill registry, generated workspace artifacts, and Build 17 metadata while preserving the earlier BeMoreAgent bundle continuity fix.

## Continuity
The bundle identifier remains BeMoreAgent, so existing TestFlight users on that identity should keep local app-container state.