### PR TITLE
Make BeMore identity and Worker ownership explicit

### DIFF
--- a/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
+++ b/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
@@ -30,13 +30,13 @@ Current shipped shell surfaces include:
 - Relaunch returns to the main tab shell after onboarding is complete.
 - The local runtime is still stubbed unless `MLCSwift` is actually present and wired.
 - Cloud routes can be configured in Settings and switched in Models.
-- Workspace actions run through OpenClaw runtime receipts. The UI should not claim files, memory,
+- Workspace actions run through BeMore runtime receipts. The UI should not claim files, memory,
   skills, or sandbox work completed unless the runtime returns a completed or persisted receipt.
-- Buddy install/personalize/check-in/training actions also run through OpenClaw runtime receipts and
+- Buddy install/personalize/check-in/training actions also run through BeMore runtime receipts and
   should not claim continuity updates unless the receipt persisted the Buddy bundle artifacts.
 - Cloud/local replies are sanitized before display so hidden reasoning/thought blocks are not shown
   unless the operator explicitly asks for an explanation.
-- The iOS sandbox currently exposes controlled OpenClaw commands (`pwd`, `ls`, `cat`, `write`, `regenerate`,
+- The iOS sandbox currently exposes controlled BeMore commands (`pwd`, `ls`, `cat`, `write`, `regenerate`,
   `skills`, `help`) rather than arbitrary host shell execution.
 
 ## Local build path

--- a/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
@@ -78,7 +78,7 @@ struct OnboardingFlow: View {
                 .font(.system(size: 36, weight: .bold))
                 .foregroundColor(BMOTheme.textPrimary)
 
-            Text("Build the mobile front door for a real self-hosted OpenClaw stack, based on the answers you give here.")
+            Text("Build the mobile front door for a real BeMore stack, based on the answers you give here.")
                 .font(.body)
                 .foregroundColor(BMOTheme.textSecondary)
                 .multilineTextAlignment(.center)
@@ -86,7 +86,7 @@ struct OnboardingFlow: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 featureRow("Generate a concrete stack profile instead of fake setup copy")
-                featureRow("Target a real OpenClaw runtime and node pairing flow")
+                featureRow("Target a real BeMore runtime and Mac pairing flow")
                 featureRow("Show honest readiness for local runtime, providers, and shell surfaces")
             }
             .padding(.horizontal, BMOTheme.spacingXL)
@@ -114,7 +114,7 @@ struct OnboardingFlow: View {
                     .foregroundColor(BMOTheme.textPrimary)
                     .padding(.horizontal, BMOTheme.spacingLG)
 
-                Text("This should match the real OpenClaw deployment the app is going to represent.")
+                Text("This should match the real BeMore deployment the app is going to represent.")
                     .font(.subheadline)
                     .foregroundColor(BMOTheme.textSecondary)
                     .padding(.horizontal, BMOTheme.spacingLG)
@@ -149,8 +149,8 @@ struct OnboardingFlow: View {
                 .padding(.horizontal, BMOTheme.spacingLG)
 
                 labeledField(title: "Stack name", text: $config.stackName, placeholder: "BeMoreAgent")
-                labeledField(title: "Primary goal", text: $config.goal, placeholder: "Run my own OpenClaw stack")
-                labeledField(title: "Runtime endpoint", text: $config.gatewayURL, placeholder: "https://openclaw.example.com")
+                labeledField(title: "Primary goal", text: $config.goal, placeholder: "Run my own BeMore stack")
+                labeledField(title: "Runtime endpoint", text: $config.gatewayURL, placeholder: "https://bemore.example.com")
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                 labeledField(title: "Admin / public domain", text: $config.adminDomain, placeholder: "example.com")
@@ -363,7 +363,7 @@ struct OnboardingFlow: View {
                     .font(.system(size: 28, weight: .bold))
                     .foregroundColor(BMOTheme.textPrimary)
 
-                Text("Your iPhone shell now reflects a real OpenClaw setup profile.")
+                Text("Your iPhone shell now reflects a real BeMore setup profile.")
                     .font(.subheadline)
                     .foregroundColor(BMOTheme.textSecondary)
 
@@ -422,7 +422,7 @@ struct OnboardingFlow: View {
 
                 Button("Launch shell") {
                     config.stackName = fallback(config.stackName, defaultValue: "BeMoreAgent")
-                    config.goal = fallback(config.goal, defaultValue: "Run a self-hosted OpenClaw stack")
+                    config.goal = fallback(config.goal, defaultValue: "Run a self-hosted BeMore stack")
                     config.role = fallback(config.role, defaultValue: "Operator")
                     config.operatorName = fallback(config.operatorName, defaultValue: "Operator")
                     config.gatewayURL = fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")
@@ -549,10 +549,10 @@ struct OnboardingFlow: View {
     private var generatedChecklist: [String] {
         var items: [String] = []
         if config.deploymentMode == .bootstrapSelfHosted {
-            items.append("Provision or verify an OpenClaw runtime endpoint at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
+            items.append("Provision or verify a BeMore runtime endpoint at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
             items.append("Set runtime and pairing/public URL values to match \(fallback(config.adminDomain, defaultValue: "prismtek.dev")).")
         } else {
-            items.append("Pair this app to the existing OpenClaw runtime endpoint at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
+            items.append("Pair this app to the existing BeMore runtime endpoint at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
         }
         if config.installNodeOnThisPhone {
             items.append("Treat this iPhone as a node surface with notification, camera, and device capability permissions.")

--- a/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
@@ -168,7 +168,7 @@ enum BuiltInSkillRegistry {
             SkillManifest(
                 id: pokemonTeamBuilderID,
                 name: "Pokemon Team Builder",
-                description: "Draft, analyze, save, and export structured Pokemon teams as OpenClaw artifacts.",
+                description: "Draft, analyze, save, and export structured Pokemon teams as BeMore workspace artifacts.",
                 version: "1.0.0",
                 category: "Games",
                 tags: ["pokemon", "team-builder", "strategy"],
@@ -191,7 +191,7 @@ enum BuiltInSkillRegistry {
             SkillManifest(
                 id: artifactRebuilderID,
                 name: "Artifact Rebuilder",
-                description: "Regenerate canonical soul, user, memory, session, and skills artifacts from current OpenClaw state.",
+                description: "Regenerate canonical soul, user, memory, session, and skills artifacts from current BeMore workspace state.",
                 version: "1.0.0",
                 category: "System",
                 tags: ["artifacts", "memory", "workspace"],
@@ -225,7 +225,7 @@ enum ClawHubCatalog {
         ClawHubSkillTemplate(
             id: "clawhub-skill-composer",
             name: "Skill Composer",
-            description: "Draft and evolve custom OpenClaw skills as manifest-backed workspace artifacts.",
+            description: "Draft and evolve custom BeMore skills as manifest-backed workspace artifacts.",
             category: "Authoring",
             tags: ["skills", "authoring", "clawhub"],
             starterMarkdown: """
@@ -410,7 +410,7 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         ensureStateStores(config: config, preferences: preferences, routeSummary: routeSummary)
         regenerateCanonicalArtifactsIfMissing(config: config, preferences: preferences, routeSummary: routeSummary)
         refreshMetadata()
-        appendEvent(type: "workspace.bootstrapped", message: "OpenClaw workspace runtime bootstrapped.")
+        appendEvent(type: "workspace.bootstrapped", message: "BeMore workspace runtime bootstrapped.")
     }
 
     func readFile(_ path: String) throws -> String {
@@ -654,7 +654,7 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
                 status: .failed,
                 summary: "Arbitrary shell execution is unavailable in the iOS sandbox",
                 output: ["exitCode": "127"],
-                error: "Unsupported command '\(op)'. Build 17 exposes a controlled OpenClaw command surface; TODO: connect a hardened process runner where platform policy allows it."
+                error: "Unsupported command '\(op)'. Build 18 exposes a controlled BeMore command surface; TODO: connect a hardened process runner where platform policy allows it."
             )
         }
     }
@@ -746,7 +746,7 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         }
         let latestLog = rootURL.appendingPathComponent("logs/latest-actions.log")
         if !fileManager.fileExists(atPath: latestLog.path) {
-            try? "OpenClaw action log initialized.\n".write(to: latestLog, atomically: true, encoding: .utf8)
+            try? "BeMore action log initialized.\n".write(to: latestLog, atomically: true, encoding: .utf8)
         }
     }
 
@@ -754,8 +754,8 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         writeJSON([
             "identity": [preferences.preferredName.nilIfBlank ?? config.operatorName.nilIfBlank ?? "operator"],
             "project": [config.stackName],
-            "workflow": [config.goal.nilIfBlank ?? "Build and operate an OpenClaw workspace"],
-            "tooling": ["OpenClaw iOS workspace runtime", routeSummary],
+            "workflow": [config.goal.nilIfBlank ?? "Build and operate a BeMore workspace"],
+            "tooling": ["BeMore iOS workspace runtime", routeSummary],
             "game": ["Pokemon Team Builder is a registered skill"]
         ], to: rootURL.appendingPathComponent("state/facts.json"))
 
@@ -801,7 +801,7 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
             "soul.md": """
             # soul.md
 
-            OpenClaw is one agent, one workspace, one sandbox, and one capability surface.
+            BeMore is one agent, one workspace, one sandbox, and one capability surface.
 
             ## Operating posture
             - Prefer confirmed runtime receipts over fluent claims.
@@ -833,7 +833,7 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
             # memory.md
 
             ## Durable facts
-            - OpenClaw should feel like a real agent workspace, not a chat-only shell.
+            - BeMore should feel like a real agent workspace, not a chat-only shell.
             - Canonical artifacts live under `.openclaw/`.
             - Pokemon Team Builder is a first-class skill and saves artifacts.
             - Completion language must be receipt-aware.

--- a/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
@@ -778,13 +778,13 @@ enum CloudPromptBuilder {
         let name = operatorName.trimmingCharacters(in: .whitespacesAndNewlines)
         let displayName = name.isEmpty ? "the operator" : name
         let toolPosture = config.toolsEnabled
-            ? "The operator intends to use tool-capable OpenClaw routes through the built-in Workspace Runtime as capabilities become available."
+            ? "The operator intends to use tool-capable BeMore routes through the built-in Workspace Runtime as capabilities become available."
             : "The operator has not enabled tool-capable behavior for this stack profile."
 
         return """
-        You are BeMoreAgent, the BMO-style operator agent for \(displayName)'s OpenClaw stack.
+        You are BeMoreAgent, the BMO-style operator agent for \(displayName)'s BeMore stack.
 
-        You are not confined to the iOS app. Do not frame yourself as app-only. Help with the full OpenClaw/operator context: planning, repo work, runtime diagnosis, provider setup, deployment reasoning, and stack operations.
+        You are not confined to the iOS app. Do not frame yourself as app-only. Help with the full BeMore operator context: planning, repo work, runtime diagnosis, provider setup, deployment reasoning, and stack operations.
 
         Current route: \(routeLabel).
         Stack name: \(config.stackName).
@@ -792,7 +792,7 @@ enum CloudPromptBuilder {
         Admin/public domain: \(config.adminDomain).
         \(toolPosture)
 
-        Be honest about capabilities. This direct cloud chat route can reason and use attached file context. Real filesystem, memory, skill, and sandbox changes must go through OpenClaw Workspace Runtime receipts. If a capability is unavailable in this iOS runtime, say unavailable or failed instead of claiming completion.
+        Be honest about capabilities. This direct cloud chat route can reason and use attached file context. Real filesystem, memory, skill, and sandbox changes must go through BeMore Workspace Runtime receipts. If a capability is unavailable in this iOS runtime, say unavailable or failed instead of claiming completion.
 
         Reply with the answer only. Do not reveal hidden reasoning, chain-of-thought, scratchpad notes, analysis sections, or internal deliberation unless the operator explicitly asks for an explanation. If asked to explain, give a concise rationale, not private step-by-step thoughts.
         """
@@ -1220,7 +1220,7 @@ final class AppState: ObservableObject {
 
     var operatorSummary: String {
         if let account = selectedProviderAccount {
-            return "Chat is routed through \(account.provider.displayName) using \(account.modelSlug). Workspace actions use the built-in OpenClaw runtime and receipts."
+            return "Chat is routed through \(account.provider.displayName) using \(account.modelSlug). Workspace actions use the built-in BeMore runtime and receipts."
         } else if let model = selectedInstalledModel {
             if usesStubRuntime {
                 return "\(model.displayName) is selected, but local inference is unavailable in this build."
@@ -1544,7 +1544,7 @@ final class AppState: ObservableObject {
             let reply = try await cloudExecutionService.send(
                 account: account,
                 messages: [
-                    CloudExecutionMessage(role: .system, content: "You are verifying BeMoreAgent's direct cloud chat route for an OpenClaw operator stack. Reply with exactly: ROUTE_OK"),
+                    CloudExecutionMessage(role: .system, content: "You are verifying BeMoreAgent's direct cloud chat route for a BeMore operator stack. Reply with exactly: ROUTE_OK"),
                     CloudExecutionMessage(role: .user, content: "Return ROUTE_OK")
                 ],
                 temperature: 0,

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ModelsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ModelsView.swift
@@ -368,7 +368,7 @@ struct ModelsView: View {
                 .fontWeight(.semibold)
                 .foregroundColor(BMOTheme.textSecondary)
 
-            Text("Choose the active model route here. Workspace actions run through OpenClaw runtime receipts, not unconfirmed model claims.")
+            Text("Choose the active model route here. Workspace actions run through BeMore runtime receipts, not unconfirmed model claims.")
                 .font(.caption)
                 .foregroundColor(BMOTheme.textTertiary)
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
@@ -41,7 +41,7 @@ struct SkillsView: View {
     private var headerCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Text("OpenClaw Skills")
+                Text("BeMore Skills")
                     .font(.system(size: 28, weight: .bold))
                     .foregroundColor(BMOTheme.textPrimary)
                 Spacer()

--- a/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
+++ b/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
@@ -97,7 +97,7 @@ final class AppStateRuntimeTests: XCTestCase {
 
         XCTAssertEqual(appState.activeRouteModeLabel, "Direct cloud model route")
         XCTAssertTrue(appState.operatorSummary.contains("routed through OpenAI"))
-        XCTAssertTrue(appState.operatorSummary.contains("Workspace actions use the built-in OpenClaw runtime"))
+        XCTAssertTrue(appState.operatorSummary.contains("Workspace actions use the built-in BeMore runtime"))
         XCTAssertTrue(appState.routeHealthSummary.contains("Cloud chat is ready"))
     }
 
@@ -115,7 +115,7 @@ final class AppStateRuntimeTests: XCTestCase {
         )
 
         XCTAssertTrue(prompt.contains("not confined to the iOS app"))
-        XCTAssertTrue(prompt.contains("full OpenClaw/operator context"))
+        XCTAssertTrue(prompt.contains("full BeMore operator context"))
         XCTAssertTrue(prompt.contains("Workspace Runtime receipts"))
         XCTAssertTrue(prompt.contains("Do not reveal hidden reasoning"))
         XCTAssertFalse(prompt.contains("only perform functions inside the app"))
@@ -139,7 +139,7 @@ final class AppStateRuntimeTests: XCTestCase {
     func testWorkspaceBootstrapCreatesCanonicalOpenClawArtifacts() throws {
         let runtime = OpenClawWorkspaceRuntime()
         var config = StackConfig.default
-        config.stackName = "OpenClaw"
+        config.stackName = "BeMore"
         config.role = "operator"
         config.goal = "build a real workspace"
 

--- a/apps/openclaw-shell-ios/README.md
+++ b/apps/openclaw-shell-ios/README.md
@@ -1,6 +1,6 @@
 # BeMoreAgent iOS Shell
 
-Native SwiftUI iPhone shell for the BeMoreAgent/OpenClaw operator stack.
+Native SwiftUI iPhone shell for the BeMoreAgent operator stack.
 
 ## Current product shell
 

--- a/docs/CLOUDFLARE_WORKER_OWNERSHIP.md
+++ b/docs/CLOUDFLARE_WORKER_OWNERSHIP.md
@@ -1,0 +1,5 @@
+# Cloudflare Worker Ownership
+
+`bmo-stack` deploys the `cloudflare/prismtek-api` Worker as `prismtek-api`.
+
+The old duplicate `prismtek-ai` Worker was removed from Cloudflare on 2026-04-11 after Cloudflare generated alternating bot PRs that flipped `wrangler.jsonc` between `prismtek-ai` and `prismtek-api`. Keep one Worker/build integration for this repo so the Worker name, source path, GitHub checks, and dashboard integration do not drift again.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "prismtek-ai",
+  "name": "prismtek-api",
   "compatibility_date": "2026-03-26",
   "main": "cloudflare/prismtek-api/index.ts"
 }


### PR DESCRIPTION
## Task contract
Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem
BeMoreAgent still had product-facing OpenClaw-centered copy, and the Cloudflare Worker dashboard had duplicated `prismtek-ai`/`prismtek-api` ownership that produced oscillating wrangler-name bot PRs.

## Smallest useful wedge
Update only BeMore-facing copy and Worker ownership metadata: keep legacy internal paths/types intact, make `prismtek-api` the repo and Cloudflare Worker name, and document that `prismtek-ai` was removed as the duplicate Worker.

## Verification plan
Run the GitHub automation validator, whitespace diff check, XcodeGen project generation, and the BeMoreAgent iOS simulator build. Confirm Cloudflare Workers Builds target `prismtek-api`.

## Rollback plan
Revert this PR commit to restore the previous copy and wrangler name; recreate the removed Cloudflare duplicate only if a live dependency is found, though current dashboard state shows `prismtek-api` as canonical.

## Summary
- updates BeMoreAgent product-facing copy from OpenClaw-centered language to BeMore language
- changes wrangler Worker name to canonical prismtek-api
- documents Cloudflare Worker ownership after removing the duplicate prismtek-ai Worker

## Validation
- node scripts/validate-github-automation.mjs
- git diff --check
- xcodegen generate
- xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath .build/DerivedData build
