### PR TITLE
docs: add iOS build ownership migration plan

### DIFF
--- a/docs/migrations/IOS_BUILD_OWNERSHIP_MIGRATION.md
+++ b/docs/migrations/IOS_BUILD_OWNERSHIP_MIGRATION.md
@@ -1,0 +1,38 @@
+# iOS Build Ownership Migration
+
+`bmo-stack` is the current owner of working BeMoreAgent iOS validation and TestFlight automation.
+
+`prismtek-apps` is the intended long-term owner of BeMore iOS product build and release automation.
+
+## Current build owner truth
+
+Current workflows in `bmo-stack`:
+- `.github/workflows/bemoreagent-ios-validate.yml`
+- `.github/workflows/testflight.yml`
+- `.github/workflows/bemoreagent-platform-ios-validate.yml`
+
+Current app paths referenced by those workflows:
+- `apps/openclaw-shell-ios`
+- `apps/bemoreagent-platform-ios`
+
+## Migration rule
+
+Do not move workflow ownership until the actual iOS project exists in `prismtek-apps`.
+
+## Safe migration order
+
+1. Freeze current workflow truth in `bmo-stack`
+2. Add ownership docs in `prismtek-apps`
+3. Re-home the iOS project files into `prismtek-apps`
+4. Recreate validate and TestFlight workflows there
+5. Mirror repo variables and secrets there
+6. Prove one real TestFlight upload from `prismtek-apps`
+7. Then demote `bmo-stack` from canonical build owner
+
+## Success criteria
+
+Migration is complete only when:
+- the iOS app project exists in `prismtek-apps`
+- validation passes there
+- TestFlight upload succeeds there
+- `bmo-stack` no longer acts as canonical release owner


### PR DESCRIPTION
## Summary

Add a docs-only migration plan that freezes the current BeMoreAgent iOS build/release truth in `bmo-stack` and defines the safe handoff path to `prismtek-apps`.

## What this adds

- `docs/migrations/IOS_BUILD_OWNERSHIP_MIGRATION.md`

## Why docs-only

`bmo-stack` currently owns the working iOS validation and TestFlight workflows.
`prismtek-apps` is the intended long-term owner, but it does not yet contain the iOS project/workflow inputs required for a safe migration.

This PR records the current truth and the migration order without touching the live shipping path.

## Key posture

- keep current iOS build/release automation working in `bmo-stack`
- do not move workflow ownership until the actual iOS project exists in `prismtek-apps`
- prove the new path there before demoting old ownership here

## Task contract

- **Problem:** iOS build and release ownership is still operationally centered in `bmo-stack`, but the intended long-term product owner is `prismtek-apps`.
- **Why now:** ownership needs to be documented before migration work starts so shipping does not break during the handoff.
- **Constraints:** do not move workflows yet, do not break current validation/TestFlight automation, and do not claim migration is complete before a real replacement path exists in `prismtek-apps`.
- **Definition of done:** the PR documents the current ownership truth, the safe migration order, and the conditions required before old workflow ownership can be demoted.
