### PR TITLE
Bump BeMoreAgent TestFlight build to 19

### DIFF
--- a/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
+++ b/apps/openclaw-shell-ios/BE_MORE_AGENT_STATUS.md
@@ -54,7 +54,7 @@ xcodebuild -project BeMoreAgent.xcodeproj \
 
 ## Release path
 
-- `CFBundleVersion` is currently `18`.
+- `CFBundleVersion` is currently `19` because App Store Connect already has build `18` and rejects duplicate uploads.
 - `IPHONEOS_DEPLOYMENT_TARGET` is currently `26.0`.
 - TestFlight delivery is repo-managed through `.github/workflows/testflight.yml`.
 - The operator runbook for that path is `apps/openclaw-shell-ios/ADMIN_TESTFLIGHT_RUNBOOK.md`.
@@ -66,7 +66,7 @@ xcodebuild -project BeMoreAgent.xcodeproj \
 - `project.yml` still has `dependencies: []`.
 - When `MLCSwift` is not importable, the app still uses the stub local-runtime path and cannot claim
   real on-device inference.
-- Arbitrary codex-style shell/process execution is not available on-device in this build. Build 18
+- Arbitrary codex-style shell/process execution is not available on-device in this build. Build 19
   provides a receipt-backed controlled sandbox surface and leaves real hardened process execution for
   a future platform/runtime integration.
 - Buddy Workshop authoring, external package publishing, and marketplace flows are not shipped in

--- a/apps/openclaw-shell-ios/OpenClawShell/Info.plist
+++ b/apps/openclaw-shell-ios/OpenClawShell/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.2</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
## Task contract
Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem
The GitHub-hosted TestFlight lane now archives and reaches App Store upload, but Apple rejected build 18 because App Store Connect already has CFBundleVersion 18. Apple does not allow reuploading the same bundle version.

## Smallest useful wedge
Bump BeMoreAgent CFBundleVersion to 19 and record the reason in the status doc so the now-fixed runner signing/upload lane can complete with a fresh build number.

## Verification plan
- `git diff --check`
- `cd apps/openclaw-shell-ios && xcodegen generate && xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath .build/DerivedData build`
- Merge and watch `Build & TestFlight` on master.

## Rollback plan
Revert this PR if Build 19 should not be used; Build 18 cannot be reuploaded while it already exists in App Store Connect.