### PR TITLE
[codex] Improve OpenClaw agent workspace UX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host context-reseed worker-create worker-upload-config worker-connect worker-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync project-snapshot continuity-report continuity-publish site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-donor-extract site-page-checklist site-parity-matrix site-parity-report site-parity-update site-react-template launchd-install durable-init durable-run-next durable-status durable-resume durable-cancel
+.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host context-reseed worker-create worker-upload-config worker-connect worker-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync openclaw-boundary-doctor openclaw-host-policy project-snapshot continuity-report continuity-publish site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-donor-extract site-page-checklist site-parity-matrix site-parity-report site-parity-update site-react-template launchd-install durable-init durable-run-next durable-status durable-resume durable-cancel
 
 # Docker Compose file
 COMPOSE_FILE=compose.yaml
@@ -159,6 +159,12 @@ runtime-cloud-dry:
 
 workspace-sync:
 	@python3 ./scripts/bmo-workspace-sync.py $(if $(ARGS),$(ARGS))
+
+openclaw-boundary-doctor:
+	@python3 ./scripts/openclaw-boundary-doctor.py
+
+openclaw-host-policy:
+	@python3 ./scripts/apply-openclaw-host-policy.py
 
 project-snapshot:
 	@bash ./scripts/bmo-project-snapshot.sh $(if $(ARGS),$(ARGS))

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This repo is intentionally local-first and operator-visible.
 - Host OpenClaw handles Telegram-facing runtime behavior.
 - OpenShell and NemoClaw provide disposable worker sandboxes.
 - `bmo-stack` provides the canonical operating environment, policy surface, and integration glue.
+- The iOS app uses its own app-container workspace. It must not read or mutate the MacBook `~/.openclaw` runtime unless Cody explicitly connects it through a gateway, pairing, or export/import path.
 
 Manual operator steps still exist:
 
@@ -88,6 +89,7 @@ Manual operator steps still exist:
 - Do not claim `prismtek.dev` web-chat fixes from `bmo-stack` alone unless the relevant `prismtek-site` path was changed and validated.
 - Do not patch vendored or donor paths first when the real owner is upstream.
 - Prefer machine-checkable manifests, validators, and runbooks over doc-only promises.
+- Use `make openclaw-boundary-doctor` to verify the MacBook OpenClaw/runtime boundary and `make openclaw-host-policy` to reapply the host Telegram delivery policy.
 
 ## Licensing and provenance
 

--- a/TASK_STATE.md
+++ b/TASK_STATE.md
@@ -1,19 +1,18 @@
 # Task State
 
-Last updated: 2026-04-09 19:33 UTC
+Last updated: 2026-04-10 10:25 UTC
 
 ## Current status
 
-- Description: Reconcile the real iOS shell state on current `master`, add a meaningful repo-backed BMO Stack surface inside the app, fix stale local-runtime/product copy, and refresh the iOS docs to match what actually ships.
-- Active repo: `/Users/taylor/development/bmo-stack`
-- Branch: `codex/ios-shell-surfaces-a`
-- Last successful step: rebased the work onto `origin/master` after confirming PR `#212` advanced the iOS target to build `13`, preserved the focused shell/doc changes, and kept the repo-managed TestFlight path intact.
-- Next intended step: rerun the required build plus simulator verification from the rebased branch, then publish the scoped PRs with truthful build/runtime status.
+- Description: Keep PR #229 merge-ready while tightening the MacBook OpenClaw/iOS boundary and host Telegram delivery policy.
+- Active repo: `/Users/prismtek/bmo-stack`
+- Branch: `fix/openclaw-build18-agent-workspace-ux`
+- Last successful step: applied host OpenClaw delivery policy, added repo-side boundary/policy doctors, and verified PR #229 was clean before this follow-up patch.
+- Next intended step: run repo checks, commit, push, and confirm the PR checks restart on the new head.
 - Verification complete: false
 - Manual steps remaining:
-  - rerun the required local build after edits on top of `origin/master`
-  - verify relaunch persistence for onboarding, buddy state, and tab layout after the rebase
-  - determine whether PR B local runtime work is honestly feasible from current `master`
+  - watch the new PR head checks after push
+  - verify live Telegram delivery with a real long response from Cody's channel
 - Safe to resume: true
 
 - 2026-04-09 19:13 UTC

--- a/WORK_IN_PROGRESS.md
+++ b/WORK_IN_PROGRESS.md
@@ -1,35 +1,34 @@
 # Work In Progress
 
-Last updated: 2026-04-09 19:33 UTC
+Last updated: 2026-04-10 10:25 UTC
 
 ## Current focus
 
-- Active mission: ship the honest remaining PR A work for the iOS shell from current `master`.
-- Why now: the assignment assumed several product-shell gaps that are already present on `master`, so the real job is to close the remaining truth gaps, add one repo-backed BMO Stack surface inside iOS, and keep the docs/release posture accurate.
+- Active mission: keep Build 18 PR #229 merge-ready while making the MacBook OpenClaw setup safer and less chatty.
+- Why now: the iOS app must not be able to affect the host `~/.openclaw` runtime unless Cody explicitly connects it through a gateway, and Telegram delivery was fragmenting long answers into small chunks.
 - Owner paths in play:
-  - `apps/openclaw-shell-ios/project.yml`
-  - `apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift`
-  - `apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift`
-  - `apps/openclaw-shell-ios/OpenClawShell/Views/HomeView.swift`
-  - `apps/openclaw-shell-ios/IOS_PRODUCT_SURFACES.md`
-  - `apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md`
-  - `docs/MISSION_CONTROL.md`
-  - `docs/POKEMON_CHAMPIONS_TEAM_BUILDER_BACKEND.md`
+  - `~/.openclaw/openclaw.json` for host-only delivery config
+  - `scripts/apply-openclaw-host-policy.py`
+  - `scripts/openclaw-boundary-doctor.py`
+  - `docs/OPENCLAW_HOST_BOUNDARY.md`
+  - `context/SESSION_STATE.md`
+  - `context/RUNBOOK.md`
+  - `README.md`
+  - `Makefile`
 
 ## Current work packet
 
-- add a bundled repo-surface presentation inside the iOS shell using existing BMO Stack docs as source material
-- fix stale onboarding/runtime copy so the app does not imply a real on-device route when it is still on the stub runtime
-- refresh the iOS product/status docs to describe what is actually available now
-- rerun build + simulator checks and decide whether PR B local runtime work is real or blocked
+- host gateway should remain loopback/local
+- iOS app workspace should remain inside the app container
+- Telegram delivery policy should collect up to 20 inbound messages into one turn and avoid tiny outbound chunks
+- repo should contain a repeatable doctor and apply script for this policy
 
 ## Next milestone
 
-- land the focused iOS shell surfaces/doc-truth PR from `codex/ios-shell-surfaces-a`
+- push the boundary/policy follow-up commit to PR #229 and verify checks
 
 ## Risks and watchouts
 
-- generated Xcode project and DerivedData should stay untracked; `xcodegen` remains the source of truth
-- current `origin/master` already advanced `CFBundleVersion` to `13` in PR `#212`, so build-number reporting must stay truthful and avoid stale build-12 claims
-- the local runtime is still stubbed; do not let onboarding, docs, or status copy imply on-device inference already exists
-- if the added BMO Stack surface is repo-backed documentation or wrapped stack state, label it clearly as wrapped and avoid fake parity claims
+- `~/.openclaw/openclaw.json` is host-local and not committed; repo scripts make the policy repeatable without storing secrets
+- `openclaw gateway status` can hang even when logs show the gateway ready, so verify with config parse, loopback listener, and logs when needed
+- live Telegram behavior still needs an actual long-message smoke test after the gateway applies the changed policy

--- a/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
+++ b/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
@@ -16,6 +16,8 @@ Current shipped shell surfaces include:
 - Chat, Skills, Artifacts, Buddy, Files, and Settings tabs
 - `.openclaw/` workspace artifacts, JSON state stores, action/event logs, and a skills registry
 - Pokémon Team Builder as a registry-backed skill that saves JSON and Markdown artifacts
+- ClawHub local starter-skill installs that persist manifest and README artifacts
+- editable/exportable/deletable Files workspace entries and `.openclaw` artifacts
 - persisted tab ordering and visibility
 - persisted buddy rename and active selection
 - bundled repo-backed surface briefs inside Mission Control
@@ -28,7 +30,9 @@ Current shipped shell surfaces include:
 - Cloud routes can be configured in Settings and switched in Models.
 - Workspace actions run through OpenClaw runtime receipts. The UI should not claim files, memory,
   skills, or sandbox work completed unless the runtime returns a completed or persisted receipt.
-- The iOS sandbox currently exposes controlled OpenClaw commands (`pwd`, `ls`, `cat`, `regenerate`,
+- Cloud/local replies are sanitized before display so hidden reasoning/thought blocks are not shown
+  unless the operator explicitly asks for an explanation.
+- The iOS sandbox currently exposes controlled OpenClaw commands (`pwd`, `ls`, `cat`, `write`, `regenerate`,
   `skills`, `help`) rather than arbitrary host shell execution.
 
 ## Local build path
@@ -46,7 +50,7 @@ xcodebuild -project BeMoreAgent.xcodeproj \
 
 ## Release path
 
-- `CFBundleVersion` is currently `17`.
+- `CFBundleVersion` is currently `18`.
 - `IPHONEOS_DEPLOYMENT_TARGET` is currently `26.0`.
 - TestFlight delivery is repo-managed through `.github/workflows/testflight.yml`.
 - The operator runbook for that path is `apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md`.
@@ -58,7 +62,7 @@ xcodebuild -project BeMoreAgent.xcodeproj \
 - `project.yml` still has `dependencies: []`.
 - When `MLCSwift` is not importable, the app still uses the stub local-runtime path and cannot claim
   real on-device inference.
-- Arbitrary codex-style shell/process execution is not available on-device in this build. Build 17
+- Arbitrary codex-style shell/process execution is not available on-device in this build. Build 18
   provides a receipt-backed controlled sandbox surface and leaves real hardened process execution for
   a future platform/runtime integration.
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Info.plist
+++ b/apps/openclaw-shell-ios/OpenClawShell/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.2</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
@@ -32,6 +32,16 @@ enum OpenClawActionKind: String, Codable, CaseIterable, Hashable {
     case workspaceRead = "workspace.read"
 }
 
+struct ClawHubSkillTemplate: Identifiable, Hashable {
+    var id: String
+    var name: String
+    var description: String
+    var category: String
+    var tags: [String]
+    var starterMarkdown: String
+    var systemImage: String
+}
+
 struct OpenClawActionRecord: Identifiable, Codable, Hashable {
     var id: UUID
     var kind: OpenClawActionKind
@@ -132,11 +142,15 @@ struct PokemonTeamMember: Identifiable, Codable, Hashable {
     var name: String
     var role: String
     var notes: String
+    var reason: String = ""
+    var battlePlan: String = ""
 }
 
 struct PokemonTeamOutput: Codable, Hashable {
     var teamMembers: [PokemonTeamMember]
     var roleBreakdown: [String]
+    var selectionRationale: [String]
+    var battleStrategy: [String]
     var summary: String
     var weaknesses: [String]
     var suggestions: [String]
@@ -205,6 +219,68 @@ enum BuiltInSkillRegistry {
     }
 }
 
+enum ClawHubCatalog {
+    static let templates: [ClawHubSkillTemplate] = [
+        ClawHubSkillTemplate(
+            id: "clawhub-skill-composer",
+            name: "Skill Composer",
+            description: "Draft and evolve custom OpenClaw skills as manifest-backed workspace artifacts.",
+            category: "Authoring",
+            tags: ["skills", "authoring", "clawhub"],
+            starterMarkdown: """
+            # Skill Composer
+
+            ## Purpose
+            Help the agent turn repeated operator workflows into clear skill manifests, instructions, inputs, outputs, and verification notes.
+
+            ## Runtime contract
+            - Read existing `.openclaw/registry/skills.json`.
+            - Propose changes first when the request is ambiguous.
+            - Persist new skill files only through workspace receipts.
+            """,
+            systemImage: "wand.and.stars"
+        ),
+        ClawHubSkillTemplate(
+            id: "clawhub-buddy-battle-coach",
+            name: "Buddy Battle Coach",
+            description: "Analyze buddy stats, recent battles, and suggested training before a duel.",
+            category: "Buddy",
+            tags: ["buddy", "battle", "training"],
+            starterMarkdown: """
+            # Buddy Battle Coach
+
+            ## Purpose
+            Connect buddy state to tactical choices: train, feed, switch event, battle, or retire a weak plan.
+
+            ## Runtime contract
+            - Read buddy state and recent action receipts.
+            - Explain the recommended action.
+            - Never claim a battle happened without a persisted battle record.
+            """,
+            systemImage: "bolt.shield"
+        ),
+        ClawHubSkillTemplate(
+            id: "clawhub-workspace-architect",
+            name: "Workspace Architect",
+            description: "Review `.openclaw` artifacts and suggest better soul, memory, session, and skill files.",
+            category: "Workspace",
+            tags: ["artifacts", "memory", "workspace"],
+            starterMarkdown: """
+            # Workspace Architect
+
+            ## Purpose
+            Keep `.openclaw` coherent by improving canonical markdown and state files with receipt-backed edits.
+
+            ## Runtime contract
+            - Read canonical artifacts before editing.
+            - Preserve user-authored facts.
+            - Save changes through workspace receipts.
+            """,
+            systemImage: "building.columns"
+        )
+    ]
+}
+
 // MARK: - Workspace Runtime
 
 @MainActor
@@ -233,8 +309,8 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
 
     func bootstrap(config: StackConfig, preferences: UserPreferences, routeSummary: String) {
         ensureWorkspaceTree()
-        skills = BuiltInSkillRegistry.manifests
-        writeJSON(skills, to: rootURL.appendingPathComponent("registry/skills.json"))
+        skills = loadSkillRegistry()
+        persistSkillRegistry()
         ensureStateStores(config: config, preferences: preferences, routeSummary: routeSummary)
         regenerateCanonicalArtifactsIfMissing(config: config, preferences: preferences, routeSummary: routeSummary)
         refreshMetadata()
@@ -257,6 +333,25 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         } catch {
             return finish(action, status: .failed, summary: "Could not write \(path)", error: error.localizedDescription)
         }
+    }
+
+    func deleteFile(_ path: String, source: String = "runtime") -> OpenClawReceipt {
+        let action = begin(kind: .workspaceWrite, source: source, title: "Delete \(path)", input: ["path": path])
+        do {
+            let url = try resolve(path)
+            guard fileManager.fileExists(atPath: url.path) else {
+                return finish(action, status: .failed, summary: "Could not delete \(path)", error: "File does not exist.")
+            }
+            try fileManager.removeItem(at: url)
+            appendEvent(type: "artifact.deleted", message: "Deleted \(path).", metadata: ["path": path])
+            return finish(action, status: .persisted, summary: "Deleted \(path)", output: ["path": path], artifacts: [path])
+        } catch {
+            return finish(action, status: .failed, summary: "Could not delete \(path)", error: error.localizedDescription)
+        }
+    }
+
+    func fileURL(for path: String) throws -> URL {
+        try resolve(path)
     }
 
     func listFiles(_ path: String = "") -> [String] {
@@ -317,8 +412,48 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         case BuiltInSkillRegistry.memoryInspectorID:
             return runMemoryInspector(manifest: manifest)
         default:
+            if manifest.entrypoint.hasPrefix("clawhub.") {
+                return runClawHubSkill(manifest: manifest, input: input)
+            }
             let action = begin(kind: .skillRun, source: "skills", title: manifest.name, input: input)
             return finish(action, status: .failed, summary: "Entrypoint is not implemented", error: "Missing entrypoint: \(manifest.entrypoint)")
+        }
+    }
+
+    func installClawHubSkill(_ template: ClawHubSkillTemplate) -> OpenClawReceipt {
+        let action = begin(kind: .skillRun, source: "clawhub", title: "Install \(template.name)", input: ["skillId": template.id])
+        if skills.contains(where: { $0.id == template.id }) {
+            return finish(action, status: .completed, summary: "\(template.name) is already installed", output: ["skillId": template.id])
+        }
+
+        let manifest = SkillManifest(
+            id: template.id,
+            name: template.name,
+            description: template.description,
+            version: "0.1.0",
+            category: template.category,
+            tags: template.tags,
+            permissions: ["workspace.read", "workspace.write", "actions.write"],
+            inputSchema: ["request": "string"],
+            outputSchema: ["summary": "string", "artifactPath": "string"],
+            ui: .init(route: "/skills/\(template.id)", systemImage: template.systemImage, accent: "accent"),
+            entrypoint: "clawhub.\(template.id)",
+            enabled: true
+        )
+
+        do {
+            let folder = "skills/\(template.id)"
+            skills.append(manifest)
+            skills.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            persistSkillRegistry()
+            _ = try writeFile("\(folder)/README.md", content: template.starterMarkdown, source: "clawhub")
+            let manifestData = try encoder.encode(manifest)
+            _ = try writeFile("\(folder)/manifest.json", content: String(data: manifestData, encoding: .utf8) ?? "{}", source: "clawhub")
+            refreshMetadata()
+            appendEvent(type: "skill.installed", message: "Installed \(template.name) from ClawHub.", metadata: ["skillId": template.id])
+            return finish(action, status: .persisted, summary: "Installed \(template.name) from ClawHub", output: ["skillId": template.id], artifacts: ["registry/skills.json", "\(folder)/README.md", "\(folder)/manifest.json"])
+        } catch {
+            return finish(action, status: .failed, summary: "Could not install \(template.name)", error: error.localizedDescription)
         }
     }
 
@@ -347,12 +482,23 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
             } catch {
                 return finish(action, status: .failed, summary: "Could not read \(target)", error: error.localizedDescription)
             }
+        case "write":
+            guard parts.count >= 3 else {
+                return finish(action, status: .failed, summary: "write requires a file path and content", error: "Usage: write <path> <content>")
+            }
+            let target = parts[1]
+            let content = parts.dropFirst(2).joined(separator: " ")
+            do {
+                return try writeFile(target, content: content, source: "sandbox")
+            } catch {
+                return finish(action, status: .failed, summary: "Could not write \(target)", error: error.localizedDescription)
+            }
         case "regenerate":
             return regenerateArtifacts(target: parts.dropFirst().first ?? "all", config: config, preferences: preferences, routeSummary: routeSummary, source: "sandbox")
         case "skills":
             return finish(action, status: .completed, summary: "Listed registered skills", output: ["stdout": skills.map { "\($0.id) - \($0.name)" }.joined(separator: "\n"), "exitCode": "0"])
         case "help":
-            return finish(action, status: .completed, summary: "Printed sandbox help", output: ["stdout": "Supported commands: pwd, ls [path], cat <path>, regenerate [all|artifact], skills, help", "exitCode": "0"])
+            return finish(action, status: .completed, summary: "Printed sandbox help", output: ["stdout": "Supported commands: pwd, ls [path], cat <path>, write <path> <content>, regenerate [all|artifact], skills, help", "exitCode": "0"])
         default:
             return finish(
                 action,
@@ -405,6 +551,20 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
 
     private var canonicalArtifactPaths: [String] {
         ["soul.md", "user.md", "memory.md", "session.md", "skills.md"]
+    }
+
+    private func loadSkillRegistry() -> [SkillManifest] {
+        let registryURL = rootURL.appendingPathComponent("registry/skills.json")
+        let existing = (try? Data(contentsOf: registryURL))
+            .flatMap { try? decoder.decode([SkillManifest].self, from: $0) } ?? []
+        var merged: [String: SkillManifest] = [:]
+        for manifest in existing { merged[manifest.id] = manifest }
+        for manifest in BuiltInSkillRegistry.manifests { merged[manifest.id] = manifest }
+        return merged.values.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    private func persistSkillRegistry() {
+        writeJSON(skills, to: rootURL.appendingPathComponent("registry/skills.json"))
     }
 
     private func ensureWorkspaceTree() {
@@ -536,6 +696,8 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
             "skills.md": """
             # skills.md
 
+            Skills are registry-backed and can be extended through ClawHub installs or user-authored manifests.
+
             \(skills.map { "- **\($0.name)** (`\($0.id)`): \($0.description)" }.joined(separator: "\n"))
             """
         ]
@@ -558,8 +720,20 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
             selected.append(candidate)
         }
         let team = selected.prefix(6).enumerated().map { index, name in
-            PokemonTeamMember(name: name, role: roles[index % roles.count], notes: "\(format) pick for \(strategy).")
+            let role = roles[index % roles.count]
+            return PokemonTeamMember(
+                name: name,
+                role: role,
+                notes: "\(format) pick for \(strategy).",
+                reason: selectionReason(for: name, role: role, strategy: strategy, mustInclude: mustInclude),
+                battlePlan: battlePlan(for: name, role: role, format: format, strategy: strategy)
+            )
         }
+        let battleStrategy = [
+            "Open with \(team.first?.name ?? "the lead") to establish \(team.first?.role.lowercased() ?? "tempo").",
+            "Use pivots and utility picks to protect the main breakers until the opponent's answers are weakened.",
+            "Preserve \(team.last?.name ?? "the cleaner") for the final turn cycle instead of trading it early."
+        ]
         let weaknesses = [
             "Validate exact legality, moves, items, and EVs against the target format before competitive use.",
             "This MVP uses curated role coverage rather than a full damage calculator or matchup database."
@@ -571,6 +745,8 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         let output = PokemonTeamOutput(
             teamMembers: Array(team),
             roleBreakdown: team.map { "\($0.name): \($0.role)" },
+            selectionRationale: team.map { "\($0.name): \($0.reason)" },
+            battleStrategy: battleStrategy,
             summary: "Drafted a \(format) team around \(strategy).",
             weaknesses: weaknesses,
             suggestions: suggestions,
@@ -592,7 +768,12 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
                 action,
                 status: .persisted,
                 summary: "Pokemon team drafted and saved",
-                output: ["summary": saved.summary, "members": saved.teamMembers.map(\.name).joined(separator: ", ")],
+                output: [
+                    "summary": saved.summary,
+                    "members": saved.teamMembers.map(\.name).joined(separator: ", "),
+                    "strategy": saved.battleStrategy.joined(separator: "\n"),
+                    "rationale": saved.selectionRationale.joined(separator: "\n")
+                ],
                 artifacts: [jsonPath, mdPath]
             )
         } catch {
@@ -610,6 +791,31 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         return finish(action, status: .completed, summary: "Read memory stores", output: ["summary": body], artifacts: paths)
     }
 
+    private func runClawHubSkill(manifest: SkillManifest, input: [String: String]) -> OpenClawReceipt {
+        let action = begin(kind: .skillRun, source: "skill.\(manifest.id)", title: manifest.name, input: input)
+        let request = input["request"].nilIfBlank ?? "Inspect this skill."
+        let path = "skills/\(manifest.id)/runs/\(safeSlug(String(Int(Date().timeIntervalSince1970)) + "-" + request.prefix(32))).md"
+        let body = """
+        # \(manifest.name) Run
+
+        - Skill: \(manifest.id)
+        - Request: \(request)
+        - Status: completed with local workspace receipt
+
+        ## Result
+        This ClawHub skill is installed and callable through the generic skill runner. Connect deeper domain logic by editing `skills/\(manifest.id)/README.md` and its manifest.
+        """
+        do {
+            let url = try resolve(path)
+            try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try body.write(to: url, atomically: true, encoding: .utf8)
+            appendEvent(type: "skill.completed", message: "\(manifest.name) wrote \(path).", metadata: ["skillId": manifest.id, "artifact": path])
+            return finish(action, status: .persisted, summary: "\(manifest.name) wrote a run artifact", output: ["summary": "Run artifact created for \(request)"], artifacts: [path])
+        } catch {
+            return finish(action, status: .failed, summary: "\(manifest.name) could not write a run artifact", error: error.localizedDescription)
+        }
+    }
+
     private func pokemonMarkdown(output: PokemonTeamOutput, format: String, strategy: String) -> String {
         """
         # Pokemon Team
@@ -621,6 +827,15 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         ## Team
         \(output.teamMembers.map { "- **\($0.name)** - \($0.role): \($0.notes)" }.joined(separator: "\n"))
 
+        ## Why these Pokemon
+        \(output.selectionRationale.map { "- \($0)" }.joined(separator: "\n"))
+
+        ## Battle strategy
+        \(output.battleStrategy.map { "- \($0)" }.joined(separator: "\n"))
+
+        ## Individual battle plans
+        \(output.teamMembers.map { "- **\($0.name)**: \($0.battlePlan)" }.joined(separator: "\n"))
+
         ## Summary
         \(output.summary)
 
@@ -630,6 +845,30 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         ## Suggestions
         \(output.suggestions.map { "- \($0)" }.joined(separator: "\n"))
         """
+    }
+
+    private func selectionReason(for name: String, role: String, strategy: String, mustInclude: [String]) -> String {
+        if mustInclude.contains(where: { $0.caseInsensitiveCompare(name) == .orderedSame }) {
+            return "Included because the operator requested it, then assigned \(role.lowercased()) so it has a defined job."
+        }
+        return "Chosen to cover \(role.lowercased()) while supporting the \(strategy) plan."
+    }
+
+    private func battlePlan(for name: String, role: String, format: String, strategy: String) -> String {
+        switch role {
+        case "Lead / speed control":
+            return "Start or enter early, force tempo, and create the first safe switch for the \(strategy) core."
+        case "Physical breaker":
+            return "Pressure special walls and punish passive turns so the cleaner has an easier endgame."
+        case "Special attacker":
+            return "Attack from the opposite damage axis and exploit defensive pivots that wall the physical breaker."
+        case "Defensive pivot":
+            return "Absorb risky hits, scout the opponent's plan, and bring attackers in without spending momentum."
+        case "Utility support":
+            return "Patch matchup gaps with status, redirection, hazard control, screens, or emergency disruption."
+        default:
+            return "Stay healthy until the opponent's checks are weakened, then close the \(format.lowercased()) game."
+        }
     }
 
     private func begin(kind: OpenClawActionKind, source: String, title: String, input: [String: String]) -> OpenClawActionRecord {
@@ -692,7 +931,11 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         }
         guard let handle = try? FileHandle(forWritingTo: url) else { return }
         defer { try? handle.close() }
-        try? handle.seekToEnd()
+        do {
+            _ = try handle.seekToEnd()
+        } catch {
+            return
+        }
         if let data = value.data(using: .utf8) {
             handle.write(data)
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
@@ -277,6 +277,101 @@ enum ClawHubCatalog {
             - Save changes through workspace receipts.
             """,
             systemImage: "building.columns"
+        ),
+        ClawHubSkillTemplate(
+            id: "clawhub-file-crafter",
+            name: "File Crafter",
+            description: "Create, revise, export, and clean up workspace files through receipt-backed file actions.",
+            category: "Workspace",
+            tags: ["files", "authoring", "export"],
+            starterMarkdown: """
+            # File Crafter
+
+            ## Purpose
+            Help the agent turn user requests into durable files in the Files or `.openclaw` workspace surfaces.
+
+            ## Runtime contract
+            - Ask for a filename when the path is ambiguous.
+            - Write only through workspace receipts.
+            - Offer export/delete follow-ups only after the file exists.
+            """,
+            systemImage: "doc.badge.plus"
+        ),
+        ClawHubSkillTemplate(
+            id: "clawhub-memory-gardener",
+            name: "Memory Gardener",
+            description: "Review durable facts and preferences, then propose precise memory.md and state-store improvements.",
+            category: "Memory",
+            tags: ["memory", "facts", "preferences"],
+            starterMarkdown: """
+            # Memory Gardener
+
+            ## Purpose
+            Keep durable memory useful by pruning noisy facts and strengthening real operator preferences.
+
+            ## Runtime contract
+            - Separate durable facts from session notes.
+            - Preserve user-authored identity details.
+            - Persist changes only after the user or runtime confirms the edit.
+            """,
+            systemImage: "leaf.fill"
+        ),
+        ClawHubSkillTemplate(
+            id: "clawhub-model-route-doctor",
+            name: "Model Route Doctor",
+            description: "Diagnose cloud/local route configuration without pretending unavailable runtimes are online.",
+            category: "Runtime",
+            tags: ["models", "routing", "diagnostics"],
+            starterMarkdown: """
+            # Model Route Doctor
+
+            ## Purpose
+            Explain what model route is active, what is missing, and which runtime capabilities are currently available.
+
+            ## Runtime contract
+            - Report configured routes separately from working routes.
+            - Never imply local inference is live when only stub runtime is present.
+            - Suggest the smallest next action to restore capability.
+            """,
+            systemImage: "stethoscope"
+        ),
+        ClawHubSkillTemplate(
+            id: "clawhub-response-cleaner",
+            name: "Response Cleaner",
+            description: "Keep assistant answers concise, answer-first, and free of hidden reasoning unless explanation is requested.",
+            category: "Chat",
+            tags: ["chat", "answers", "reasoning"],
+            starterMarkdown: """
+            # Response Cleaner
+
+            ## Purpose
+            Help the agent answer the user's actual request without leaking scratchpad, hidden reasoning, or unrelated receipts.
+
+            ## Runtime contract
+            - Preserve the final answer.
+            - Remove thought-process scaffolding.
+            - Include rationale only when the user asks for explanation.
+            """,
+            systemImage: "text.bubble"
+        ),
+        ClawHubSkillTemplate(
+            id: "clawhub-battle-arena",
+            name: "Buddy Battle Arena",
+            description: "Create receipt-backed buddy battle records, outcomes, and training recommendations.",
+            category: "Buddy",
+            tags: ["buddy", "battle", "records"],
+            starterMarkdown: """
+            # Buddy Battle Arena
+
+            ## Purpose
+            Turn buddy battles into real persisted records instead of flavor text.
+
+            ## Runtime contract
+            - Read current buddy stats before battle.
+            - Persist the battle result, rewards, and next training plan.
+            - Mark uncertain simulator details as planned, not completed.
+            """,
+            systemImage: "shield.lefthalf.filled"
         )
     ]
 }
@@ -698,7 +793,20 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
 
             Skills are registry-backed and can be extended through ClawHub installs or user-authored manifests.
 
-            \(skills.map { "- **\($0.name)** (`\($0.id)`): \($0.description)" }.joined(separator: "\n"))
+            ## Installed skills
+            \(skills.map { skill in
+                "- **\(skill.name)** (`\(skill.id)`): \(skill.description)\n  - Category: \(skill.category)\n  - Entrypoint: \(skill.entrypoint)\n  - Permissions: \(skill.permissions.joined(separator: ", "))"
+            }.joined(separator: "\n"))
+
+            ## ClawHub starters
+            \(ClawHubCatalog.templates.map { "- **\($0.name)** (`\($0.id)`): \($0.description)" }.joined(separator: "\n"))
+
+            ## Skill authoring rules
+            - New skills need a manifest in `registry/skills.json`.
+            - Skill instructions should live under `skills/<skill-id>/README.md`.
+            - A skill may propose edits, but persisted changes require workspace receipts.
+            - Skill output artifacts should stay under that skill's folder unless the user asks for a shared file.
+            - Chat should not treat old skill artifacts as active context unless the user attaches or references them.
             """
         ]
     }

--- a/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
@@ -617,6 +617,29 @@ final class WorkspaceStore: ObservableObject {
         load()
     }
 
+    func createFile(named filename: String, content: String = "") {
+        let cleaned = filename
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: "\\", with: "-")
+        guard !cleaned.isEmpty else {
+            errorMessage = "Enter a filename first."
+            return
+        }
+
+        let destination = Paths.workspaceDirectory.appendingPathComponent(cleaned)
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                errorMessage = "\(cleaned) already exists."
+                return
+            }
+            try content.write(to: destination, atomically: true, encoding: .utf8)
+            load()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
     func delete(_ file: WorkspaceFile) {
         do {
             try FileManager.default.removeItem(at: file.localURL)
@@ -770,7 +793,52 @@ enum CloudPromptBuilder {
         \(toolPosture)
 
         Be honest about capabilities. This direct cloud chat route can reason and use attached file context. Real filesystem, memory, skill, and sandbox changes must go through OpenClaw Workspace Runtime receipts. If a capability is unavailable in this iOS runtime, say unavailable or failed instead of claiming completion.
+
+        Reply with the answer only. Do not reveal hidden reasoning, chain-of-thought, scratchpad notes, analysis sections, or internal deliberation unless the operator explicitly asks for an explanation. If asked to explain, give a concise rationale, not private step-by-step thoughts.
         """
+    }
+}
+
+enum AgentReplySanitizer {
+    static func userVisibleAnswer(from raw: String) -> String {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        text = removeDelimited("<think>", "</think>", from: text)
+        text = removeDelimited("<thinking>", "</thinking>", from: text)
+        text = removeDelimited("```thought", "```", from: text)
+        text = removeDelimited("```thinking", "```", from: text)
+
+        let dropPrefixes = [
+            "Thought process:",
+            "Thinking:",
+            "Reasoning:",
+            "Analysis:",
+            "Chain of thought:",
+            "Scratchpad:"
+        ]
+        var lines = text.components(separatedBy: .newlines)
+        while let first = lines.first {
+            let trimmed = first.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty || dropPrefixes.contains(where: { trimmed.range(of: $0, options: [.caseInsensitive, .anchored]) != nil }) {
+                lines.removeFirst()
+            } else {
+                break
+            }
+        }
+
+        text = lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? "I do not have a user-visible answer from that route." : text
+    }
+
+    private static func removeDelimited(_ start: String, _ end: String, from value: String) -> String {
+        var result = value
+        while let startRange = result.range(of: start, options: [.caseInsensitive]) {
+            guard let endRange = result.range(of: end, options: [.caseInsensitive], range: startRange.upperBound..<result.endIndex) else {
+                result.removeSubrange(startRange.lowerBound..<result.endIndex)
+                break
+            }
+            result.removeSubrange(startRange.lowerBound..<endRange.upperBound)
+        }
+        return result
     }
 }
 
@@ -1511,13 +1579,13 @@ final class AppState: ObservableObject {
             let reply: String
             if let account = selectedProviderAccount {
                 runtimeStatus = "Cloud: \(account.provider.displayName)"
-                reply = try await cloudExecutionService.send(
+                reply = AgentReplySanitizer.userVisibleAnswer(from: try await cloudExecutionService.send(
                     account: account,
                     messages: buildCloudMessages(attachedFiles: attachedFiles)
-                )
+                ))
             } else {
                 if usesStubRuntime { runtimeStatus = "Stub preview" }
-                reply = try await engine.generate(prompt: cleaned, fileContexts: attachedFiles, chatHistory: chatStore.messages)
+                reply = AgentReplySanitizer.userVisibleAnswer(from: try await engine.generate(prompt: cleaned, fileContexts: attachedFiles, chatHistory: chatStore.messages))
             }
             chatStore.messages.append(ChatMessage(role: .assistant, content: reply))
             workspaceRuntime.refreshMetadata()
@@ -1549,6 +1617,33 @@ final class AppState: ObservableObject {
 
     func runSandbox(command: String) -> OpenClawReceipt {
         let receipt = workspaceRuntime.runSandbox(command: command, config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
+        chatStore.messages.append(ChatMessage(role: .system, content: ReceiptFormatter.confirmedSummary(for: receipt)))
+        chatStore.persist()
+        return receipt
+    }
+
+    func writeWorkspaceArtifact(path: String, content: String) -> OpenClawReceipt {
+        let receipt: OpenClawReceipt
+        do {
+            receipt = try workspaceRuntime.writeFile(path, content: content, source: "user")
+        } catch {
+            receipt = OpenClawReceipt(actionId: UUID(), status: .failed, title: "Write \(path)", summary: "Could not write \(path)", output: [:], artifacts: [], logs: [], error: error.localizedDescription)
+        }
+        chatStore.messages.append(ChatMessage(role: .system, content: ReceiptFormatter.confirmedSummary(for: receipt)))
+        chatStore.persist()
+        return receipt
+    }
+
+    func deleteWorkspaceArtifact(path: String) -> OpenClawReceipt {
+        let receipt = workspaceRuntime.deleteFile(path, source: "user")
+        chatStore.messages.append(ChatMessage(role: .system, content: ReceiptFormatter.confirmedSummary(for: receipt)))
+        chatStore.persist()
+        return receipt
+    }
+
+    func installClawHubSkill(_ template: ClawHubSkillTemplate) -> OpenClawReceipt {
+        let receipt = workspaceRuntime.installClawHubSkill(template)
+        _ = regenerateArtifacts(target: "skills.md")
         chatStore.messages.append(ChatMessage(role: .system, content: ReceiptFormatter.confirmedSummary(for: receipt)))
         chatStore.persist()
         return receipt

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ArtifactsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ArtifactsView.swift
@@ -97,50 +97,123 @@ struct ArtifactsView: View {
 
 struct ArtifactPreviewView: View {
     @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
     let artifact: OpenClawArtifactMetadata
     @State private var content = ""
     @State private var error: String?
     @State private var receipt: OpenClawReceipt?
+    @State private var isEditing = false
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
-                header
-                if let receipt {
-                    ActionReceiptCard(receipt: receipt)
-                }
-                if let error {
-                    Text(error)
-                        .font(.subheadline)
-                        .foregroundColor(BMOTheme.error)
-                        .bmoCard()
-                } else {
-                    Text(content.isEmpty ? "Empty artifact." : content)
-                        .font(.system(.caption, design: .monospaced))
+        Group {
+            if isEditing {
+                VStack(spacing: 0) {
+                    TextEditor(text: $content)
+                        .font(.system(.body, design: .monospaced))
                         .foregroundColor(BMOTheme.textPrimary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .bmoCard()
+                        .scrollContentBackground(.hidden)
+                        .background(BMOTheme.backgroundPrimary)
+                        .padding(BMOTheme.spacingMD)
+                }
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
+                        header
+                        if let receipt {
+                            ActionReceiptCard(receipt: receipt)
+                        }
+                        if let error {
+                            Text(error)
+                                .font(.subheadline)
+                                .foregroundColor(BMOTheme.error)
+                                .bmoCard()
+                        } else {
+                            actionBar
+                            preview
+                        }
+                    }
+                    .padding(.horizontal, BMOTheme.spacingMD)
+                    .padding(.bottom, BMOTheme.spacingXL)
                 }
             }
-            .padding(.horizontal, BMOTheme.spacingMD)
-            .padding(.bottom, BMOTheme.spacingXL)
         }
         .background(BMOTheme.backgroundPrimary)
         .navigationTitle(artifact.path)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                if let url = try? appState.workspaceRuntime.fileURL(for: artifact.path) {
+                    ShareLink(item: url) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
-                if ["soul.md", "user.md", "memory.md", "session.md", "skills.md"].contains(artifact.path) {
-                    Button("Regenerate") {
-                        receipt = appState.regenerateArtifacts(target: artifact.path)
+                if isEditing {
+                    Button("Save") {
+                        receipt = appState.writeWorkspaceArtifact(path: artifact.path, content: content)
+                        isEditing = false
                         load()
+                    }
+                    .foregroundColor(BMOTheme.accent)
+                } else {
+                    Button("Edit") {
+                        isEditing = true
                     }
                     .foregroundColor(BMOTheme.accent)
                 }
             }
+            ToolbarItem(placement: .bottomBar) {
+                HStack {
+                    if ["soul.md", "user.md", "memory.md", "session.md", "skills.md"].contains(artifact.path) {
+                        Button("Regenerate") {
+                            receipt = appState.regenerateArtifacts(target: artifact.path)
+                            load()
+                        }
+                        .foregroundColor(BMOTheme.accent)
+                    }
+
+                    Spacer()
+
+                    Button(role: .destructive) {
+                        receipt = appState.deleteWorkspaceArtifact(path: artifact.path)
+                        dismiss()
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
+            }
         }
         .onAppear(perform: load)
+    }
+
+    private var preview: some View {
+        Text(content.isEmpty ? "Empty artifact." : content)
+            .font(.system(.caption, design: .monospaced))
+            .foregroundColor(BMOTheme.textPrimary)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .bmoCard()
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: 10) {
+            Button {
+                isEditing = true
+            } label: {
+                Label("Edit", systemImage: "pencil")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(BMOButtonStyle(isPrimary: false))
+
+            if let url = try? appState.workspaceRuntime.fileURL(for: artifact.path) {
+                ShareLink(item: url) {
+                    Label("Export", systemImage: "square.and.arrow.up")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+            }
+        }
     }
 
     private var header: some View {
@@ -148,7 +221,7 @@ struct ArtifactPreviewView: View {
             Text(artifact.path)
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-            Text("Preview is read from the persisted `.openclaw` artifact.")
+            Text("Read, edit, export, or delete this persisted `.openclaw` artifact. Canonical markdown can also be regenerated.")
                 .font(.caption)
                 .foregroundColor(BMOTheme.textTertiary)
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
@@ -410,6 +410,18 @@ final class BuddyProfileStore: ObservableObject {
         persist()
     }
 
+    func removeBuddy(_ target: GeneratedBuddy) {
+        guard var state else { return }
+        guard state.collection.count > 1 else { return }
+        state.collection.removeAll { $0.id == target.id }
+        state.tradeOffers.removeAll { $0.id == target.id }
+        if state.activeBuddy.id == target.id, let replacement = state.collection.first {
+            state.activeBuddy = replacement
+        }
+        self.state = state
+        persist()
+    }
+
     private func mutateActiveBuddy(_ mutation: (inout GeneratedBuddy) -> Void) {
         guard var state else { return }
         var buddy = state.activeBuddy
@@ -464,6 +476,7 @@ struct BuddyView: View {
     @StateObject private var store = BuddyProfileStore()
     @State private var renameTarget: GeneratedBuddy?
     @State private var renameDraft = ""
+    @State private var lastReceipt: OpenClawReceipt?
 
     private var profileID: String {
         BuddyGenerator.profileSignature(for: appState.stackConfig)
@@ -474,6 +487,9 @@ struct BuddyView: View {
             ScrollView {
                 VStack(spacing: BMOTheme.spacingMD) {
                     systemStatusCard
+                    if let lastReceipt {
+                        ActionReceiptCard(receipt: lastReceipt)
+                    }
                     recentRuntimeCard
                     if let buddy = store.activeBuddy {
                         header(for: buddy)
@@ -525,9 +541,10 @@ struct BuddyView: View {
                         }
                         ToolbarItem(placement: .confirmationAction) {
                             Button("Save") {
-                                store.renameBuddy(buddy, to: renameDraft)
-                                renameTarget = nil
-                            }
+                store.renameBuddy(buddy, to: renameDraft)
+                persistBuddyStateReceipt("Renamed \(buddy.name) to \(renameDraft).")
+                renameTarget = nil
+            }
                         }
                     }
                 }
@@ -674,14 +691,17 @@ struct BuddyView: View {
             HStack(spacing: 10) {
                 buttonChip(label: "Feed", icon: "carrot.fill") {
                     store.feedActiveBuddy()
+                    persistBuddyStateReceipt("Fed active buddy and persisted updated care stats.")
                 }
                 buttonChip(label: "Train", icon: "figure.run") {
                     store.trainActiveBuddy()
+                    persistBuddyStateReceipt("Trained active buddy and persisted updated battle stats.")
                 }
             }
 
             Button {
                 store.regenerateBuddy(from: appState.stackConfig)
+                persistBuddyStateReceipt("Generated a new active buddy from the current agent profile.")
             } label: {
                 HStack {
                     Image(systemName: "sparkles")
@@ -718,6 +738,9 @@ struct BuddyView: View {
 
             Button {
                 store.startBattle()
+                if let latest = store.battleHistory.first {
+                    persistBuddyStateReceipt(latest.summary)
+                }
             } label: {
                 HStack {
                     Image(systemName: "bolt.shield.fill")
@@ -781,6 +804,7 @@ struct BuddyView: View {
 
                     Button {
                         store.acceptTrade(offer, from: appState.stackConfig)
+                        persistBuddyStateReceipt("Accepted trade for \(offer.name) and made it the active buddy.")
                     } label: {
                         HStack {
                             Image(systemName: "arrow.triangle.swap")
@@ -841,6 +865,7 @@ struct BuddyView: View {
                             } else {
                                 Button("Make Active") {
                                     store.makeActiveBuddy(buddy)
+                                    persistBuddyStateReceipt("Made \(buddy.name) the active buddy.")
                                 }
                                 .buttonStyle(.bordered)
                             }
@@ -851,6 +876,16 @@ struct BuddyView: View {
                             }
                             .font(.caption)
                             .foregroundColor(BMOTheme.accent)
+
+                            if store.collection.count > 1 {
+                                Button(role: .destructive) {
+                                    store.removeBuddy(buddy)
+                                    persistBuddyStateReceipt("Removed \(buddy.name) from the buddy collection.")
+                                } label: {
+                                    Text("Remove")
+                                }
+                                .font(.caption)
+                            }
                         }
                     }
                 }
@@ -912,6 +947,23 @@ struct BuddyView: View {
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(BMOButtonStyle(isPrimary: false))
+    }
+
+    private func persistBuddyStateReceipt(_ summary: String) {
+        let active = store.activeBuddy?.name ?? "No active buddy"
+        let latestBattle = store.battleHistory.first?.summary ?? "No battles yet."
+        let markdown = """
+        # Buddy State
+
+        - Active buddy: \(active)
+        - Collection count: \(store.collection.count)
+        - Last update: \(summary)
+        - Latest battle: \(latestBattle)
+
+        Buddy state is tied to the current OpenClaw agent profile signature:
+        `\(profileID)`
+        """
+        lastReceipt = appState.writeWorkspaceArtifact(path: "state/buddy.md", content: markdown)
     }
 }
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
@@ -16,7 +16,7 @@ struct ChatView: View {
                                     .id(message.id)
                             }
 
-                            ForEach(appState.workspaceRuntime.recentActions.prefix(3)) { action in
+                            ForEach(chatScopedActions) { action in
                                 ActionRecordCard(action: action)
                             }
 
@@ -168,6 +168,13 @@ struct ChatView: View {
         !appState.chatStore.isGenerating &&
         !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         (appState.selectedProviderAccount != nil || (appState.selectedInstalledModel != nil && !appState.usesStubRuntime))
+    }
+
+    private var chatScopedActions: [OpenClawActionRecord] {
+        appState.workspaceRuntime.recentActions
+            .filter { $0.source == "chat" || $0.source == "assistant" }
+            .prefix(3)
+            .map { $0 }
     }
 
     private var statusLine: String {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/FilesView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/FilesView.swift
@@ -4,6 +4,9 @@ import UniformTypeIdentifiers
 struct FilesView: View {
     @EnvironmentObject private var appState: AppState
     @State private var isImporterPresented = false
+    @State private var isCreatePresented = false
+    @State private var newFilename = "notes.md"
+    @State private var selectedFile: WorkspaceFile?
 
     var body: some View {
         NavigationStack {
@@ -25,10 +28,18 @@ struct FilesView: View {
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
-                        isImporterPresented = true
+                        isCreatePresented = true
                     } label: {
                         Image(systemName: "plus.circle.fill")
                             .foregroundColor(BMOTheme.accent)
+                    }
+                }
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        isImporterPresented = true
+                    } label: {
+                        Image(systemName: "square.and.arrow.down")
+                            .foregroundColor(BMOTheme.textSecondary)
                     }
                 }
             }
@@ -55,6 +66,35 @@ struct FilesView: View {
             } message: {
                 Text(appState.workspaceStore.errorMessage ?? "Unknown error")
             }
+            .sheet(isPresented: $isCreatePresented) {
+                NavigationStack {
+                    Form {
+                        Section("New workspace file") {
+                            TextField("Filename", text: $newFilename)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                            Text("Creates a real file in the Files workspace. Markdown, text, JSON, and source files can be edited after creation.")
+                                .font(.caption)
+                                .foregroundColor(BMOTheme.textTertiary)
+                        }
+                    }
+                    .navigationTitle("Create File")
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { isCreatePresented = false }
+                        }
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Create") {
+                                appState.workspaceStore.createFile(named: newFilename, content: "# \(newFilename)\n\n")
+                                isCreatePresented = false
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationDestination(item: $selectedFile) { file in
+                WorkspaceFileEditorView(file: file)
+            }
         }
     }
 
@@ -74,10 +114,17 @@ struct FilesView: View {
                 .foregroundColor(BMOTheme.textSecondary)
                 .multilineTextAlignment(.center)
 
-            Button("Import Files") {
-                isImporterPresented = true
+            HStack {
+                Button("Create File") {
+                    isCreatePresented = true
+                }
+                .buttonStyle(BMOButtonStyle())
+
+                Button("Import") {
+                    isImporterPresented = true
+                }
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
             }
-            .buttonStyle(BMOButtonStyle())
             .padding(.top, BMOTheme.spacingSM)
         }
     }
@@ -107,11 +154,16 @@ struct FilesView: View {
             }
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(file.filename)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundColor(BMOTheme.textPrimary)
-                    .lineLimit(1)
+                Button {
+                    selectedFile = file
+                } label: {
+                    Text(file.filename)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(BMOTheme.textPrimary)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
                 Text(file.ext.uppercased())
                     .font(.caption2)
                     .foregroundColor(BMOTheme.textTertiary)
@@ -139,6 +191,12 @@ struct FilesView: View {
                     .font(.subheadline)
                     .foregroundColor(BMOTheme.error.opacity(0.6))
             }
+
+            ShareLink(item: file.localURL) {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.subheadline)
+                    .foregroundColor(BMOTheme.textTertiary)
+            }
         }
         .bmoCard()
     }
@@ -155,6 +213,71 @@ struct FilesView: View {
             return "tablecells"
         default:
             return "doc"
+        }
+    }
+}
+
+struct WorkspaceFileEditorView: View {
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+    let file: WorkspaceFile
+    @State private var text = ""
+    @State private var isLoaded = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if file.isTextLike {
+                TextEditor(text: $text)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundColor(BMOTheme.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .background(BMOTheme.backgroundPrimary)
+                    .padding(BMOTheme.spacingMD)
+            } else {
+                VStack(spacing: BMOTheme.spacingMD) {
+                    Image(systemName: "doc.fill")
+                        .font(.system(size: 44))
+                        .foregroundColor(BMOTheme.textTertiary)
+                    Text("This file is not editable as text.")
+                        .foregroundColor(BMOTheme.textSecondary)
+                    ShareLink(item: file.localURL) {
+                        Label("Export File", systemImage: "square.and.arrow.up")
+                    }
+                    .buttonStyle(BMOButtonStyle())
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(BMOTheme.backgroundPrimary)
+            }
+        }
+        .navigationTitle(file.filename)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                ShareLink(item: file.localURL) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                if file.isTextLike {
+                    Button("Save") {
+                        appState.workspaceStore.saveText(text, for: file)
+                    }
+                    .foregroundColor(BMOTheme.accent)
+                }
+            }
+            ToolbarItem(placement: .bottomBar) {
+                Button(role: .destructive) {
+                    appState.workspaceStore.delete(file)
+                    dismiss()
+                } label: {
+                    Label("Delete File", systemImage: "trash")
+                }
+            }
+        }
+        .onAppear {
+            guard !isLoaded else { return }
+            text = appState.workspaceStore.readText(for: file)
+            isLoaded = true
         }
     }
 }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
@@ -3,12 +3,18 @@ import SwiftUI
 struct MissionControlView: View {
     @EnvironmentObject private var appState: AppState
     @State private var selectedSurface: RepoSurface?
+    @State private var lastReceipt: OpenClawReceipt?
+    @State private var sandboxCommand = "ls"
 
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: BMOTheme.spacingMD) {
                     headerCard
+                    if let lastReceipt {
+                        ActionReceiptCard(receipt: lastReceipt)
+                    }
+                    openClawDashboardCard
                     stackContractCard
                     routeCard
                     metricsCard
@@ -54,6 +60,59 @@ struct MissionControlView: View {
             Text(appState.operatorSummary)
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
+        }
+        .bmoCard()
+    }
+
+    private var openClawDashboardCard: some View {
+        let status = appState.buddyRuntimeStatus
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("OpenClaw Dashboard")
+                        .font(.headline)
+                        .foregroundColor(BMOTheme.textPrimary)
+                    Text("One view for route, runtime, artifacts, skills, files, and receipts.")
+                        .font(.caption)
+                        .foregroundColor(BMOTheme.textSecondary)
+                }
+                Spacer()
+                StatusBadge(label: status.runtimeAvailable ? "Online" : "Needs setup", color: status.runtimeAvailable ? BMOTheme.success : BMOTheme.warning)
+            }
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                dashboardMetric("Artifacts", value: "\(appState.workspaceRuntime.artifacts.count)", icon: "doc.richtext")
+                dashboardMetric("Skills", value: "\(appState.workspaceRuntime.skills.count)", icon: "sparkles.rectangle.stack")
+                dashboardMetric("Files", value: "\(appState.workspaceStore.files.count)", icon: "folder")
+                dashboardMetric("Failures", value: "\(status.failedActions.count)", icon: "exclamationmark.triangle")
+            }
+
+            HStack(spacing: 8) {
+                Button("Regenerate Core") {
+                    lastReceipt = appState.regenerateArtifacts(target: "all")
+                }
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+
+                Button("Open Skills") {
+                    appState.selectedTab = .skills
+                }
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+            }
+
+            HStack(spacing: 8) {
+                TextField("Sandbox command", text: $sandboxCommand)
+                    .textFieldStyle(.plain)
+                    .foregroundColor(BMOTheme.textPrimary)
+                    .padding(10)
+                    .background(BMOTheme.backgroundSecondary)
+                    .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusSmall, style: .continuous))
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                Button("Run") {
+                    lastReceipt = appState.runSandbox(command: sandboxCommand)
+                }
+                .buttonStyle(BMOButtonStyle())
+            }
         }
         .bmoCard()
     }
@@ -195,5 +254,25 @@ struct MissionControlView: View {
                 .foregroundColor(BMOTheme.textPrimary)
         }
         .font(.caption)
+    }
+
+    private func dashboardMetric(_ label: String, value: String, icon: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .foregroundColor(BMOTheme.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.caption2)
+                    .foregroundColor(BMOTheme.textTertiary)
+                Text(value)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(BMOTheme.textPrimary)
+            }
+            Spacer()
+        }
+        .padding(10)
+        .background(BMOTheme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusSmall, style: .continuous))
     }
 }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
@@ -14,6 +14,8 @@ struct SkillsView: View {
                         ActionReceiptCard(receipt: lastReceipt)
                     }
 
+                    clawHubCard
+
                     ForEach(appState.workspaceRuntime.skills) { skill in
                         skillCard(skill)
                     }
@@ -104,7 +106,7 @@ struct SkillsView: View {
                 .buttonStyle(BMOButtonStyle())
             } else {
                 Button {
-                    let input = skill.id == BuiltInSkillRegistry.artifactRebuilderID ? ["target": "all"] : [:]
+                    let input = skill.id == BuiltInSkillRegistry.artifactRebuilderID ? ["target": "all"] : ["request": "Run \(skill.name) from Skills."]
                     lastReceipt = appState.runSkill(id: skill.id, input: input)
                 } label: {
                     HStack {
@@ -114,6 +116,48 @@ struct SkillsView: View {
                     .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(BMOButtonStyle(isPrimary: false))
+            }
+        }
+        .bmoCard()
+    }
+
+    private var clawHubCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("ClawHub")
+                        .font(.headline)
+                        .foregroundColor(BMOTheme.textPrimary)
+                    Text("Install starter skills into `.openclaw/registry/skills.json` with real README and manifest artifacts.")
+                        .font(.caption)
+                        .foregroundColor(BMOTheme.textSecondary)
+                }
+                Spacer()
+                StatusBadge(label: "Local", color: BMOTheme.success)
+            }
+
+            ForEach(ClawHubCatalog.templates) { template in
+                let installed = appState.workspaceRuntime.skills.contains(where: { $0.id == template.id })
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: template.systemImage)
+                        .foregroundColor(BMOTheme.accent)
+                        .frame(width: 24)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(template.name)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .foregroundColor(BMOTheme.textPrimary)
+                        Text(template.description)
+                            .font(.caption)
+                            .foregroundColor(BMOTheme.textSecondary)
+                    }
+                    Spacer()
+                    Button(installed ? "Installed" : "Install") {
+                        lastReceipt = appState.installClawHubSkill(template)
+                    }
+                    .disabled(installed)
+                    .buttonStyle(.bordered)
+                }
             }
         }
         .bmoCard()
@@ -211,6 +255,26 @@ struct PokemonTeamBuilderView: View {
             Text("Open Artifacts to inspect the saved JSON and Markdown team files.")
                 .font(.caption)
                 .foregroundColor(BMOTheme.textTertiary)
+            if let strategy = receipt?.output["strategy"] {
+                Divider().overlay(BMOTheme.divider)
+                Text("Battle strategy")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(BMOTheme.textPrimary)
+                Text(strategy)
+                    .font(.caption)
+                    .foregroundColor(BMOTheme.textSecondary)
+            }
+            if let rationale = receipt?.output["rationale"] {
+                Divider().overlay(BMOTheme.divider)
+                Text("Why these picks")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(BMOTheme.textPrimary)
+                Text(rationale)
+                    .font(.caption)
+                    .foregroundColor(BMOTheme.textSecondary)
+            }
         }
         .bmoCard()
     }

--- a/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
+++ b/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
@@ -96,9 +96,9 @@ final class AppStateRuntimeTests: XCTestCase {
         appState.setSelectedProvider(.openAI)
 
         XCTAssertEqual(appState.activeRouteModeLabel, "Direct cloud model route")
-        XCTAssertTrue(appState.operatorSummary.contains("routed directly through OpenAI"))
-        XCTAssertTrue(appState.operatorSummary.contains("Gateway tools still require"))
-        XCTAssertTrue(appState.routeHealthSummary.contains("Direct cloud chat is ready"))
+        XCTAssertTrue(appState.operatorSummary.contains("routed through OpenAI"))
+        XCTAssertTrue(appState.operatorSummary.contains("Workspace actions use the built-in OpenClaw runtime"))
+        XCTAssertTrue(appState.routeHealthSummary.contains("Cloud chat is ready"))
     }
 
     func testCloudSystemPromptDoesNotConfineAgentToAppOnly() {
@@ -116,8 +116,24 @@ final class AppStateRuntimeTests: XCTestCase {
 
         XCTAssertTrue(prompt.contains("not confined to the iOS app"))
         XCTAssertTrue(prompt.contains("full OpenClaw/operator context"))
-        XCTAssertTrue(prompt.contains("does not by itself grant direct device control"))
+        XCTAssertTrue(prompt.contains("Workspace Runtime receipts"))
+        XCTAssertTrue(prompt.contains("Do not reveal hidden reasoning"))
         XCTAssertFalse(prompt.contains("only perform functions inside the app"))
+    }
+
+    func testAgentReplySanitizerRemovesThoughtBlocks() {
+        let raw = """
+        <think>
+        private chain of thought
+        </think>
+
+        Here is the actual answer.
+        """
+
+        let cleaned = AgentReplySanitizer.userVisibleAnswer(from: raw)
+
+        XCTAssertEqual(cleaned, "Here is the actual answer.")
+        XCTAssertFalse(cleaned.localizedCaseInsensitiveContains("private chain"))
     }
 
     func testWorkspaceBootstrapCreatesCanonicalOpenClawArtifacts() throws {
@@ -158,8 +174,39 @@ final class AppStateRuntimeTests: XCTestCase {
         XCTAssertEqual(receipt.status, .persisted)
         XCTAssertEqual(receipt.artifacts.count, 2)
         XCTAssertTrue(receipt.output["members"]?.contains("Pikachu") == true)
+        XCTAssertTrue(receipt.output["strategy"]?.contains("Open with") == true)
+        XCTAssertTrue(receipt.output["rationale"]?.contains("Pikachu") == true)
         XCTAssertTrue(receipt.artifacts.allSatisfy { FileManager.default.fileExists(atPath: Paths.openClawDirectory.appendingPathComponent($0).path) })
         XCTAssertTrue(ReceiptFormatter.confirmedSummary(for: receipt).hasPrefix("Persisted:"))
+    }
+
+    func testWorkspaceArtifactsCanBeEditedAndDeletedWithReceipts() throws {
+        let runtime = OpenClawWorkspaceRuntime()
+        runtime.bootstrap(config: .default, preferences: .default, routeSummary: "Route not configured")
+
+        let writeReceipt = try runtime.writeFile("notes/test.md", content: "# Test\n")
+        XCTAssertEqual(writeReceipt.status, .persisted)
+        XCTAssertEqual(try runtime.readFile("notes/test.md"), "# Test\n")
+
+        let deleteReceipt = runtime.deleteFile("notes/test.md")
+        XCTAssertEqual(deleteReceipt.status, .persisted)
+        XCTAssertThrowsError(try runtime.readFile("notes/test.md"))
+    }
+
+    func testClawHubInstallsRegistryBackedSkill() throws {
+        let runtime = OpenClawWorkspaceRuntime()
+        runtime.bootstrap(config: .default, preferences: .default, routeSummary: "Route not configured")
+
+        let template = try XCTUnwrap(ClawHubCatalog.templates.first)
+        let receipt = runtime.installClawHubSkill(template)
+
+        XCTAssertEqual(receipt.status, .persisted)
+        XCTAssertTrue(runtime.skills.contains(where: { $0.id == template.id }))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: Paths.openClawDirectory.appendingPathComponent("skills/\(template.id)/README.md").path))
+
+        let runReceipt = runtime.runSkill(id: template.id, input: ["request": "coach me"], config: .default, preferences: .default, routeSummary: "Route not configured")
+        XCTAssertEqual(runReceipt.status, .persisted)
+        XCTAssertFalse(runReceipt.artifacts.isEmpty)
     }
 
     func testSandboxRejectsUnsupportedShellWithoutFakeCompletion() {

--- a/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
+++ b/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
@@ -151,6 +151,11 @@ final class AppStateRuntimeTests: XCTestCase {
 
         let soul = try runtime.readFile("soul.md")
         XCTAssertTrue(soul.contains("one agent, one workspace"))
+        let skillsMarkdown = try runtime.readFile("skills.md")
+        XCTAssertTrue(skillsMarkdown.contains("## Installed skills"))
+        XCTAssertTrue(skillsMarkdown.contains("## ClawHub starters"))
+        XCTAssertTrue(skillsMarkdown.contains("File Crafter"))
+        XCTAssertTrue(skillsMarkdown.contains("Chat should not treat old skill artifacts as active context"))
         XCTAssertTrue(runtime.skills.contains(where: { $0.id == BuiltInSkillRegistry.pokemonTeamBuilderID }))
     }
 
@@ -198,6 +203,7 @@ final class AppStateRuntimeTests: XCTestCase {
         runtime.bootstrap(config: .default, preferences: .default, routeSummary: "Route not configured")
 
         let template = try XCTUnwrap(ClawHubCatalog.templates.first)
+        XCTAssertGreaterThanOrEqual(ClawHubCatalog.templates.count, 8)
         let receipt = runtime.installClawHubSkill(template)
 
         XCTAssertEqual(receipt.status, .persisted)

--- a/context/RUNBOOK.md
+++ b/context/RUNBOOK.md
@@ -7,6 +7,7 @@
 - `prismtek-site` owns the public `prismtek.dev` Cloudflare Pages surface.
 - `context/` is the canonical repo context.
 - `openshell sandbox list` is the live sandbox truth when available.
+- MacBook OpenClaw runtime state under `~/.openclaw` and the iOS app's app-container `.openclaw` workspace are separate by default. Connect them only through an explicit gateway, pairing, or export/import path.
 
 ## Restart recovery protocol
 
@@ -88,6 +89,8 @@ Run these before ad hoc debugging when they fit:
 4. `make workspace-sync`
 5. `make site-caretaker`
 6. `make worker-ready`
+
+Use `make openclaw-boundary-doctor` when checking that the MacBook OpenClaw runtime remains isolated from the iOS app sandbox. Use `make openclaw-host-policy` to reapply the Telegram delivery policy that collects up to 20 inbound messages into one turn and avoids tiny outbound chunks.
 
 `make worker-ready` changes sandbox state, so prefer it after the status and routing checks above.
 

--- a/context/SESSION_STATE.md
+++ b/context/SESSION_STATE.md
@@ -12,6 +12,8 @@ Important decisions:
 3. Context should not live only inside the sandbox.
 4. Share project files, not live runtime state.
 5. Prefer one-message replies unless asked otherwise.
+6. The iOS app's `.openclaw` workspace is app-container state, not the MacBook `~/.openclaw` runtime. The two should connect only through an explicit gateway, pairing, or export/import path.
+7. Telegram delivery should collect up to 20 inbound messages into one agent turn, then deliver the answer in the fewest platform-safe chunks.
 
 Restart recovery:
 - Authoritative startup sequence is in `context/RUNBOOK.md`, Restart Recovery Protocol.

--- a/docs/OPENCLAW_HOST_BOUNDARY.md
+++ b/docs/OPENCLAW_HOST_BOUNDARY.md
@@ -1,0 +1,46 @@
+# OpenClaw Host Boundary
+
+This repo tracks the desired operator contract for Cody's MacBook OpenClaw setup. The iOS app is a separate sandboxed client.
+
+## Boundary
+
+- Mac OpenClaw runtime state lives under `~/.openclaw`.
+- The iOS app workspace lives inside the app container at `Documents/OpenClawWorkspace/.openclaw`.
+- `bmo-stack` source files are the durable policy and automation source of truth.
+- The app must not read or write the Mac's `~/.openclaw` files directly.
+- The Mac runtime and app may interact only through an explicitly configured gateway, pairing, or manual export/import flow.
+
+## Current Host Delivery Policy
+
+Telegram should prefer one coherent answer. It should not stream lots of small paragraph-sized messages just because the model emits paragraphs.
+
+Host policy:
+
+- collect up to 20 inbound user messages into one agent turn before summarizing overflow
+- keep Telegram reply threading on the first delivered chunk only
+- use length-based outbound chunking
+- coalesce block-streamed replies into near-Telegram-limit chunks
+
+Apply it with:
+
+```sh
+make openclaw-host-policy
+```
+
+Verify the host/app boundary with:
+
+```sh
+make openclaw-boundary-doctor
+```
+
+## Expected Good State
+
+- gateway config is local/loopback
+- gateway listens on `127.0.0.1:18789`
+- Telegram is bound to the host-facing `main` agent
+- iOS source contains no direct `~/.openclaw` references
+- the iOS app uses its own app-container `.openclaw` workspace
+
+## Important Caveat
+
+The OpenClaw CLI is the live owner for runtime delivery behavior. If a repo-side check passes but Telegram delivery still behaves incorrectly, continue in the live `openclaw` owner path and treat this repo as the policy/automation source, not proof that the live channel changed.

--- a/scripts/apply-openclaw-host-policy.py
+++ b/scripts/apply-openclaw-host-policy.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Apply BMO's host OpenClaw delivery policy without printing secrets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, data: dict) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+    path.chmod(0o600)
+
+
+def apply_policy(data: dict) -> dict:
+    messages = data.setdefault("messages", {})
+    queue = messages.setdefault("queue", {})
+    queue["mode"] = "collect"
+    queue["debounceMs"] = 900
+    queue["cap"] = 20
+    queue["drop"] = "summarize"
+    queue.setdefault("byChannel", {})["telegram"] = "collect"
+
+    inbound = messages.setdefault("inbound", {})
+    inbound["debounceMs"] = 1200
+    inbound.setdefault("byChannel", {})["telegram"] = 1200
+
+    channels = data.setdefault("channels", {})
+    telegram = channels.setdefault("telegram", {})
+    telegram["replyToMode"] = "first"
+    telegram["textChunkLimit"] = 4000
+    telegram["chunkMode"] = "length"
+
+    streaming = telegram.setdefault("streaming", {})
+    streaming["mode"] = "block"
+    streaming["chunkMode"] = "length"
+    block = streaming.setdefault("block", {})
+    coalesce = block.setdefault("coalesce", {})
+    coalesce["minChars"] = 3200
+    coalesce["maxChars"] = 3900
+    coalesce["idleMs"] = 2500
+
+    gateway = data.setdefault("gateway", {})
+    gateway.setdefault("mode", "local")
+    gateway.setdefault("bind", "loopback")
+    gateway.setdefault("port", 18789)
+
+    return data
+
+
+def summary(data: dict) -> dict:
+    telegram = data.get("channels", {}).get("telegram", {})
+    streaming = telegram.get("streaming", {})
+    return {
+        "gateway": {
+            "mode": data.get("gateway", {}).get("mode"),
+            "bind": data.get("gateway", {}).get("bind"),
+            "port": data.get("gateway", {}).get("port"),
+        },
+        "messages": {
+            "queueMode": data.get("messages", {}).get("queue", {}).get("mode"),
+            "queueCap": data.get("messages", {}).get("queue", {}).get("cap"),
+            "telegramInboundDebounceMs": data.get("messages", {}).get("inbound", {}).get("byChannel", {}).get("telegram"),
+        },
+        "telegramDelivery": {
+            "replyToMode": telegram.get("replyToMode"),
+            "textChunkLimit": telegram.get("textChunkLimit"),
+            "chunkMode": telegram.get("chunkMode"),
+            "streamingMode": streaming.get("mode"),
+            "streamingChunkMode": streaming.get("chunkMode"),
+            "coalesce": streaming.get("block", {}).get("coalesce", {}),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=os.path.expanduser("~/.openclaw/openclaw.json"),
+        help="OpenClaw config path. Defaults to ~/.openclaw/openclaw.json.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print the intended non-secret summary without writing.")
+    args = parser.parse_args()
+
+    path = Path(args.config).expanduser()
+    if not path.exists():
+        raise SystemExit(f"OpenClaw config not found: {path}")
+
+    data = apply_policy(load_json(path))
+    if args.dry_run:
+        print(json.dumps(summary(data), indent=2))
+        return 0
+
+    backup = path.with_name(f"{path.name}.pre-bmo-host-policy-{time.strftime('%Y%m%d-%H%M%S')}")
+    shutil.copy2(path, backup)
+    write_json(path, data)
+    print(f"updated {path}")
+    print(f"backup {backup}")
+    print(json.dumps(summary(data), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/openclaw-boundary-doctor.py
+++ b/scripts/openclaw-boundary-doctor.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Verify the Mac OpenClaw runtime is separate from the iOS app sandbox."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "apps" / "openclaw-shell-ios" / "OpenClawShell"
+CONFIG_PATH = Path(os.path.expanduser("~/.openclaw/openclaw.json"))
+
+
+def status(ok: bool, label: str, detail: str) -> bool:
+    marker = "PASS" if ok else "FAIL"
+    print(f"[{marker}] {label}: {detail}")
+    return ok
+
+
+def load_config() -> dict:
+    if not CONFIG_PATH.exists():
+        return {}
+    with CONFIG_PATH.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def port_listens(host: str, port: int) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+def app_mentions_host_openclaw() -> list[str]:
+    needles = ("~/.openclaw", "$HOME/.openclaw", "/Users/prismtek/.openclaw", "/.openclaw/workspace")
+    matches: list[str] = []
+    for path in APP_ROOT.rglob("*.swift"):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for needle in needles:
+            if needle in text:
+                matches.append(f"{path.relative_to(REPO_ROOT)} contains {needle}")
+    return matches
+
+
+def main() -> int:
+    failures = 0
+    config = load_config()
+    gateway = config.get("gateway", {})
+    telegram = config.get("channels", {}).get("telegram", {})
+    messages = config.get("messages", {})
+
+    failures += not status(CONFIG_PATH.exists(), "host config", str(CONFIG_PATH))
+
+    bind = gateway.get("bind")
+    mode = gateway.get("mode")
+    port = int(gateway.get("port") or 18789)
+    local_bind = bind in {"loopback", "127.0.0.1", "localhost"} and mode in {"local", None}
+    failures += not status(local_bind, "gateway exposure", f"mode={mode!r}, bind={bind!r}, port={port}")
+    failures += not status(port_listens("127.0.0.1", port), "gateway listener", f"127.0.0.1:{port}")
+
+    runtime_services = APP_ROOT / "RuntimeServices.swift"
+    runtime_text = runtime_services.read_text(encoding="utf-8", errors="ignore") if runtime_services.exists() else ""
+    app_uses_container = "documentsDirectory.appendingPathComponent(\"OpenClawWorkspace\"" in runtime_text
+    app_uses_local_openclaw = "workspaceDirectory.appendingPathComponent(\".openclaw\"" in runtime_text
+    failures += not status(app_uses_container and app_uses_local_openclaw, "iOS sandbox", "uses app Documents/OpenClawWorkspace/.openclaw")
+
+    host_mentions = app_mentions_host_openclaw()
+    failures += not status(not host_mentions, "iOS host isolation", "no direct ~/.openclaw references" if not host_mentions else "; ".join(host_mentions))
+
+    queue = messages.get("queue", {})
+    coalesce = telegram.get("streaming", {}).get("block", {}).get("coalesce", {})
+    delivery_ok = (
+        queue.get("mode") == "collect"
+        and queue.get("cap") == 20
+        and telegram.get("textChunkLimit") == 4000
+        and telegram.get("chunkMode") == "length"
+        and telegram.get("streaming", {}).get("chunkMode") == "length"
+        and coalesce.get("maxChars", 0) >= 3900
+    )
+    failures += not status(
+        delivery_ok,
+        "Telegram delivery policy",
+        f"queueCap={queue.get('cap')}, textChunkLimit={telegram.get('textChunkLimit')}, chunkMode={telegram.get('chunkMode')}, coalesce={coalesce}",
+    )
+
+    print("\nBoundary rule: the iOS app owns its app-container workspace. The Mac OpenClaw runtime owns ~/.openclaw. They meet only through an explicitly configured gateway or export/import path.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Task contract

Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem

Build 17 established the workspace runtime, but several surfaces still felt ornamental: files were mostly import-only, artifacts were read-only, Skills had no install path, Mission Control lacked dashboard actions, Buddy buttons did not surface receipts, and model replies could expose reasoning text.

## Smallest useful wedge

- hide cloud/local model thought-process blocks before replies are rendered in chat
- add real create/edit/export/delete flows for Files and editable/exportable/deletable `.openclaw` artifacts
- add ClawHub starter-skill installs, registry persistence, generic ClawHub skill runs, and richer Pokémon team rationale/strategy output
- make Mission Control more like an OpenClaw dashboard with runtime metrics, artifact regeneration, and sandbox command receipts
- make Buddy actions persist receipt-backed `state/buddy.md`, add removal from the collection, and keep buddy state tied to the agent profile
- bump BeMoreAgent build number to 18 while preserving bundle ID `BeMoreAgent` and iOS target 26.0

## Verification plan

Completed locally:

- `git diff --check`
- `cd apps/openclaw-shell-ios && xcodegen generate`
- `cd apps/openclaw-shell-ios && xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath .build/DerivedData build`
- `cd apps/openclaw-shell-ios && xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath .build/DerivedData build-for-testing`

An actual simulator test launch was attempted against `iPhone 17 Pro`, but the simulator launcher stalled and was stopped after about a minute; Xcode reported `NSMachErrorDomain Code -308` after the process was killed. The test bundle itself builds successfully.

## Rollback plan

Revert commit `c172169` from this branch. The patch is limited to the native iOS shell and status note, and does not change secrets, production infrastructure, or the bundle identifier contract.
