### PR TITLE
Fix TestFlight runner signing preflight

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -23,6 +23,10 @@ jobs:
       ASC_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
       ASC_KEY_ID: ${{ secrets.APPSTORE_CONNECT_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_ISSUER_ID }}
+      IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64: ${{ secrets.BEMORE_IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64 }}
+      IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.BEMORE_IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+      IOS_APPSTORE_PROFILE_BASE64: ${{ secrets.BEMORE_IOS_APPSTORE_PROFILE_BASE64 }}
+      IOS_APPSTORE_PROFILE_NAME: iOS Team Store Provisioning Profile: BeMoreAgent
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -88,6 +92,62 @@ jobs:
             printf '%s' "$ASC_API_KEY" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
           fi
 
+      - name: Validate CI signing assets
+        run: |
+          missing=0
+          for name in IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64 IOS_DISTRIBUTION_CERTIFICATE_PASSWORD IOS_APPSTORE_PROFILE_BASE64; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error title=Missing BeMoreAgent CI signing secret::$name is required for GitHub-hosted TestFlight delivery. Export the BeMoreAgent App Store distribution .p12 and App Store .mobileprovision profile, then set BEMORE_IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64, BEMORE_IOS_DISTRIBUTION_CERTIFICATE_PASSWORD, and BEMORE_IOS_APPSTORE_PROFILE_BASE64."
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 65
+          fi
+          echo "CI signing assets are present for team DY9FHPRZA9 and bundle id BeMoreAgent."
+
+      - name: Import CI signing assets
+        run: |
+          umask 077
+          SIGNING_KEYCHAIN="$RUNNER_TEMP/bemoreagent-signing.keychain-db"
+          SIGNING_KEYCHAIN_PASSWORD="$(uuidgen)"
+          CERT_PATH="$RUNNER_TEMP/bemoreagent-distribution.p12"
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          PROFILE_PATH="$PROFILE_DIR/BeMoreAgent-AppStore.mobileprovision"
+
+          printf '%s' "$IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64" | base64 --decode > "$CERT_PATH"
+          mkdir -p "$PROFILE_DIR"
+          printf '%s' "$IOS_APPSTORE_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+
+          security create-keychain -p "$SIGNING_KEYCHAIN_PASSWORD" "$SIGNING_KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$SIGNING_KEYCHAIN"
+          security unlock-keychain -p "$SIGNING_KEYCHAIN_PASSWORD" "$SIGNING_KEYCHAIN"
+          security import "$CERT_PATH" -k "$SIGNING_KEYCHAIN" -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/xcodebuild
+          security list-keychains -d user -s "$SIGNING_KEYCHAIN" $(security list-keychains -d user | sed 's/[ "]//g')
+          security default-keychain -d user -s "$SIGNING_KEYCHAIN"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$SIGNING_KEYCHAIN_PASSWORD" "$SIGNING_KEYCHAIN"
+
+          security find-identity -v -p codesigning "$SIGNING_KEYCHAIN"
+          PROFILE_NAME="$(security cms -D -i "$PROFILE_PATH" | plutil -extract Name raw -o - -)"
+          PROFILE_BUNDLE="$(security cms -D -i "$PROFILE_PATH" | plutil -extract Entitlements.application-identifier raw -o - -)"
+          PROFILE_GET_TASK_ALLOW="$(security cms -D -i "$PROFILE_PATH" | plutil -extract Entitlements.get-task-allow raw -o - -)"
+          echo "Imported profile: $PROFILE_NAME"
+          echo "Profile application identifier: $PROFILE_BUNDLE"
+          if [ "$PROFILE_BUNDLE" != "DY9FHPRZA9.BeMoreAgent" ]; then
+            echo "::error title=Wrong provisioning profile::Expected DY9FHPRZA9.BeMoreAgent, got $PROFILE_BUNDLE"
+            exit 65
+          fi
+          if [ "$PROFILE_GET_TASK_ALLOW" != "false" ]; then
+            echo "::error title=Wrong provisioning profile::Expected an App Store profile with get-task-allow=false, got $PROFILE_GET_TASK_ALLOW"
+            exit 65
+          fi
+          if [ "$PROFILE_NAME" != "$IOS_APPSTORE_PROFILE_NAME" ]; then
+            echo "::notice title=Provisioning profile name differs::Expected '$IOS_APPSTORE_PROFILE_NAME', got '$PROFILE_NAME'. The workflow will use the imported name."
+            echo "IOS_APPSTORE_PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"
+          fi
+          echo "BEMORE_SIGNING_KEYCHAIN=$SIGNING_KEYCHAIN" >> "$GITHUB_ENV"
+          echo "BEMORE_SIGNING_PROFILE_PATH=$PROFILE_PATH" >> "$GITHUB_ENV"
+
       - name: Show app version and build
         run: |
           VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' OpenClawShell/Info.plist)
@@ -140,10 +200,12 @@ jobs:
             -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
             CODE_SIGN_STYLE=Automatic \
             DEVELOPMENT_TEAM=DY9FHPRZA9 \
+            OTHER_CODE_SIGN_FLAGS="--keychain $BEMORE_SIGNING_KEYCHAIN" \
             clean archive
 
       - name: Export and upload to TestFlight
         run: |
+          plutil -p exportOptions-upload.plist
           xcodebuild -exportArchive \
             -archivePath "$RUNNER_TEMP/BeMoreAgent.xcarchive" \
             -exportPath "$RUNNER_TEMP/BeMoreAgent-export" \
@@ -180,4 +242,8 @@ jobs:
 
       - name: Clean temporary signing files
         if: always()
-        run: rm -f "$RUNNER_TEMP/AuthKey.p8"
+        run: |
+          rm -f "$RUNNER_TEMP/AuthKey.p8" "$RUNNER_TEMP/bemoreagent-distribution.p12"
+          if [ -n "${BEMORE_SIGNING_KEYCHAIN:-}" ]; then
+            security delete-keychain "$BEMORE_SIGNING_KEYCHAIN" || true
+          fi

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -123,7 +123,7 @@ jobs:
           security set-keychain-settings -lut 21600 "$SIGNING_KEYCHAIN"
           security unlock-keychain -p "$SIGNING_KEYCHAIN_PASSWORD" "$SIGNING_KEYCHAIN"
           security import "$CERT_PATH" -k "$SIGNING_KEYCHAIN" -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/xcodebuild
-          security list-keychains -d user -s "$SIGNING_KEYCHAIN" $(security list-keychains -d user | sed 's/[ "]//g')
+          security list-keychains -d user -s "$SIGNING_KEYCHAIN"
           security default-keychain -d user -s "$SIGNING_KEYCHAIN"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$SIGNING_KEYCHAIN_PASSWORD" "$SIGNING_KEYCHAIN"
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -26,7 +26,7 @@ jobs:
       IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64: ${{ secrets.BEMORE_IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64 }}
       IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.BEMORE_IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
       IOS_APPSTORE_PROFILE_BASE64: ${{ secrets.BEMORE_IOS_APPSTORE_PROFILE_BASE64 }}
-      IOS_APPSTORE_PROFILE_NAME: iOS Team Store Provisioning Profile: BeMoreAgent
+      IOS_APPSTORE_PROFILE_NAME: 'iOS Team Store Provisioning Profile: BeMoreAgent'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md
+++ b/apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md
@@ -17,6 +17,29 @@ The `Build & TestFlight` workflow expects these GitHub repository secrets:
 - `APPSTORE_CONNECT_API_KEY`
 - `APPSTORE_CONNECT_KEY_ID`
 - `APPSTORE_CONNECT_ISSUER_ID`
+- `BEMORE_IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64`
+- `BEMORE_IOS_DISTRIBUTION_CERTIFICATE_PASSWORD`
+- `BEMORE_IOS_APPSTORE_PROFILE_BASE64`
+
+The runner must not rely on Apple automatic certificate creation. It imports the BeMoreAgent
+App Store signing certificate and App Store provisioning profile first, then lets Xcode automatic
+signing select those existing assets. This avoids the Apple Developer certificate-quota failure:
+
+```text
+Choose a certificate to revoke. Your account has reached the maximum number of certificates.
+```
+
+Current expected signing inputs:
+
+- Team: `DY9FHPRZA9`
+- Bundle identifier: `BeMoreAgent`
+- Profile application identifier: `DY9FHPRZA9.BeMoreAgent`
+- Profile name: `iOS Team Store Provisioning Profile: BeMoreAgent`
+- Certificate: `iPhone Distribution: Cody Sumpter (DY9FHPRZA9)`
+
+If the `.p12` private-key export is blocked by macOS Keychain UI authorization, export it from Keychain
+Access on the Mac with the matching private key, base64 encode it, and set the three `BEMORE_IOS_*`
+secrets before rerunning `Build & TestFlight`.
 
 ### Variables
 


### PR DESCRIPTION
## Task contract
Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem
Build & TestFlight was still red on GitHub-hosted signing because the runner did not have the local distribution certificate private key or App Store provisioning profile. Xcode then tried automatic repair and hit the Apple certificate quota / missing-profile path.

## Smallest useful wedge
Import the BeMoreAgent distribution p12 and App Store provisioning profile from explicit GitHub secrets, validate the team/bundle/profile contract before archiving, keep automatic signing so the Xcode-managed App Store profile is accepted, and document the required secret set in the admin runbook.

## Verification plan
- `git diff --check`
- `node scripts/validate-github-automation.mjs`
- `cd apps/openclaw-shell-ios && xcodegen generate && xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath .build/DerivedData build`
- Dispatch `Build & TestFlight` on this branch to verify runner-side archive/upload.

## Rollback plan
Revert this PR to return the workflow to the previous automatic-signing behavior and remove/rotate the three BeMoreAgent CI signing secrets if desired.