### PR TITLE
docs: add BeMore product direction and Build 18+ planning docs

### DIFF
--- a/context/plans/2026-04-10-bemore-build18-plus-product-direction.md
+++ b/context/plans/2026-04-10-bemore-build18-plus-product-direction.md
@@ -1,0 +1,81 @@
+## Problem
+
+The repo now has a future-facing BeMore product direction, but the current iOS shell owner path and release posture still matter.
+
+The active app path is `apps/openclaw-shell-ios`, and Build 17 is already implemented.
+If future Buddy, workspace, and marketplace work is described as if it belongs inside Build 17, planning will become misleading fast.
+
+## Planning stance
+
+Treat Build 17 as the landed baseline.
+Treat the newly added BeMore product direction as Build 18+ planning unless a later build line becomes the safer delivery target.
+
+## Current owner path
+
+- `apps/openclaw-shell-ios`
+
+## Current baseline
+
+- Build 17 already implemented
+- existing shell surfaces remain the current product baseline
+- docs should not imply that new Buddy Workshop or Council scope belongs in Build 17
+
+## New direction to carry forward
+
+The next product direction should focus on:
+- stronger workspace embodiment
+- evolving markdown memory with Buddy stewardship
+- Council Starter Pack as canonical seed content
+- Buddy Library install flow
+- Buddy Workshop sanitation and sharing foundations
+
+## Smallest useful Build 18 wedge
+
+A good Build 18 candidate should probably focus on a narrow but undeniable slice:
+- workspace runtime strengthening
+- Buddy continuity improvements
+- starter Buddy template model
+- Buddy Library inspect/install flow
+
+Avoid stuffing full creator marketplace scope into the same build unless the implementation is much smaller than expected.
+
+## Scope guardrails
+
+### Good Build 18 scope
+- real workspace capability expansion
+- Buddy state stewardship improvements
+- starter template install flow
+- local clean-copy derivation
+- markdown memory evolution improvements
+
+### Probably later than Build 18
+- full creator payouts
+- complex moderation queue tooling
+- disputes and refund handling
+- advanced licensing matrix UX
+- creator subscriptions
+- business pack commerce
+
+## Files added for planning posture
+
+- `docs/BEMORE_PRODUCT_VISION.md`
+- `docs/BEMORE_PHASED_ROADMAP.md`
+- `docs/BUDDY_WORKSHOP_SPEC.md`
+- `docs/COUNCIL_STARTER_PACK.md`
+- `docs/CODEX_IMPLEMENTATION_PROMPT_BEMORE.md`
+- `docs/BEMORE_BUILD18_PLUS_DELIVERY_POSTURE.md`
+
+## Recommended next repo actions
+
+1. keep these docs as planning references only
+2. break Build 18 into issue-sized wedges under `docs/planning/issue-drafts/`
+3. open a focused PR against the future build line as docs-only product direction
+4. keep app-path references anchored to `apps/openclaw-shell-ios` until a real repo rename happens
+
+## Rollback posture
+
+If any of the new docs create confusion, the correct rollback is not to abandon the product direction.
+It is to narrow or clarify the build targeting language so the repo stays honest about:
+- current baseline
+- current owner path
+- next delivery build

--- a/docs/BEMORE_BUILD18_PLUS_DELIVERY_POSTURE.md
+++ b/docs/BEMORE_BUILD18_PLUS_DELIVERY_POSTURE.md
@@ -1,0 +1,79 @@
+# BeMore Build 18+ Delivery Posture
+
+## Why this exists
+
+Recent product-direction docs on this branch introduce future-facing BeMore work:
+- workspace runtime expansion
+- Buddy stewardship and evolving memory
+- Council Starter Pack
+- Buddy Workshop template and marketplace foundations
+
+Those additions must be read against the current delivery reality in this repo.
+
+## Current owner path
+
+The current iOS shell owner path in this repo is:
+- `apps/openclaw-shell-ios`
+
+The current product shell README already positions this app as the BeMoreAgent iOS Shell.
+
+## Current baseline
+
+Build 17 is already implemented.
+
+Treat Build 17 as the shipped or already-landed baseline for current shell/runtime work.
+Do **not** frame new Buddy Workshop, Council Starter Pack, or broader workspace expansion work as something that should be retrofitted into Build 17.
+
+## Planning rule
+
+Anything newly proposed from the BeMore product-direction docs should be treated as:
+- Build 18 work
+- or later than Build 18 if sequencing, runtime risk, or store/release posture requires it
+
+## Branch posture
+
+A recent relevant implementation lane is:
+- `fix/openclaw-build17-workspace-runtime`
+
+Use that as historical and structural context only.
+Do not treat it as the branch where future Buddy Workshop or post-Build-17 scope should be forced.
+
+## Practical interpretation
+
+### Build 17 owns
+- the current implemented shell baseline
+- current runtime and workspace work already completed for that build line
+- the already-landed product shell posture for `apps/openclaw-shell-ios`
+
+### Build 18+ should own
+- future workspace/runtime expansion beyond Build 17
+- Buddy stewardship improvements beyond the current shell baseline
+- Council Starter Pack installable template system
+- Buddy Library and Buddy Workshop foundations
+- sanitation and publishing foundations for Buddy Templates
+- marketplace, creator, and monetization systems
+
+## How to use the new docs safely
+
+When reading these docs:
+- `docs/BEMORE_PRODUCT_VISION.md`
+- `docs/BEMORE_PHASED_ROADMAP.md`
+- `docs/BUDDY_WORKSHOP_SPEC.md`
+- `docs/COUNCIL_STARTER_PACK.md`
+- `docs/CODEX_IMPLEMENTATION_PROMPT_BEMORE.md`
+
+interpret them as:
+- product direction
+- Build 18+ planning
+- issue-draft and implementation input
+
+not as a claim that this scope belongs in Build 17.
+
+## Strong recommendation
+
+For future implementation planning, use this sequence:
+1. treat Build 17 as the baseline
+2. define Build 18 as the first Buddy/workspace/memory expansion candidate
+3. break marketplace scope into later follow-on work if Build 18 would become too broad
+
+That keeps the repo honest and avoids back-porting future product ideas into an already-implemented build line.

--- a/docs/BEMORE_BUILD_FILTERS.md
+++ b/docs/BEMORE_BUILD_FILTERS.md
@@ -1,0 +1,217 @@
+# BeMore Build Filters
+
+## Purpose
+
+Turn `AGENT_SYSTEM_BENCHMARK_GRID.md` into a practical prioritization filter for roadmap and implementation decisions.
+
+Use this before approving a major feature, build target, or product pivot.
+
+## Product target
+
+BeMore should feel like:
+
+> Perplexity-level trust and clarity  
+> plus Hermes-level runtime embodiment  
+> plus a Buddy/council system neither of them owns.
+
+## Must not lose
+
+BeMore must not lose on:
+- trust
+- clarity
+- speed to first useful result
+- honest execution semantics
+
+Even if BeMore goes deeper than Perplexity or more emotional than Hermes, it cannot feel slower, fuzzier, or less trustworthy than simpler products.
+
+## Comparative product filters
+
+### What to steal from Hermes Agent
+- real runtime depth
+- file-based persistent memory
+- durable skills
+- delegation and subagents
+- multiple execution backends
+- context files as working surface
+
+### What to steal from Perplexity
+- legible product loop
+- fast grounded answers
+- citation clarity
+- source visibility
+- trust-forward presentation
+- simple mental model
+
+### What BeMore must add that neither owns
+- Buddy identity and progression
+- living markdown memory as a first-class feature
+- Buddy stewardship of memory and state
+- councils / team Buddies
+- daily-life assistant usefulness
+- mobile-first workspace embodiment
+
+## Scoring filters for major features
+
+Score each proposed feature from 0 to 2 on each axis.
+
+- **0** = does not help
+- **1** = helps somewhat
+- **2** = strongly helps
+
+### A. Trust
+Does this make the product easier to trust?
+Examples:
+- citations
+- receipts
+- visible sources
+- explicit state changes
+- honest status reporting
+
+### B. Clarity
+Does this make the product easier to understand?
+Examples:
+- simpler flow
+- fewer ambiguous labels
+- cleaner user model
+- better explanation of what happened
+
+### C. Embodiment
+Does this make the agent more real?
+Examples:
+- file access
+- command execution
+- diffs
+- task results
+- process visibility
+
+### D. Living memory
+Does this make memory more durable, legible, and useful?
+Examples:
+- markdown regeneration
+- Buddy memory summaries
+- current priorities
+- durable preferences
+
+### E. Daily usefulness
+Does this help the app earn a place in everyday life?
+Examples:
+- briefing
+- reminders
+- note capture
+- routines
+- drafts
+- today view
+
+### F. Buddy differentiation
+Does this strengthen what only BeMore can own?
+Examples:
+- Buddy identity
+- growth
+- stewardship
+- councils
+- Buddy templates
+
+### G. Simplicity of feel
+Even if the internals are deeper, does the feature keep the outer product loop simple?
+
+## Shipping rule
+
+A major feature should usually score well in at least two of these three buckets:
+- trust / clarity
+- embodiment / living memory
+- daily usefulness / Buddy differentiation
+
+If it scores high only on technical cleverness, it is probably not ready.
+
+## Product legibility filter
+
+Ask this explicitly:
+
+**Will a new user understand what this feature is for within one session?**
+
+If no, the feature likely needs one of:
+- narrower scope
+- better naming
+- clearer placement
+- later sequencing
+
+## Failure mode guardrails
+
+### If BeMore over-indexes on Hermes
+You get:
+- too much infra language
+- too much visible complexity
+- a dev tool first, product second feel
+- runtime depth without enough trust presentation
+
+### If BeMore over-indexes on Perplexity
+You get:
+- a search/summarization app with weak embodiment
+- Buddy system that feels decorative
+- shallow memory
+- low emotional stickiness
+
+### Correct balance
+Aim for:
+- simple outer loop
+- deep inner runtime
+- trustworthy answers
+- real memory
+- real action
+- distinctive Buddy system
+
+## Build-stage filters
+
+### P0 filters
+Ship only if it improves one or more of:
+- workspace embodiment
+- receipts/results
+- no fake completion claims
+- file/edit/save/run loop
+
+### P1 filters
+Ship if it improves:
+- living markdown memory
+- Buddy memory stewardship
+- search grounding
+- citation trust
+
+### P2 filters
+Ship if it improves:
+- daily assistant usefulness
+- routines
+- App Intents / briefings / personal workflows
+- Buddy training and specialization
+
+### P3 filters
+Ship if it improves:
+- councils / teams
+- Buddy Workshop
+- creator templates
+- economy or progression systems
+
+## Decision questions before approval
+
+Before approving a major feature, ask:
+- Does this improve trust?
+- Does this improve embodiment?
+- Does this improve living memory?
+- Does this improve daily usefulness?
+- Does this improve Buddy differentiation?
+- Does this make the product simpler or more confusing?
+- Is this Build 17 baseline work, or truly Build 18+ work?
+
+## Kill criteria
+
+A feature should be delayed, narrowed, or rejected if:
+- it mostly adds complexity without trust gains
+- it weakens product legibility
+- it duplicates what another repo already owns
+- it belongs to a later build stage
+- it makes Buddy feel ornamental instead of core
+
+## One-line decision rule
+
+If a feature makes BeMore feel more trustworthy, more embodied, more useful every day, and more uniquely Buddy-shaped, it is probably good.
+
+If it only makes the system more clever, it is probably not ready.

--- a/docs/BEMORE_PHASED_ROADMAP.md
+++ b/docs/BEMORE_PHASED_ROADMAP.md
@@ -1,0 +1,173 @@
+# BeMore Phased Roadmap
+
+## Roadmap rule
+
+Ship the body first, then the continuity layer, then the ecosystem, then the economy.
+
+Do not invert this order.
+A paid marketplace on top of a weak workspace or fake memory layer will feel hollow fast.
+
+## Phase 1 — Core embodiment and continuity
+
+### Goal
+Prove that BeMore is a real agent system, not just smart chat.
+
+### Ship
+- Agent Workspace surface
+- workspace runtime contract
+- file browser
+- editor and save flow
+- command and process execution
+- results and receipts
+- diff and review surfaces
+- task and subtask flow
+- evolving markdown memory
+- Buddy as continuity steward
+- no fake completion semantics
+
+### Exit criteria
+A user can:
+- browse files
+- open and edit a file
+- save changes
+- run a command
+- inspect stdout and stderr
+- review diffs
+- run a subtask
+- see Buddy report what changed in state
+
+## Phase 2 — Council Starter Pack and Buddy Library
+
+### Goal
+Make onboarding concrete, useful, and characterful.
+
+### Ship
+- canonical 12-member Council Starter Pack
+- starter Buddy install flow
+- Help Me Choose flow
+- custom Buddy creation
+- Buddy profile pages
+- starter stats and move sets
+- growth-stage metadata
+- official structured Buddy templates
+
+### Exit criteria
+A new user can install or create a Buddy and immediately understand:
+- what it is for
+- how it behaves
+- what role it plays
+- how it may evolve
+
+## Phase 3 — Daily-life assistant layer
+
+### Goal
+Make BeMore sticky every day, not only when the user opens the workspace.
+
+### Ship
+- morning briefing
+- note capture
+- reminders and tasks
+- schedule and weather summary
+- drafts
+- routines
+- What matters now surface
+- stronger session carry-forward
+- Buddy home surface for active focus and recent changes
+
+### Exit criteria
+A user can rely on BeMore daily without attached compute.
+
+## Phase 4 — Buddy Workshop as library and sharing
+
+### Goal
+Turn Buddies into installable portable artifacts.
+
+### Ship
+- Buddy Workshop browse and discovery
+- official template listings
+- install flow
+- derived-from-template provenance
+- creator draft packaging flow
+- sanitation pipeline
+- validation pipeline
+- visibility modes for private, unlisted, and public free templates
+- ratings and reporting
+- moderation basics
+- no payouts yet
+
+### Exit criteria
+Creators can publish free sanitized templates and users can install them into clean personal copies.
+
+## Phase 5 — Paid official packs and ecosystem growth
+
+### Goal
+Monetize safely before opening creator payouts.
+
+### Ship
+- official premium packs
+- premium council bundles
+- premium cosmetics
+- premium knowledge and skill packs
+- App Store safe purchase flow
+- badges and featured sections
+- stronger trust and moderation tooling
+
+### Exit criteria
+The store generates revenue without yet exposing creator payout complexity.
+
+## Phase 6 — Paid creator marketplace
+
+### Goal
+Open the creator economy after privacy, moderation, and portability are proven.
+
+### Ship
+- creator profiles
+- paid Buddy Templates
+- revenue share
+- license types
+- verified creators
+- review and dispute system
+- refund handling
+- creator analytics
+- moderation strikes and appeals
+
+### Exit criteria
+Paid creator publishing works without privacy bleed or low-trust listings.
+
+## Phase 7 — Advanced marketplace and attached power
+
+### Goal
+Turn BeMore into both a serious personal agent and a creator platform.
+
+### Ship
+- council bundles
+- business packs
+- team templates
+- creator subscriptions
+- seasonal drops
+- attached desktop or VPS execution
+- heavier runtime jobs
+- persistent cloud tasks
+- multi-agent teamwork
+
+### Exit criteria
+BeMore supports both individual daily use and serious power workflows.
+
+## Strong sequencing guidance
+
+If a team must choose one next step, do this order:
+
+1. workspace runtime and honest receipts
+2. evolving markdown memory and Buddy stewardship
+3. official starter Buddy templates
+4. Buddy Library and install flow
+5. sanitation and free sharing foundations
+6. paid creator marketplace later
+
+The product must feel:
+1. real
+2. personal
+3. shareable
+4. monetizable
+
+Not the reverse.

--- a/docs/BEMORE_PRODUCT_VISION.md
+++ b/docs/BEMORE_PRODUCT_VISION.md
@@ -1,0 +1,230 @@
+# BeMore Product Vision
+
+## Repo posture first
+
+`bmo-stack` is still the operator, policy, planning, and integration repository for BMO.
+It does **not** claim to be the sole live owner of every BeMore surface.
+
+This document exists to do two things safely:
+
+1. capture the intended product direction for BeMore and related OpenClaw shell surfaces
+2. keep that direction grounded in the ownership boundaries already defined in `README.md`, `AGENTS.md`, and the runtime docs
+
+Treat this as a product-direction reference and control document, not as a claim that `bmo-stack` alone implements the full product.
+
+## One-line vision
+
+BeMore is a standalone personal agent app for daily life and real work, with a real workspace runtime, living markdown memory, a Buddy system that grows with the user, and a Buddy Workshop where creators can publish, share, install, and later sell portable Buddy Templates.
+
+## Product thesis
+
+Most AI apps still feel temporary.
+They can answer prompts, but they do not maintain continuity, hold readable state, or become more useful over time.
+
+BeMore should feel different in four ways:
+
+1. it helps every day
+2. it can actually do work
+3. it remembers and evolves
+4. it becomes an ecosystem
+
+## Four integrated surfaces
+
+### 1. Daily life assistant
+
+This is the sticky everyday layer.
+
+It should handle:
+- morning briefings
+- reminders
+- tasks
+- notes
+- schedules
+- weather
+- drafts
+- routines
+- personal organization
+
+### 2. Agent workspace
+
+This is the embodiment layer.
+
+It should handle:
+- files
+- editor flows
+- runtime actions
+- command execution
+- results and receipts
+- review and diffs
+- tasks and subtasks
+- coding and creative execution
+
+### 3. Living memory system
+
+This is the continuity layer.
+
+It should handle:
+- evolving markdown artifacts
+- durable preferences
+- current priorities
+- working context
+- change reporting
+- promotion of durable memory from use
+
+Buddy matters only if this layer is real.
+
+### 4. Buddy ecosystem
+
+This is the identity and distribution layer.
+
+It should handle:
+- official starter Buddies
+- custom Buddy creation
+- Council Starter Pack
+- Buddy Templates
+- installs and derivations
+- free community sharing
+- later paid creator marketplace
+- skill packs, knowledge packs, council packs, and cosmetics
+
+## Core pillars
+
+### Standalone first
+
+A new user should get something real without feeling forced into a hosted backend.
+
+Minimum free-path value:
+- one real agent
+- useful memory
+- task help
+- writing and planning support
+- one starter Buddy
+- Buddy personalization
+- basic workspace power
+
+### Workspace gives the product teeth
+
+The workspace is not a side feature.
+It is what upgrades BeMore from assistant to agent.
+
+### Buddy is the continuity layer
+
+Buddy is not just another chat tab.
+Buddy should act as:
+- memory steward
+- explainer of state
+- keeper of current priorities
+- identity anchor
+- change reporter
+- personalization shell
+
+### Markdown memory is real
+
+Canonical artifacts should remain first-class:
+- `.openclaw/soul.md`
+- `.openclaw/user.md`
+- `.openclaw/memory.md`
+- `.openclaw/session.md`
+- `.openclaw/skills.md`
+
+They should be readable, curated, partly user-owned, and regenerated from durable state rather than endless append-only sludge.
+
+### Buddy Templates are portable, not live exports
+
+The marketplace object is a sanitized Buddy Template, not a raw live Buddy.
+
+That protects:
+- privacy
+- compatibility
+- clean installs
+- moderation
+- monetization
+
+### Ecosystem before economy
+
+Launch order should be:
+1. official Buddies and official packs
+2. free community sharing
+3. paid creator marketplace later
+
+## Canonical starter layer
+
+The Council Starter Pack should become the canonical V1 seed roster.
+
+For V1, each starter Buddy should be:
+- a structured template
+- locked initial stats
+- locked initial move set
+- locked initial role and class
+- editable name and nickname
+- later-evolving appearance and growth stage
+
+This gives the product:
+- clearer onboarding
+- stronger identity
+- balancing baselines
+- a future marketplace seed set
+
+## Buddy Workshop positioning
+
+Buddy Workshop lets creators package and share powerful Buddy Templates inside BeMore, so anyone can discover, install, and grow a Buddy built for their daily life or workflow.
+
+Buddy Workshop is not only a store.
+It is also:
+- the discovery layer
+- the creator layer
+- the identity amplifier
+- the future monetization path
+
+## Business model
+
+The cleanest commercial posture is still:
+
+### Keep freedom free
+
+Free or open:
+- app itself
+- local mode
+- BYOK mode
+- self-hosted runtime
+- basic Buddy and memory system
+- one agent
+- starter council access
+
+### Charge for convenience and compute
+
+Paid:
+- hosted model usage
+- managed runtime
+- background runs
+- multi-agent orchestration
+- cloud sync
+- premium models
+- official premium packs
+- premium council bundles
+- premium cosmetics
+- later paid creator templates
+
+## What this repo should own in that story
+
+`bmo-stack` should primarily own:
+- product boundary docs
+- control docs
+- planning artifacts
+- implementation prompts
+- issue drafts
+- policy and sanitization rules
+- canonical council and Buddy contract references
+- integration guidance across repos
+
+It should not pretend that every shipped app surface lives here.
+
+## Strong recommendation
+
+The first real win is not more branding or lore.
+It is one honest vertical slice where all of these are true:
+- the workspace can do real work
+- the memory can evolve
+- Buddy can explain what changed
+- starter Buddies install cleanly from structured templates
+- Buddy Workshop foundations exist without privacy bleed

--- a/docs/BUDDY_WORKSHOP_SPEC.md
+++ b/docs/BUDDY_WORKSHOP_SPEC.md
@@ -1,0 +1,468 @@
+# Buddy Workshop Spec
+
+## Product concept
+
+Buddy Workshop is the in-app library, sharing layer, and later marketplace where users can publish, share, install, and eventually sell Buddy Templates.
+
+The marketplace object is **not** a raw live Buddy.
+It is a sanitized portable Buddy Template that can be installed into another user's account and then personalized there.
+
+## Core safety rule
+
+Never publish live Buddy state.
+
+Publishing must always convert a Buddy into a sanitized template draft.
+This is the most important policy in the whole system.
+
+## What a Buddy Template contains
+
+### Required
+- Buddy name
+- short description
+- category
+- intended use case
+- primary role or class
+- personality profile
+- voice style profile
+- visual archetype
+- color palette
+- body style
+- starter stats
+- starter moves or starter skills
+- growth path metadata
+- recommended user type
+- tags
+- version number
+- creator name or handle
+- cover art, ASCII preview, or pixel preview
+
+### Optional
+- starter routines
+- task recipes
+- workflow suggestions
+- challenge profile
+- recommended council pairings
+- public benchmark results
+- sample outputs
+- premium skin bundle
+- premium skill bundle
+
+### Structured metadata
+Every template should also carry:
+- template_id
+- creator_id
+- created_at
+- updated_at
+- template_version
+- compatibility_version
+- content_rating
+- visibility
+- price
+- license_type
+
+## What must be stripped before publishing
+
+### Always strip
+- private conversation history
+- raw chat logs
+- user-specific memory
+- linked accounts
+- documents uploaded by the creator
+- email, text, and calendar contents
+- private creator notes
+- secret prompts containing private information
+- API keys, tokens, and credentials
+- hidden task history tied to the creator
+- private markdown memory state
+- personal identifiers unless explicitly public
+
+### Strip by default unless creator marks it public
+- training transcripts
+- examples generated from real user work
+- benchmark inputs
+- saved workflows containing private context
+- custom notes
+- internal tags or annotations
+
+### Safe to keep
+- personality structure
+- role or class
+- skill loadout
+- visual identity
+- generic public starter memories
+- public routines
+- public sample tasks
+- benchmark summaries
+- performance badges
+- challenge achievements
+- public descriptions
+
+## Marketplace item types
+
+Start with a narrow item set.
+
+### Buddy Templates
+Main marketplace object for:
+- starter companions
+- role-based Buddies
+- workflow-specific Buddies
+- themed personality Buddies
+
+### Skill Packs
+Attach new capabilities or starter loadouts to compatible Buddies.
+
+### Knowledge Packs
+Curated public knowledge bundles for specific domains.
+Examples:
+- indie game dev pack
+- ADHD planning pack
+- startup ops pack
+- content creator pack
+
+### Cosmetic Packs
+Skins, pixel variations, idle animation packs, and visual accents.
+
+### Council Packs
+Small themed teams of Buddies designed to work together.
+
+## Publishing flow
+
+### Step 1 — Create
+Creator starts from:
+- a Buddy they trained
+- a premade template
+- a new template draft
+
+### Step 2 — Package
+System converts the Buddy into a publishable template draft.
+
+### Step 3 — Sanitize
+Automatic sanitation pass removes:
+- private memory
+- account links
+- personal documents
+- unsafe hidden content
+- private logs
+
+### Step 4 — Fill listing info
+Creator chooses:
+- title
+- short description
+- category
+- tags
+- intended audience
+- preview images
+- pricing
+- version notes
+
+### Step 5 — Validation
+System checks:
+- metadata completeness
+- broken references
+- banned content
+- restricted terms
+- unsafe prompt patterns
+- unsupported skill dependencies
+
+### Step 6 — Review
+Either:
+- auto-approved if low risk
+- queued for moderation if medium or high risk
+
+### Step 7 — Publish
+Template becomes one of:
+- private
+- unlisted
+- public free
+- public paid
+
+## Creator publishing rules
+
+### Allowed
+- original Buddy templates
+- productivity-focused Buddies
+- creative Buddies
+- workflow helpers
+- business or personal planning templates
+- public-domain-safe knowledge bundles
+- original visual variations
+
+### Not allowed
+- stolen or copied creator content
+- copyrighted character clones
+- templates containing personal data
+- impersonation Buddies
+- misleading claims such as guaranteed income
+- illegal activity workflows
+- harmful instructions
+- scam, fraud, or social-engineering templates
+- templates designed to evade platform safety
+
+### Restricted or manual review
+- health-related Buddies
+- legal or financial-heavy Buddies
+- child-facing Buddies
+- emotionally manipulative or dependency-driven Buddies
+- public therapy Buddies
+- extreme persuasion workflows
+
+## Review and moderation flow
+
+### Layer 1 — automated checks
+- profanity and abuse scan
+- private data scan
+- secrets scan
+- policy keyword scan
+- copyrighted-character flagging
+- restricted domain detection
+- unsupported dependency detection
+
+### Layer 2 — marketplace safety rules
+- listing clarity
+- honest labeling
+- no deceptive screenshots
+- no fake benchmark claims
+- no hidden premium dependency traps
+
+### Layer 3 — human review
+Use for:
+- flagged listings
+- premium creators at launch
+- disputes
+- high-volume creators
+- restricted categories
+
+### User controls
+Users must be able to:
+- report a Buddy
+- block a creator
+- hide content categories
+- uninstall and review purchases
+- see what a Buddy Template contains before installing
+
+## Install flow for buyers
+
+Listing pages should show:
+- Buddy name
+- creator
+- role or class
+- personality summary
+- ideal use case
+- included items
+- starter stats
+- move or skill highlights
+- screenshots or previews
+- compatibility
+- review score
+- whether it includes premium dependencies
+
+### On install
+The app should:
+- create a new local copy
+- mark it as derived from the installed template
+- let the user rename it
+- let the user personalize it
+- start clean with the buyer's own private memory
+
+That guarantees:
+- the buyer owns their version
+- the creator's source Buddy stays separate
+- private state does not bleed across users
+
+## Rating and reputation
+
+### Creator metrics
+- total installs
+- paid installs
+- retention score
+- average rating
+- completion rate
+- challenge score
+- refund rate
+- moderation strikes
+
+### Buddy metrics
+- usefulness rating
+- setup ease
+- visual quality
+- task reliability
+- benchmark category scores
+- works-as-described score
+
+### Early badges
+- Verified Creator
+- Great Starter Buddy
+- Strong Daily Life Buddy
+- Top Workflow Buddy
+- Well Rated
+- High Retention
+- Great for Teams
+
+## Pricing model
+
+Keep early pricing simple.
+
+### Free templates
+Use for:
+- community growth
+- discovery
+- starter ecosystem
+- creator onboarding
+
+### Paid templates
+Recommended ranges:
+- $0.99 to $2.99 for simple starter Buddies
+- $3.99 to $7.99 for high-quality specialized Buddies
+- $9.99 to $19.99 for premium packs, council bundles, or business workflow Buddies
+
+## Revenue share
+
+Best launch order:
+
+### Phase 1
+Only platform-sold content:
+- official Buddies
+- official packs
+- premium cosmetic packs
+
+### Phase 2
+Creators can publish free templates.
+
+### Phase 3
+Creators can sell paid templates.
+
+### Revenue split options
+- 70 / 30 for fast ecosystem goodwill
+- 60 / 40 if hosting and moderation cost are high
+- later tiered splits for verified creators
+
+## Licensing model
+
+Each template should carry a clear license.
+
+Suggested license types:
+- Personal Use
+- Personal + Team Use
+- Commercial Internal Use
+- No Resale / No Repackaging
+- Remix Allowed
+- Remix Not Allowed
+
+Best default:
+Personal Use, No Resale, Remix Allowed, attribution off by default unless creator opts in.
+
+## Buddy Template schema
+
+Use a structured object, not a giant prompt blob.
+
+```ts
+type BuddyTemplate = {
+  templateId: string;
+  creatorId: string;
+  version: string;
+  compatibilityVersion: string;
+
+  listing: {
+    title: string;
+    description: string;
+    category: string;
+    tags: string[];
+    priceCents: number;
+    visibility: "private" | "unlisted" | "public_free" | "public_paid";
+    contentRating: "general" | "teen" | "restricted";
+  };
+
+  buddy: {
+    defaultName: string;
+    class: string;
+    role: string;
+    personalityPrimary: string;
+    personalitySecondary?: string;
+    voicePrimary: string;
+    voiceSecondary?: string;
+    archetype: string;
+    bodyStyle: string;
+    palette: string;
+    evolutionStage: number;
+  };
+
+  gameplay: {
+    stats: Record<string, number>;
+    moves: string[];
+    passive?: string;
+    growthPath?: string[];
+  };
+
+  utility: {
+    starterSkills: string[];
+    taskBiases: string[];
+    recommendedUseCases: string[];
+    suggestedRoutines?: string[];
+  };
+
+  assets: {
+    asciiVariantId?: string;
+    pixelVariantId?: string;
+    coverImage?: string;
+    gallery?: string[];
+  };
+
+  provenance: {
+    derivedFromTemplateId?: string;
+    sanitizedAt: string;
+    benchmarkSummary?: Record<string, number>;
+  };
+};
+```
+
+## Phased rollout
+
+### Phase 1 — Buddy Library
+- official starter council
+- official premium packs
+- no creator publishing yet
+
+### Phase 2 — Community sharing
+- free creator templates
+- private, unlisted, and public free visibility
+- ratings
+- moderation
+- no payouts yet
+
+### Phase 3 — Paid creator marketplace
+- paid templates
+- creator profiles
+- payouts
+- verified creators
+- review system
+- reports and disputes
+
+### Phase 4 — Advanced marketplace
+- council bundles
+- business packs
+- team templates
+- seasonal drops
+- creator subscriptions
+
+## Strong launch recommendation
+
+Launch with:
+- official Council Starter Pack
+- custom Buddy creation
+- Buddy Workshop as a library and sharing system
+- free community template publishing
+- paid official packs only
+
+Add later:
+- paid creator templates
+- revenue share
+- creator verification
+- business workflow Buddy packs
+
+Avoid at launch:
+- raw live-Buddy resale
+- unsanitized exports
+- internal marketplace currency
+- wallets or balances
+- wager-based battling
+- copyrighted character marketplace items

--- a/docs/CODEX_IMPLEMENTATION_PROMPT_BEMORE.md
+++ b/docs/CODEX_IMPLEMENTATION_PROMPT_BEMORE.md
@@ -1,0 +1,486 @@
+# BeMore Codex Implementation Prompt
+
+Use this prompt to drive repo work from the current iOS shell owner path:
+- `apps/openclaw-shell-ios`
+
+Ground implementation planning in the latest known delivery lane when relevant:
+- `fix/openclaw-build17-workspace-runtime`
+
+Do not pretend the app has already been renamed or reorganized if the repo still uses older path names.
+
+## Ask mode pre-prompt
+
+```text
+Read the repo and produce a concrete implementation plan for the prompt that follows.
+
+Be specific about:
+- existing subsystems to reuse
+- files likely to change
+- the shortest path to the flagship flow
+- which parts should ship in this pass vs later phases
+- highest-risk wiring points
+- data model choices for Buddy Templates, installs, sanitation, and Buddy memory
+
+Do not implement yet.
+Do not give a vague product roadmap.
+Return a repo-specific build plan with a recommended implementation order.
+```
+
+## Code mode prompt
+
+```text
+You are modifying this repo in one primary implementation pass.
+
+Your mission is to build the first strong vertical slice of BeMore's new identity from the current owner path in this repo.
+
+Current owner path:
+- apps/openclaw-shell-ios
+
+Current delivery lane to treat as highly relevant when present:
+- fix/openclaw-build17-workspace-runtime
+
+Do not stop at analysis.
+Do not return a design memo instead of code.
+Implement the strongest coherent vertical slice you can, then run validation, fix the most important breakages, and report exact remaining blockers.
+
+# Product direction
+
+This app is not just a thin assistant client.
+It is becoming a standalone personal agent system app.
+
+It should feel like:
+- one agent
+- one workspace
+- one runtime
+- one evolving memory layer
+- one Buddy that matters
+- one future-facing ecosystem for Buddy Templates
+
+The app has four integrated surfaces:
+1. daily-life assistant
+2. agent workspace
+3. living memory system
+4. Buddy ecosystem / Buddy Workshop
+
+# Core goal for this pass
+
+Build the runtime and app surfaces that make the in-app agent materially more capable, while also making Buddy important through evolving markdown state and making Buddy templates installable in a safe structured way.
+
+This pass must establish 7 things:
+1. a real Workspace Runtime
+2. a real Agent Workspace surface
+3. evolving markdown memory files
+4. Buddy as steward of those files
+5. real receipts and results for actions
+6. canonical Council Starter Pack data and templates
+7. first Buddy Workshop template and install foundations
+
+# Highest-priority product truth
+
+The app already has intelligence.
+It now needs embodiment, continuity, and portable identity.
+
+Embodiment:
+- browse files
+- open, edit, and save files
+- run commands
+- inspect output
+- review diffs
+- run subtasks
+
+Continuity:
+- markdown files evolve through use
+- Buddy tracks what changed
+- memory feels curated and operational, not theatrical
+
+Portable identity:
+- Buddies can be represented as structured templates
+- installs create clean derived copies
+- private state does not bleed across users
+
+# Absolute priorities
+
+## Priority 1 — Workspace Runtime
+
+Create or formalize one app-facing runtime contract.
+
+It must cover directly or via adapters:
+- workspace.listFiles(path?)
+- workspace.readFile(path)
+- workspace.writeFile(path, content)
+- workspace.searchFiles(query)
+- runtime.runCommand(command, options?)
+- runtime.listProcesses()
+- runtime.pollProcess(id)
+- runtime.killProcess(id)
+- review.listChangedFiles()
+- review.getDiff(path)
+- tasks.list()
+- tasks.create(input)
+- tasks.runSubtask(input)
+- artifacts.list()
+- artifacts.read(path)
+- receipts.list()
+
+Reuse existing repo primitives where possible.
+Do not rewrite major subsystems if adapters can unify them.
+
+## Priority 2 — Agent Workspace shell
+
+Create one coherent workspace surface.
+
+Minimum sections:
+- Files
+- Editor
+- Terminal
+- Tasks
+- Review
+- Results
+- Buddy / Memory
+- Buddies / Library
+
+## Priority 3 — File/editor flow
+
+Minimum:
+- browse workspace tree
+- open a file
+- edit it
+- save it
+- switch between open or recent files
+- support markdown and code reasonably well
+
+## Priority 4 — Command/process flow
+
+Minimum:
+- run command
+- see running, completed, and failed state
+- view stdout and stderr
+- rerun command
+- stop command
+- inspect recent runs
+
+## Priority 5 — Diff/review flow
+
+Minimum:
+- changed files list
+- diff view
+- changed and untracked indicators
+- links from runs, tasks, and results to affected files where possible
+
+## Priority 6 — Task/subtask flow
+
+Minimum:
+- task list
+- current task
+- create task
+- run subtask
+- show task status
+- show result summary
+- connect tasks to files, runs, and results
+
+## Priority 7 — Evolving markdown memory
+
+Implement or formalize these canonical files as real app artifacts:
+- .openclaw/soul.md
+- .openclaw/user.md
+- .openclaw/memory.md
+- .openclaw/session.md
+- .openclaw/skills.md
+
+Required behavior:
+- session.md updates frequently
+- memory.md updates from durable extracted facts
+- user.md updates conservatively from repeated preferences or patterns
+- skills.md reflects actual capabilities
+- soul.md changes rarely and remains stable
+
+Use a real pipeline:
+- event -> extract -> merge -> regenerate markdown -> Buddy surfaces change
+
+Important:
+- do not append forever
+- use stable sections
+- preserve or separate user-authored vs generated content
+- avoid recap sludge
+- generated state should feel curated and operational
+
+## Priority 8 — Buddy as continuity steward
+
+Buddy should:
+- explain what changed in markdown state
+- surface stale files
+- suggest promotions from conversation to durable memory
+- show current focus and active tasks
+- show recent artifact or memory changes
+- act as steward of continuity, not just another chat tab
+
+Minimum Buddy outputs:
+- what changed
+- what matters now
+- what is stale
+- what should be remembered
+
+## Priority 9 — Council Starter Pack foundations
+
+Add canonical starter Buddy template data for the 12-member public council.
+
+For V1 these should be:
+- starter Buddy templates
+- locked initial stats
+- locked initial move sets
+- locked initial class identity
+- editable name
+- editable nickname
+- later-evolving appearance and growth stage
+
+The 12 canonical starter Buddies are:
+- BMO
+- Prismo
+- NEPTR
+- Princess Bubblegum
+- Finn
+- Jake
+- Marceline
+- Simon
+- Peppermint Butler
+- Lady Rainicorn
+- Lemongrab
+- Flame Princess
+
+Each starter template should include:
+- buddy name
+- short description
+- role or class
+- personality profile
+- voice style
+- visual archetype
+- starter stats
+- starter moves
+- growth metadata
+- tags
+- recommended user type
+
+Use structured data, not giant prompt blobs.
+
+## Priority 10 — Buddy Workshop template model
+
+Implement the first structured Buddy Template schema and supporting install flow.
+
+At minimum create a typed model equivalent to:
+
+```ts
+type BuddyTemplate = {
+  templateId: string;
+  creatorId: string;
+  version: string;
+  compatibilityVersion: string;
+
+  listing: {
+    title: string;
+    description: string;
+    category: string;
+    tags: string[];
+    priceCents: number;
+    visibility: "private" | "unlisted" | "public_free" | "public_paid";
+    contentRating: "general" | "teen" | "restricted";
+  };
+
+  buddy: {
+    defaultName: string;
+    class: string;
+    role: string;
+    personalityPrimary: string;
+    personalitySecondary?: string;
+    voicePrimary: string;
+    voiceSecondary?: string;
+    archetype: string;
+    bodyStyle: string;
+    palette: string;
+    evolutionStage: number;
+  };
+
+  gameplay: {
+    stats: Record<string, number>;
+    moves: string[];
+    passive?: string;
+    growthPath?: string[];
+  };
+
+  utility: {
+    starterSkills: string[];
+    taskBiases: string[];
+    recommendedUseCases: string[];
+    suggestedRoutines?: string[];
+  };
+
+  assets: {
+    asciiVariantId?: string;
+    pixelVariantId?: string;
+    coverImage?: string;
+    gallery?: string[];
+  };
+
+  provenance: {
+    derivedFromTemplateId?: string;
+    sanitizedAt: string;
+    benchmarkSummary?: Record<string, number>;
+  };
+};
+```
+
+## Priority 11 — Install flow
+
+On install the app should:
+- create a new local Buddy copy
+- mark it as derived from the installed template
+- let the user rename it
+- let the user personalize it
+- start with the buyer's own clean private memory
+
+That means:
+- the buyer owns their version
+- the creator's source Buddy stays separate
+- private state does not bleed across users
+
+## Priority 12 — Sanitation and publishing foundations
+
+Do not build full payouts in this pass.
+Do implement the foundations for safe packaging.
+
+Create a publish/package pipeline that can convert a Buddy into a sanitized Buddy Template draft.
+
+Always strip:
+- private conversation history
+- raw chat logs
+- user-specific memory
+- linked accounts
+- uploaded documents
+- email, text, and calendar contents
+- creator notes
+- secret prompts containing private information
+- API keys / tokens / credentials
+- hidden task history tied to the creator
+- private markdown memory state
+- personal identifiers unless explicitly public
+
+Safe to keep:
+- personality structure
+- role or class
+- skill loadout
+- visual identity
+- generic public starter memories
+- public routines
+- public sample tasks
+- benchmark summaries
+- performance badges
+- public descriptions
+
+At minimum:
+- implement data-level sanitation hooks
+- add validation for metadata completeness and broken references
+- create placeholders for banned content, restricted term checks, and unsupported dependency checks
+
+## Priority 13 — Buddy Library / Workshop UI foundations
+
+Create a simple but real Buddy Library / Workshop surface.
+
+Minimum:
+- list official starter templates
+- view template detail
+- inspect included items
+- inspect stats, move highlights, and use cases
+- install template
+- see whether a Buddy is installed / derived from template
+
+## Priority 14 — Real execution semantics
+
+No fake success.
+
+The app or agent must not claim:
+- created
+- saved
+- updated
+- generated
+- published
+- installed
+- persisted
+
+unless confirmed by real execution, results, receipts, or state transitions.
+
+# Flagship user flow
+
+After your changes, this flow should work as far as the repo allows:
+1. open Agent Workspace
+2. browse workspace files
+3. open and edit a file
+4. save changes
+5. run a command
+6. inspect stdout, stderr, and status
+7. review changed files and diffs
+8. run a subtask using repo-native foundations where possible
+9. inspect results, receipts, and artifacts
+10. open Buddy Library
+11. inspect a Council Starter Pack Buddy template
+12. install it into a clean local Buddy copy
+13. rename or personalize the installed Buddy
+14. see Buddy report what changed in markdown memory and state
+
+If this flow is not real, the task is not done.
+
+# Non-goals for this pass
+
+Do not spend this pass on:
+- pixel-perfect UI polish
+- full creator payouts
+- wallets or balances
+- marketplace currency
+- raw live-Buddy resale
+- unrelated docs-only output
+- claiming every BeMore surface is fully implemented inside this repo
+
+# Acceptance criteria
+
+This work is successful only if all are true:
+1. There is a real Agent Workspace surface.
+2. Files can be browsed, opened, edited, and saved.
+3. Commands can be run and their output/state is visible.
+4. Changed files and diffs can be reviewed.
+5. Tasks and subtasks can be created or run using repo-native foundations where possible.
+6. The canonical markdown files exist and evolve through use.
+7. Buddy visibly reports and interprets markdown and memory changes.
+8. The app does not fake completion claims.
+9. Canonical starter Buddy templates exist in structured form.
+10. A user can inspect and install a starter Buddy template.
+11. Installed Buddies are clean derived copies, not shared live state.
+12. The flagship flow works as far as the repo allows.
+
+# Validation
+
+At the end:
+- run the most relevant builds and tests available
+- fix the most important failures
+- do not widen scope after the main slice works
+- report exact remaining blockers
+
+# Output format when finished
+
+Return:
+1. concise summary
+2. major files changed
+3. commands and tests run
+4. known limitations and TODOs
+5. whether the flagship flow works end to end
+6. whether evolving markdown + Buddy stewardship are working
+7. whether starter Buddy template install flow works
+8. whether sanitation and publishing foundations exist
+```
+
+## Strong sequencing guidance
+
+If implementation effort must be staged, use this order:
+1. workspace runtime and honest receipts
+2. evolving markdown memory and Buddy stewardship
+3. official starter Buddy templates
+4. Buddy Library and install flow
+5. sanitation and free sharing foundations
+6. paid creator marketplace later

--- a/docs/COUNCIL_STARTER_PACK.md
+++ b/docs/COUNCIL_STARTER_PACK.md
@@ -1,0 +1,421 @@
+# Council Starter Pack
+
+## Purpose
+
+This document defines the canonical V1 starter Buddy roster for BeMore.
+
+Use it for:
+- onboarding defaults
+- official template seeds
+- balancing baselines
+- future Buddy Workshop compatibility
+- Help Me Choose routing
+
+## Core system model
+
+### 8-stat starter system
+Use a 1 to 10 scale.
+
+- Focus — staying on task
+- Creativity — ideation, novelty, and style
+- Memory — recall and continuity
+- Speed — quickness and throughput
+- Logic — structure and correctness
+- Empathy — warmth and fit
+- Discipline — consistency and rigor
+- Charm — friendliness and expression
+
+### Balance rule
+Starter Buddies should feel distinct but fair.
+
+Target:
+- average total around 44 points
+- one clear strength
+- one secondary strength
+- one mild weakness
+- no completely dead stat at starter stage
+
+### Move system
+Each Buddy starts with four moves:
+- one signature move
+- two role-aligned utility moves
+- one universal support move
+
+Move categories:
+- Support
+- Control
+- Attack
+- Recovery
+- Utility
+
+### Growth path
+Each Buddy has three tiers:
+- Tier 1 — Starter
+- Tier 2 — Specialized
+- Tier 3 — Council Form
+
+At Tier 2, each Buddy unlocks one passive.
+At Tier 3, that passive upgrades.
+
+## The canonical 12
+
+## 1. BMO
+
+**Role:** Companion / Everyday Buddy
+
+**Stats**
+- Focus 5
+- Creativity 6
+- Memory 5
+- Speed 5
+- Logic 4
+- Empathy 9
+- Discipline 3
+- Charm 7
+
+**Moves**
+- Heart Ping
+- Cheerful Reframe
+- Little Helper
+- Daily Spark
+
+**Passive**
+- Warm Presence
+
+**Onboarding copy**
+A warm, playful Buddy for daily life, chats, routines, and company.
+
+## 2. Prismo
+
+**Role:** Strategist / Coordinator
+
+**Stats**
+- Focus 7
+- Creativity 6
+- Memory 6
+- Speed 4
+- Logic 8
+- Empathy 5
+- Discipline 4
+- Charm 4
+
+**Moves**
+- Timeline Shift
+- Big Picture
+- Delegate
+- Tie Breaker
+
+**Passive**
+- Cosmic Orchestrator
+
+**Onboarding copy**
+Best for planning, prioritizing, coordinating tasks, and keeping your team aligned.
+
+## 3. NEPTR
+
+**Role:** Verifier / QA Buddy
+
+**Stats**
+- Focus 7
+- Creativity 3
+- Memory 7
+- Speed 4
+- Logic 8
+- Empathy 4
+- Discipline 8
+- Charm 3
+
+**Moves**
+- Verify
+- Sanity Check
+- Completion Gate
+- Pass/Fail
+
+**Passive**
+- Literal Mind
+
+**Onboarding copy**
+For users who want checking, proof, careful review, and fewer mistakes.
+
+## 4. Princess Bubblegum
+
+**Role:** Architect
+
+**Stats**
+- Focus 8
+- Creativity 5
+- Memory 7
+- Speed 4
+- Logic 9
+- Empathy 4
+- Discipline 6
+- Charm 1
+
+**Moves**
+- System Map
+- Blueprint
+- Refactor Beam
+- Royal Override
+
+**Passive**
+- High Standards
+
+**Onboarding copy**
+For structure, planning, systems design, and long-term maintainable thinking.
+
+## 5. Finn
+
+**Role:** Builder / Action Buddy
+
+**Stats**
+- Focus 7
+- Creativity 4
+- Memory 4
+- Speed 8
+- Logic 5
+- Empathy 5
+- Discipline 6
+- Charm 5
+
+**Moves**
+- Do the Thing
+- Momentum
+- Adventure Rush
+- Courage Buff
+
+**Passive**
+- Action First
+
+**Onboarding copy**
+For execution, shipping, momentum, and getting unstuck fast.
+
+## 6. Jake
+
+**Role:** Simplifier
+
+**Stats**
+- Focus 5
+- Creativity 7
+- Memory 4
+- Speed 5
+- Logic 5
+- Empathy 6
+- Discipline 3
+- Charm 9
+
+**Moves**
+- Stretch Around It
+- Easy Mode
+- Shortcut
+- Chill Vibes
+
+**Passive**
+- Elastic Thinking
+
+**Onboarding copy**
+For cutting through complexity, reducing stress, and finding easier paths.
+
+## 7. Marceline
+
+**Role:** Creative Director
+
+**Stats**
+- Focus 4
+- Creativity 9
+- Memory 5
+- Speed 5
+- Logic 4
+- Empathy 6
+- Discipline 3
+- Charm 8
+
+**Moves**
+- Style Check
+- Name Drop
+- Polish Pass
+- Cool Factor
+
+**Passive**
+- Taste Meter
+
+**Onboarding copy**
+For naming, writing tone, visuals, polish, and better taste.
+
+## 8. Simon
+
+**Role:** Archivist
+
+**Stats**
+- Focus 6
+- Creativity 4
+- Memory 9
+- Speed 3
+- Logic 7
+- Empathy 6
+- Discipline 5
+- Charm 4
+
+**Moves**
+- Recall Thread
+- History Lesson
+- Reconstruct
+- Calm Insight
+
+**Passive**
+- Context Keeper
+
+**Onboarding copy**
+For continuity, remembering important things, and reconstructing what happened.
+
+## 9. Peppermint Butler
+
+**Role:** Guardian
+
+**Stats**
+- Focus 7
+- Creativity 4
+- Memory 6
+- Speed 4
+- Logic 7
+- Empathy 3
+- Discipline 9
+- Charm 4
+
+**Moves**
+- Permission Check
+- Seal Secret
+- Dark Protocol
+- Risk Sense
+
+**Passive**
+- Danger Steward
+
+**Onboarding copy**
+For caution, security, sensitive work, and risky decisions.
+
+## 10. Lady Rainicorn
+
+**Role:** Bridge Buddy
+
+**Stats**
+- Focus 6
+- Creativity 6
+- Memory 6
+- Speed 5
+- Logic 6
+- Empathy 5
+- Discipline 4
+- Charm 6
+
+**Moves**
+- Translate Worlds
+- Rainbow Bridge
+- Port Shift
+- Graceful Sync
+
+**Passive**
+- Cross-World Harmony
+
+**Onboarding copy**
+For portability, cross-device workflows, and keeping things working together.
+
+## 11. Lemongrab
+
+**Role:** Auditor
+
+**Stats**
+- Focus 8
+- Creativity 2
+- Memory 6
+- Speed 4
+- Logic 8
+- Empathy 1
+- Discipline 10
+- Charm 1
+
+**Moves**
+- UNACCEPTABLE
+- Spec Audit
+- Violation Report
+- Severity Spike
+
+**Passive**
+- No Nonsense
+
+**Onboarding copy**
+For rules, requirements, final checks, and accountability.
+
+## 12. Flame Princess
+
+**Role:** Stress Tester
+
+**Stats**
+- Focus 7
+- Creativity 4
+- Memory 4
+- Speed 9
+- Logic 6
+- Empathy 3
+- Discipline 6
+- Charm 5
+
+**Moves**
+- Heat Test
+- Bottleneck Burn
+- Overclock
+- Critical Heat
+
+**Passive**
+- Pressure Truth
+
+**Onboarding copy**
+For speed, stress testing, bottlenecks, and performance tuning.
+
+## Starter team recommendations
+
+### Best first Buddy for most users
+- BMO
+
+### Best first Buddy for builders
+- Finn or Princess Bubblegum
+
+### Best first Buddy for organized life
+- Prismo or Simon
+
+### Best first Buddy for creatives
+- Marceline
+
+### Best first Buddy for cautious power users
+- NEPTR or Peppermint Butler
+
+## Help Me Choose mapping
+
+- I want a general everyday Buddy → BMO
+- I want to get more done → Finn
+- I want help planning and organizing → Prismo
+- I want help remembering things → Simon
+- I want structure and system design → Princess Bubblegum
+- I want less overwhelm → Jake
+- I want more creativity and polish → Marceline
+- I want a careful and safe Buddy → Peppermint Butler
+- I want strong verification → NEPTR
+- I work across devices or systems → Lady Rainicorn
+- I need strict standards → Lemongrab
+- I care about speed and performance → Flame Princess
+
+## V1 implementation guidance
+
+For V1 keep these as:
+- official starter Buddy templates
+- locked initial stats
+- locked initial move sets
+- locked initial class identity
+- editable name
+- editable nickname
+- later-evolving appearance and growth stage
+
+That gives the product:
+- lower onboarding friction
+- stronger identity
+- cleaner balance
+- a canonical seed roster for Buddy Workshop and future council systems

--- a/docs/PRODUCT_MONOREPO_DECISION.md
+++ b/docs/PRODUCT_MONOREPO_DECISION.md
@@ -1,0 +1,133 @@
+# Product Monorepo Decision
+
+## Purpose
+
+Force an explicit decision on whether `prismtek.dev_mega-app` becomes the one true implementation home for the BeMore app family.
+
+This document exists because repo ambiguity is now a larger risk than product ambiguity.
+
+## Decision statement
+
+**Question:** Should `prismtek.dev_mega-app` become the canonical product monorepo for BeMore and future Prismtek app-family implementation?
+
+**Recommended answer:** Yes — unless it fails the promotion criteria below in a way that cannot be corrected quickly.
+
+## Why this matters
+
+Without a decision, the ecosystem keeps drifting into one of the worst possible states:
+- `openclaw` is too product-shaped
+- `bmo-stack` is too implementation-shaped
+- `prismtek-site` risks owning app logic by accident
+- `prismtek.dev_mega-app` risks becoming de facto canonical by momentum without actually being declared canonical
+
+That creates split-brain planning and implementation.
+
+## Current ownership model
+
+Keep this spine:
+- `openclaw` = engine
+- `bmo-stack` = brain / policy / council / Buddy identity
+- `prismtek-site` = public web + site-backed surfaces
+- product monorepo = shipped app family implementation
+
+The unresolved question is simply whether `prismtek.dev_mega-app` is that product monorepo.
+
+## Promotion option
+
+### Promote `prismtek.dev_mega-app` to canonical product monorepo
+
+If promoted, it should own:
+- BeMore app-family implementation
+- shared product packages
+- Buddy UI
+- Buddy Workshop UI
+- marketplace implementation
+- shared auth/account/profile systems for the app family
+- shared design system
+- app-family packages that are not runtime substrate or web-site ownership
+
+It should not own:
+- runtime substrate already owned by `openclaw`
+- policy / identity / council contracts already owned by `bmo-stack`
+- pure `prismtek.dev` site ownership already owned by `prismtek-site`
+
+### Promotion criteria
+
+Promote only if all are true:
+- [ ] repo structure is coherent enough to converge future product work there
+- [ ] README can clearly state what it owns and does not own
+- [ ] it does not duplicate `openclaw` runtime substrate ownership
+- [ ] it does not duplicate `bmo-stack` policy ownership
+- [ ] it can become the default implementation target for Build 18+ app-family work
+
+### Consequences of promotion
+- future BeMore implementation converges there
+- `BMO-app` and similar transitional repos get folded or frozen
+- implementation roadmap moves there
+- `bmo-stack` remains source of truth for policy / Buddy philosophy / council / strategy
+
+## Demotion option
+
+### Demote `prismtek.dev_mega-app` to satellite or archive path
+
+Choose this only if:
+- the repo is too structurally messy to safely converge into
+- it duplicates too much other ownership
+- another repo is clearly a better implementation home
+
+### Consequences of demotion
+- extract useful code or docs quickly
+- select a replacement canonical product implementation repo immediately
+- archive or clearly freeze `prismtek.dev_mega-app`
+- do not leave it in limbo
+
+## Hard rule
+
+There is no stable future where `prismtek.dev_mega-app` remains half-canonical forever.
+
+It must become either:
+- canonical product monorepo
+or
+- clearly demoted and superseded
+
+## Decision owner and timing
+
+**Decision owner:** Cody
+**Decision target:** as soon as practical, before major new cross-surface product work begins
+
+## Default recommendation
+
+Promote `prismtek.dev_mega-app`.
+
+Reason:
+- the ownership model already wants a product implementation home
+- your repo map already separates engine, brain, and public web cleanly
+- the real remaining gap is the shipped app-family implementation home
+- leaving that gap unresolved will keep spawning shadow repos and partial canonical claims
+
+## Immediate follow-up if promoted
+
+- [ ] add canonical README ownership statement
+- [ ] move implementation roadmap there
+- [ ] mark `BMO-app` and other transitional app repos as satellite or archive
+- [ ] link back to `bmo-stack` for product-brain docs
+- [ ] link to `openclaw` for runtime substrate
+- [ ] link to `prismtek-site` for public-web ownership
+
+## Immediate follow-up if demoted
+
+- [ ] name the replacement canonical product repo immediately
+- [ ] move implementation roadmap there
+- [ ] extract any valuable code/docs from `prismtek.dev_mega-app`
+- [ ] add superseded banner
+- [ ] archive or freeze fast
+
+## Final rule of thumb
+
+If a future feature is:
+- runtime substrate → `openclaw`
+- Buddy philosophy / council / identity / operating policy → `bmo-stack`
+- public website / public dashboards / site APIs → `prismtek-site`
+- shipped app-family implementation → product monorepo
+
+This doc exists to make the last line explicit.

--- a/docs/REPO_EXECUTION_CHECKLIST.md
+++ b/docs/REPO_EXECUTION_CHECKLIST.md
@@ -1,0 +1,129 @@
+# Repo Execution Checklist
+
+## Purpose
+
+Turn `REPO_OWNERSHIP.md` into an execution document so the Prismtek ecosystem can be cleaned up without relying on memory or momentum.
+
+This checklist assumes the current ownership spine is:
+- `openclaw` = engine
+- `bmo-stack` = brain / policy / council / Buddy identity
+- `prismtek-site` = public web + site-owned surfaces
+- `prismtek.dev_mega-app` = unresolved product monorepo decision
+
+## Critical blocker
+
+### `prismtek.dev_mega-app`
+**Status:** unresolved
+**Decision required:** promote or demote
+**Why it matters:** do not let future product implementation drift into an implied monorepo by inertia.
+
+Until this is decided:
+- do not start broad new cross-surface implementation there by default
+- do not let it quietly become source of truth for app-family work
+- do not describe it as canonical without an explicit decision
+
+## Repo class legend
+
+- **Canonical** = allowed to be source of truth
+- **Satellite** = useful supporting repo, not source of truth
+- **Experimental** = exploratory, allowed to be messy
+- **Archive** = historical or superseded, should stop competing for attention
+
+## Repo-by-repo checklist
+
+| Repo | Current class | Target class | Canonical owner for domain | Immediate action | Notes | Status |
+|---|---|---|---|---|---|---|
+| `openclaw` | Canonical | Canonical | `openclaw` | Keep canonical | Runtime engine / substrate | TODO |
+| `bmo-stack` | Canonical | Canonical | `bmo-stack` | Keep canonical | Brain / policy / Buddy identity | TODO |
+| `prismtek-site` | Canonical | Canonical | `prismtek-site` | Keep canonical | Public web + site-backed surfaces | TODO |
+| `prismtek.dev_mega-app` | Unresolved | Canonical or Satellite | TBD | Decide promote vs demote | Most important unresolved repo | BLOCKED |
+| `BMO-app` | Satellite-ish | Satellite or Archive | Product monorepo if promoted | Decide fold vs freeze | Transitional app naming; should not remain half-canonical | TODO |
+| `PrismBot` | Shadow lineage | Archive | `bmo-stack` or product monorepo depending content | Add superseded banner, extract anything still needed | Private legacy line | TODO |
+| `Prismbot-BMO` | Shadow lineage | Archive | `bmo-stack` | Add superseded banner | Naming drift / historical lineage | TODO |
+| `Prismbot-Public` | Shadow lineage | Archive | `prismtek-site` | Add superseded banner | Public-facing historical line | TODO |
+| `WixPrismBot` | Shadow lineage | Archive | `prismtek-site` | Add superseded banner | Historical Wix-era line | TODO |
+| `prismbot.wix` | Shadow lineage | Archive | `prismtek-site` | Add superseded banner | Historical Wix-era line | TODO |
+| `omni-bmo` | Satellite | Satellite or Archive | `bmo-stack` unless sharply distinct | Decide keep-if-distinct vs fold | Keep only if it still owns a real concept | TODO |
+| `claw-code` | Satellite | Satellite or Archive | `openclaw` or product monorepo depending scope | Write one-line ownership rule | Keep only if sharply scoped | TODO |
+| `FlowMaster` | Experimental | Experimental | none | Mark experimental in README | No flagship ambiguity | TODO |
+| `nemoclaw` | Experimental | Experimental or Satellite | `openclaw` if it graduates | Mark experimental unless promoted | Prototype / concept line | TODO |
+| `omni-openclaw-starter` | Experimental | Experimental or Archive | `openclaw` | Mark experimental or freeze | Starter/prototype repo | TODO |
+| `Edge-Gallery` | Experimental | Experimental or Satellite | TBD | Mark experimental | Creative-tool line unless promoted | TODO |
+| `Wildlands-Critter-Clash` | Separate product | Separate product | itself | Keep separate if active | Does not need to fold into BeMore by default | TODO |
+| `Prismtek.dev` | Shadow web line | Archive or redirect-only | `prismtek-site` | Clarify whether this is superseded | Potential naming confusion with `prismtek-site` | TODO |
+| `prismtek-site-replica` | Shadow / support | Archive or internal support | `prismtek-site` | Clarify support role or freeze | Should not compete with canonical web repo | TODO |
+| `Automind-Lab/bmo-stack` | Cross-org duplicate | Archive or redirect | `codysumpter-cloud/bmo-stack` unless intentionally moved | Clarify authoritative copy | Avoid split-brain docs | TODO |
+| `Automind-Lab/prismtek.dev_mega-app` | Cross-org duplicate | Archive or redirect | chosen canonical monorepo | Clarify authoritative copy | Avoid split-brain implementation | TODO |
+| `Automind-Lab/prismtek.dev_mega-appALL` | Cross-org duplicate | Archive | chosen canonical monorepo | Freeze or remove ambiguity | Name alone creates confusion | TODO |
+| `automindlab-stack` | Separate org repo | Satellite or separate canonical domain | Automind-Lab | Clarify whether separate product or donor | Keep only if it owns truly separate scope | TODO |
+
+## Immediate sequence
+
+### 1. Resolve the product monorepo
+- [ ] Decide whether `prismtek.dev_mega-app` is promoted or demoted
+- [ ] Name the decision owner
+- [ ] Record the decision in `docs/PRODUCT_MONOREPO_DECISION.md`
+
+### 2. Freeze shadow lineage repos
+Start with the most confusing names first:
+- [ ] `PrismBot`
+- [ ] `Prismbot-BMO`
+- [ ] `Prismbot-Public`
+- [ ] `WixPrismBot`
+- [ ] `prismbot.wix`
+- [ ] `BMO-app`
+
+### 3. Add README status banners
+- [ ] superseded banner on archive candidates
+- [ ] experimental banner on exploratory repos
+- [ ] satellite banner on support repos
+
+### 4. Stop source-of-truth overlap
+For each core surface, confirm one owner only:
+- [ ] runtime → `openclaw`
+- [ ] policy / identity / Buddy philosophy → `bmo-stack`
+- [ ] public web → `prismtek-site`
+- [ ] shipped app family → product monorepo if promoted
+
+### 5. Clean cross-org duplicates
+- [ ] decide whether `codysumpter-cloud/*` or `Automind-Lab/*` is canonical per repo family
+- [ ] mark non-canonical duplicates clearly
+
+### 6. Mark experiments honestly
+- [ ] `FlowMaster`
+- [ ] `nemoclaw`
+- [ ] `omni-openclaw-starter`
+- [ ] `Edge-Gallery`
+
+### 7. Run one cleanup sweep
+- [ ] README headers
+- [ ] repo descriptions
+- [ ] top-level docs
+- [ ] canonical links
+- [ ] archived / superseded notices
+
+## Transition rules
+
+### Experimental → Satellite
+Only if:
+- it has a named owner
+- it has a clear purpose
+- it no longer duplicates a canonical repo
+
+### Satellite → Canonical
+Only if:
+- it owns a distinct surface
+- source-of-truth boundaries are documented
+- overlapping repos are demoted or archived
+
+### Any repo → Archive
+When:
+- it no longer owns a unique surface
+- its useful ideas or code are extracted
+- its README points to the canonical replacement
+
+## Recommended operating rule
+
+Do not start major new product implementation until the product monorepo decision is explicit.
+
+That single decision controls whether future BeMore app-family work converges cleanly or keeps leaking across repo boundaries.

--- a/docs/planning/issue-drafts/2026-04-10/01-build18-workspace-buddy-foundations.md
+++ b/docs/planning/issue-drafts/2026-04-10/01-build18-workspace-buddy-foundations.md
@@ -1,0 +1,57 @@
+# Title
+
+build18: strengthen workspace runtime and Buddy continuity foundations in `apps/openclaw-shell-ios`
+
+# Labels
+
+docs, planning, ios, bemore, buddy, workspace, priority:P1
+
+## Summary
+
+Define the first Build 18 candidate wedge for the current iOS shell owner path in `apps/openclaw-shell-ios`.
+
+This issue is about the next real vertical slice after the already-implemented Build 17 baseline.
+
+## Problem
+
+The product direction now points toward a stronger BeMore agent workspace, evolving markdown memory, and Buddy stewardship, but that future scope must be grounded in the current app path and release posture.
+
+If Build 18 is not scoped tightly, it will sprawl across runtime, UX, marketplace, and content systems all at once.
+
+## Goal
+
+Define and implement a narrow Build 18 wedge that makes the app feel more like a real personal agent system without dragging in full marketplace complexity.
+
+## Scope
+
+Focus on:
+- stronger workspace runtime embodiment
+- Buddy continuity improvements
+- visible state change reporting
+- memory evolution improvements
+- starter template plumbing only where needed to support the wedge
+
+## In scope
+- clearer workspace runtime contract inside the current app path
+- files, results, and task state cohesion improvements
+- Buddy outputs for what changed / what matters now / what is stale
+- conservative markdown memory evolution improvements
+- honest receipts and no fake completion claims
+
+## Out of scope
+- creator payouts
+- full Buddy Workshop publishing
+- advanced moderation systems
+- full creator economy UX
+- broad commercialization work
+
+## Acceptance criteria
+- [ ] Build 18 is clearly treated as post-Build-17 work
+- [ ] `apps/openclaw-shell-ios` is used as the owner path in planning and implementation docs
+- [ ] Buddy continuity improvements are visible in-product
+- [ ] workspace/runtime state is more embodied and inspectable
+- [ ] new work does not pretend to be part of Build 17
+
+## Notes
+
+Treat this as the first serious Build 18 candidate, not as the place to ship the entire BeMore future at once.

--- a/docs/planning/issue-drafts/2026-04-10/02-build18-council-starter-pack-and-buddy-library.md
+++ b/docs/planning/issue-drafts/2026-04-10/02-build18-council-starter-pack-and-buddy-library.md
@@ -1,0 +1,55 @@
+# Title
+
+build18: add Council Starter Pack templates and Buddy Library foundations
+
+# Labels
+
+docs, planning, ios, bemore, buddy, council, priority:P1
+
+## Summary
+
+Plan the Build 18 work needed to turn the canonical council roster into installable starter Buddy templates inside the current iOS shell path.
+
+## Problem
+
+The product direction is much clearer once the Council Starter Pack becomes structured seed content.
+Without that seed layer, Buddy remains too abstract and Buddy Workshop has no canonical foundation.
+
+## Goal
+
+Ship the first official structured Buddy template layer for the canonical 12-member council roster and expose it through a simple Buddy Library flow.
+
+## Scope
+
+Add and wire up:
+- canonical structured starter templates
+- starter stats / moves / roles / tags / growth metadata
+- Buddy Library browse and inspect surface
+- local install flow that creates clean derived copies
+- rename and personalize after install
+
+## In scope
+- official Council Starter Pack templates
+- Buddy detail view
+- inspect stats / moves / role / use cases
+- install into local copy
+- derived-from-template provenance
+- buyer-local memory separation
+
+## Out of scope
+- paid templates
+- creator publishing
+- moderation queue tooling
+- licensing UX breadth
+- advanced marketplace discovery systems
+
+## Acceptance criteria
+- [ ] The 12 council Buddies exist in structured template form
+- [ ] A user can inspect a starter Buddy before install
+- [ ] Installing creates a new local derived copy
+- [ ] The installed Buddy can be renamed and personalized
+- [ ] Creator/source state and user-installed state do not bleed across each other
+
+## Notes
+
+This issue should give Build 18 a strong identity and onboarding win without requiring the full Buddy Workshop marketplace to exist yet.

--- a/docs/planning/issue-drafts/2026-04-10/03-build18-buddy-workshop-sanitized-template-foundations.md
+++ b/docs/planning/issue-drafts/2026-04-10/03-build18-buddy-workshop-sanitized-template-foundations.md
@@ -1,0 +1,60 @@
+# Title
+
+build18+: add Buddy Workshop sanitized template foundations before creator marketplace
+
+# Labels
+
+docs, planning, ios, bemore, marketplace, privacy, safety, priority:P1
+
+## Summary
+
+Plan the first safe Buddy Workshop foundation layer without pretending the creator marketplace should fully launch in the same build.
+
+## Problem
+
+Buddy Workshop becomes dangerous fast if live Buddy state, private memory, or user-specific artifacts can leak across installs or publishing flows.
+
+The marketplace object must be a sanitized portable Buddy Template, not a raw live Buddy export.
+
+## Goal
+
+Define and implement the first safe packaging, sanitation, validation, and install foundations for Buddy Templates.
+
+## Scope
+
+Add and wire up:
+- template packaging draft flow
+- sanitation pass
+- metadata validation
+- clean-copy install guarantees
+- visibility groundwork for private / unlisted / public free later
+
+## In scope
+- data model for Buddy Templates
+- sanitation hooks
+- strip rules for private state
+- validation for broken references and missing metadata
+- install-time clean local copy creation
+- policy docs for allowed / restricted / disallowed categories
+
+## Out of scope
+- creator payouts
+- refund handling
+- moderation disputes tooling
+- full creator profile systems
+- advanced review score algorithms
+- internal marketplace currency or wallets
+
+## Acceptance criteria
+- [ ] Publishing flow is framed around sanitized Buddy Templates, not live Buddy resale
+- [ ] Always-strip private state rules are documented and enforceable in the design
+- [ ] Install flow guarantees clean local copies
+- [ ] Build 18 scope remains focused on foundations, not full creator commerce
+- [ ] docs clearly separate free sharing / official packs / later paid creator marketplace
+
+## Notes
+
+The safest launch order remains:
+1. official starter council
+2. free community sharing later
+3. paid creator templates after privacy, moderation, and portability are proven


### PR DESCRIPTION
## Summary

Add repo-grounded BeMore product-direction docs without pretending the current app path or release posture is cleaner than it is.

This PR:
- adds BeMore product vision and phased roadmap docs
- adds Buddy Workshop and Council Starter Pack specs
- adds a Codex implementation prompt grounded in the current iOS shell owner path
- adds a Build 18+ delivery posture doc so Build 17 stays the baseline, not the target for future scope
- adds issue-ready drafts for Build 18 workspace/Buddy foundations, Council Starter Pack + Buddy Library, and Buddy Workshop sanitized-template foundations

## Important posture

- current app owner path remains `apps/openclaw-shell-ios`
- Build 17 is already implemented and should be treated as the baseline
- new Buddy/workspace/marketplace scope in these docs should be interpreted as Build 18+ planning

## Files added

- `docs/BEMORE_PRODUCT_VISION.md`
- `docs/BEMORE_PHASED_ROADMAP.md`
- `docs/BUDDY_WORKSHOP_SPEC.md`
- `docs/COUNCIL_STARTER_PACK.md`
- `docs/CODEX_IMPLEMENTATION_PROMPT_BEMORE.md`
- `docs/BEMORE_BUILD18_PLUS_DELIVERY_POSTURE.md`
- `context/plans/2026-04-10-bemore-build18-plus-product-direction.md`
- `docs/planning/issue-drafts/2026-04-10/01-build18-workspace-buddy-foundations.md`
- `docs/planning/issue-drafts/2026-04-10/02-build18-council-starter-pack-and-buddy-library.md`
- `docs/planning/issue-drafts/2026-04-10/03-build18-buddy-workshop-sanitized-template-foundations.md`

## Why docs-only

This repo already contains the current shell/runtime baseline. These additions are planning/control artifacts intended to guide future Build 18+ work without mislabeling it as Build 17 scope.
