### PR TITLE
ci: use macos 26 for iOS build jobs

### DIFF
--- a/.github/workflows/bemoreagent-ios-validate.yml
+++ b/.github/workflows/bemoreagent-ios-validate.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build-ios:
     name: Generate and build BeMoreAgent
-    runs-on: macos-latest
+    runs-on: macos-26
     defaults:
       run:
         working-directory: apps/openclaw-shell-ios

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-26
     defaults:
       run:
         working-directory: apps/openclaw-shell-ios


### PR DESCRIPTION
## Summary

Switches BeMoreAgent iOS validation and Build & TestFlight from `macos-latest` to `macos-26` so hosted GitHub Actions use an iOS 26-capable Xcode image.

This follows the GitHub Actions macOS 26 hosted runner label documented by GitHub and fixes the `master` Build & TestFlight failure where `macos-latest` exposed Xcode 16.4 / iPhoneOS SDK 18.5 while the project requires `IPHONEOS_DEPLOYMENT_TARGET 26.0`.

## Task contract
- Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem

Build & TestFlight ran on hosted macOS after #235, but failed in the Xcode preflight with `Xcode SDK 18.5 is too old for IPHONEOS_DEPLOYMENT_TARGET 26.0`.

## Smallest useful wedge

Use the hosted `macos-26` runner label for both BeMoreAgent iOS validation and Build & TestFlight so the workflows run on the correct macOS/Xcode generation.

## Verification plan

Run `node scripts/validate-github-automation.mjs` locally and use GitHub PR checks plus the post-merge `master` Build & TestFlight run as the release proof path.

## Rollback plan

Revert this PR if the project target is intentionally lowered below iOS 26 or if a dedicated iOS 26 self-hosted runner is brought back online and explicitly chosen for release workflows.
