### PR TITLE
Align iOS shell with Buddy-first BeMore

### DIFF
--- a/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
@@ -421,41 +421,41 @@ struct KnownModel: Identifiable {
 
 enum AppTab: String, Codable, CaseIterable, Hashable, Identifiable {
     case missionControl
-    case models
-    case chat
-    case skills
-    case artifacts
     case buddy
     case files
+    case skills
+    case artifacts
     case pairing
+    case models
+    case chat
     case settings
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .missionControl: return "Control"
+        case .missionControl: return "Home"
+        case .buddy: return "Buddy"
+        case .files: return "Workspace"
+        case .skills: return "Skills"
+        case .artifacts: return "Results"
+        case .pairing: return "Mac"
         case .models: return "Models"
         case .chat: return "Chat"
-        case .skills: return "Skills"
-        case .artifacts: return "Artifacts"
-        case .buddy: return "Buddy"
-        case .files: return "Files"
-        case .pairing: return "Pairing"
         case .settings: return "Settings"
         }
     }
 
     var systemImage: String {
         switch self {
-        case .missionControl: return "switch.2"
+        case .missionControl: return "heart.text.square.fill"
+        case .buddy: return "person.crop.circle.badge.checkmark"
+        case .files: return "folder.fill"
+        case .skills: return "sparkles.rectangle.stack.fill"
+        case .artifacts: return "checklist.checked"
+        case .pairing: return "macbook.and.iphone"
         case .models: return "cpu"
         case .chat: return "message.fill"
-        case .skills: return "sparkles.rectangle.stack.fill"
-        case .artifacts: return "doc.richtext.fill"
-        case .buddy: return "person.2.fill"
-        case .files: return "folder.fill"
-        case .pairing: return "macbook.and.iphone"
         case .settings: return "gearshape.fill"
         }
     }
@@ -471,7 +471,7 @@ struct ShellPreferences: Codable, Hashable {
     var selectedTab: AppTab
 
     static let `default` = ShellPreferences(
-        orderedTabs: AppTab.allCases,
+        orderedTabs: [.missionControl, .buddy, .files, .skills, .artifacts, .pairing, .models, .chat, .settings],
         hiddenTabs: [],
         selectedTab: .missionControl
     )

--- a/apps/openclaw-shell-ios/OpenClawShell/BuddyMarkdownRenderer.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/BuddyMarkdownRenderer.swift
@@ -110,7 +110,7 @@ enum BuddyMarkdownRenderer {
         if let level = nextLevel.level, let remainingXP = nextLevel.remainingXP {
             lines.append("Next level: \(level) in \(remainingXP) XP.")
         } else {
-            lines.append("Level cap reached for the current Build 18 wedge.")
+            lines.append("Level cap reached for the current BeMore companion wedge.")
         }
 
         if let challenge = roleProfile?.dailyChallengeHook {

--- a/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OpenClawWorkspaceRuntime.swift
@@ -599,8 +599,8 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
             let manifestData = try encoder.encode(manifest)
             _ = try writeFile("\(folder)/manifest.json", content: String(data: manifestData, encoding: .utf8) ?? "{}", source: "clawhub")
             refreshMetadata()
-            appendEvent(type: "skill.installed", message: "Installed \(template.name) from ClawHub.", metadata: ["skillId": template.id])
-            return finish(action, status: .persisted, summary: "Installed \(template.name) from ClawHub", output: ["skillId": template.id], artifacts: ["registry/skills.json", "\(folder)/README.md", "\(folder)/manifest.json"])
+            appendEvent(type: "skill.installed", message: "Installed \(template.name) from Buddy Skill Hub.", metadata: ["skillId": template.id])
+            return finish(action, status: .persisted, summary: "Installed \(template.name) from Buddy Skill Hub", output: ["skillId": template.id], artifacts: ["registry/skills.json", "\(folder)/README.md", "\(folder)/manifest.json"])
         } catch {
             return finish(action, status: .failed, summary: "Could not install \(template.name)", error: error.localizedDescription)
         }
@@ -654,7 +654,7 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
                 status: .failed,
                 summary: "Arbitrary shell execution is unavailable in the iOS sandbox",
                 output: ["exitCode": "127"],
-                error: "Unsupported command '\(op)'. Build 18 exposes a controlled BeMore command surface; TODO: connect a hardened process runner where platform policy allows it."
+                error: "Unsupported command '\(op)'. iPhone uses a controlled BeMore command surface; pair with Mac for full process execution."
             )
         }
     }
@@ -859,14 +859,14 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
             "skills.md": """
             # skills.md
 
-            Skills are registry-backed and can be extended through ClawHub installs or user-authored manifests.
+            Skills are registry-backed and can be extended through Buddy Skill Hub installs or user-authored manifests.
 
             ## Installed skills
             \(skills.map { skill in
                 "- **\(skill.name)** (`\(skill.id)`): \(skill.description)\n  - Category: \(skill.category)\n  - Entrypoint: \(skill.entrypoint)\n  - Permissions: \(skill.permissions.joined(separator: ", "))"
             }.joined(separator: "\n"))
 
-            ## ClawHub starters
+            ## Buddy Skill Hub starters
             \(ClawHubCatalog.templates.map { "- **\($0.name)** (`\($0.id)`): \($0.description)" }.joined(separator: "\n"))
 
             ## Skill authoring rules
@@ -979,7 +979,7 @@ final class OpenClawWorkspaceRuntime: ObservableObject {
         - Status: completed with local workspace receipt
 
         ## Result
-        This ClawHub skill is installed and callable through the generic skill runner. Connect deeper domain logic by editing `skills/\(manifest.id)/README.md` and its manifest.
+        This Buddy Skill Hub skill is installed and callable through the generic skill runner. Connect deeper domain logic by editing `skills/\(manifest.id)/README.md` and its manifest.
         """
         do {
             let url = try resolve(path)

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ArtifactsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ArtifactsView.swift
@@ -54,13 +54,13 @@ struct ArtifactsView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Text(".openclaw")
+                Text("Results")
                     .font(.system(size: 28, weight: .bold))
                     .foregroundColor(BMOTheme.textPrimary)
                 Spacer()
                 StatusBadge(label: "\(appState.workspaceRuntime.artifacts.count) files", color: BMOTheme.accent)
             }
-            Text("Canonical files, state stores, action receipts, event logs, registry data, and saved skill outputs live here.")
+            Text("Canonical state, receipts, event logs, registry data, and saved Buddy skill outputs live here.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
         }
@@ -221,7 +221,7 @@ struct ArtifactPreviewView: View {
             Text(artifact.path)
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-            Text("Read, edit, export, or delete this persisted `.openclaw` artifact. Canonical markdown can also be regenerated.")
+            Text("Read, edit, export, or delete this persisted `Results` artifact. Canonical markdown can also be regenerated.")
                 .font(.caption)
                 .foregroundColor(BMOTheme.textTertiary)
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyAsciiView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyAsciiView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+enum BuddyAnimationMood {
+    case idle
+    case happy
+    case thinking
+    case working
+    case sleepy
+    case levelUp
+}
+
+struct BuddyAsciiView: View {
+    let mood: BuddyAnimationMood
+    var compact = false
+    @State private var tick = 0
+
+    var body: some View {
+        Text(frame)
+            .font(.system(size: compact ? 12 : 19, weight: .bold, design: .monospaced))
+            .foregroundColor(BMOTheme.accent)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(compact ? 12 : 18)
+            .background(BMOTheme.backgroundSecondary)
+            .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusSmall, style: .continuous))
+            .task {
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 520_000_000)
+                    tick += 1
+                }
+            }
+            .accessibilityLabel("Buddy \(label)")
+    }
+
+    private var label: String {
+        switch mood {
+        case .idle: return "idle"
+        case .happy: return "happy"
+        case .thinking: return "thinking"
+        case .working: return "working"
+        case .sleepy: return "sleepy"
+        case .levelUp: return "level up"
+        }
+    }
+
+    private var frame: String {
+        let frames = framesForMood
+        return frames[tick % frames.count]
+    }
+
+    private var framesForMood: [String] {
+        switch mood {
+        case .idle:
+            return [
+                Self.make(["   /\\_/\\", "  ( o.o )", "  /| _ |\\", "   /   \\", "  _|   |_"]),
+                Self.make(["   /\\_/\\", "  ( o.o )", "  /| _ |\\", "   /   \\", "   |___|"])
+            ]
+        case .happy:
+            return [
+                Self.make(["   /\\_/\\", "  ( ^.^ )", "  /| * |\\", "   / \\ \\", "  _| |_|"]),
+                Self.make(["  \\/\\_/\\/", "  ( ^o^ )", "  /| * |\\", "   / \\ \\", "  _| |_|"])
+            ]
+        case .thinking:
+            return [
+                Self.make(["   /\\_/\\", "  ( o.o )  ?", "  /| _ |\\", "   /   \\", "   |___|"]),
+                Self.make(["   /\\_/\\", "  ( o_o )  ..", "  /| _ |\\", "   /   \\", "   |___|"])
+            ]
+        case .working:
+            return [
+                Self.make(["    .-.", "  <(o o)> *", "   /| # |\\", "  /_|___|_\\", "    \\ /"]),
+                Self.make(["    .-.", "  <(o o)> **", "   /| # |\\", "  /_|___|_\\", "    / \\"])
+            ]
+        case .sleepy:
+            return [
+                Self.make(["   /\\_/\\", "  ( -.- ) z", "  /| _ |\\", "   /   \\", "   |___|"]),
+                Self.make(["   /\\_/\\", "  ( -.- ) zz", "  /| _ |\\", "   /   \\", "  _|___|_"])
+            ]
+        case .levelUp:
+            return [
+                Self.make(["  * /\\_/\\ *", "   ( ^.^ )", "  /|[*]|\\", "   / \\ \\", "  _| |_|"]),
+                Self.make([" **/\\_/\\**", "   ( ^o^ )", "  /|[*]|\\", "   / \\ \\", "  _| |_|"])
+            ]
+        }
+    }
+
+    private static func make(_ lines: [String]) -> String {
+        lines.joined(separator: "\n")
+    }
+}

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
@@ -69,7 +69,7 @@ struct BuddyView: View {
         return VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Build 18 Buddy Runtime")
+                    Text("Buddy Runtime")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
                     Text("Structured Buddy templates, installable local instances, readable continuity files, and receipt-backed updates.")
@@ -136,7 +136,7 @@ struct BuddyView: View {
                 .background(BMOTheme.backgroundSecondary)
                 .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
 
-            Text(template?.onboardingCopy ?? "Legacy Buddy migrated into the Build 18 runtime.")
+            Text(template?.onboardingCopy ?? "Buddy profile is ready for the BeMore runtime.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
 
@@ -268,7 +268,7 @@ struct BuddyView: View {
                     Text("Council Starter Pack")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("Official Build 18 Buddy templates bundled into the app from canonical PR #231 contracts.")
+                    Text("BeMore Buddy templates bundled with local continuity, training, and receipt-backed state.")
                         .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
@@ -376,7 +376,7 @@ struct BuddyView: View {
             Text("No Buddy Installed Yet")
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-            Text("Install one Council starter Buddy below to create a clean local instance, start the Buddy event stream, and generate `.openclaw/buddy.md` plus `.openclaw/buddies.md`.")
+            Text("Install a starter Buddy to create a local companion, start the Buddy event stream, and keep receipt-backed continuity.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/MacPairingView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/MacPairingView.swift
@@ -78,7 +78,7 @@ struct MacPairingView: View {
                     detailRow("Pair code", value: code)
                 }
             } else {
-                Text("No Mac snapshot yet. Start BeMore Mac Build 1, expose the runtime endpoint intentionally, then inspect it here.")
+                Text("No Mac snapshot yet. Start BeMore Mac, expose the runtime endpoint intentionally, then inspect it here.")
                     .font(.caption)
                     .foregroundColor(BMOTheme.textSecondary)
             }
@@ -105,7 +105,7 @@ struct MacPairingView: View {
             }
 
             if appState.macRuntimeSnapshot?.tasks.isEmpty ?? true {
-                Text("No Mac tasks reported.")
+                Text("No Mac tasks yet. Create or run a Buddy task on the Mac to mirror it here.")
                     .font(.caption)
                     .foregroundColor(BMOTheme.textTertiary)
             }
@@ -137,7 +137,7 @@ struct MacPairingView: View {
             }
 
             if appState.macRuntimeSnapshot?.processes.isEmpty ?? true {
-                Text("No Mac command output reported.")
+                Text("No Mac command output yet. Run a task on the Mac to inspect it here.")
                     .font(.caption)
                     .foregroundColor(BMOTheme.textTertiary)
             }
@@ -161,7 +161,7 @@ struct MacPairingView: View {
                     .font(.caption2.monospaced())
                     .foregroundColor(BMOTheme.textSecondary)
             } else {
-                Text("No unified diff reported.")
+                Text("No Mac diff yet.")
                     .font(.caption)
                     .foregroundColor(BMOTheme.textTertiary)
             }
@@ -185,7 +185,7 @@ struct MacPairingView: View {
             }
 
             if (appState.macRuntimeSnapshot?.artifacts.isEmpty ?? true) && (appState.macRuntimeSnapshot?.receipts.isEmpty ?? true) {
-                Text("No Mac artifacts or receipts reported.")
+                Text("No Mac artifacts or receipts yet.")
                     .font(.caption)
                     .foregroundColor(BMOTheme.textTertiary)
             }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
@@ -10,16 +10,15 @@ struct MissionControlView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: BMOTheme.spacingMD) {
-                    headerCard
+                    buddyHomeCard
+                    primaryFlowCard
                     if let lastReceipt {
                         ActionReceiptCard(receipt: lastReceipt)
                     }
-                    openClawDashboardCard
-                    stackContractCard
+                    taskAndResultsCard
+                    skillsCard
+                    macPowerCard
                     routeCard
-                    metricsCard
-                    providerCard
-                    shellCard
                     stackSurfacesCard
                 }
                 .padding(.horizontal, BMOTheme.spacingMD)
@@ -29,7 +28,7 @@ struct MissionControlView: View {
             .navigationTitle("")
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    Text("Mission Control")
+                    Text("Buddy Home")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
                 }
@@ -39,66 +38,91 @@ struct MissionControlView: View {
             .sheet(item: $selectedSurface) { surface in
                 RepoSurfaceDetailView(surface: surface)
             }
+            .onAppear { appState.workspaceRuntime.refreshMetadata() }
         }
     }
 
-    private var headerCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(appState.operatorDisplayName)
-                        .font(.system(size: 28, weight: .bold))
+    private var buddyHomeCard: some View {
+        let status = appState.buddyRuntimeStatus
+        return VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("BeMore")
+                        .font(.caption.weight(.semibold))
+                        .foregroundColor(BMOTheme.textTertiary)
+                    Text("Buddy keeps the work moving.")
+                        .font(.system(size: 30, weight: .bold))
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("BeMore mobile operator shell")
+                    Text(appState.operatorSummary)
                         .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
                 Spacer()
-                StatusBadge(label: appState.activeRouteModeLabel, color: appState.selectedProviderAccount != nil ? BMOTheme.success : (appState.selectedInstalledModel != nil ? BMOTheme.accent : BMOTheme.warning))
+                StatusBadge(label: status.runtimeAvailable ? "Buddy ready" : "Needs setup", color: status.runtimeAvailable ? BMOTheme.success : BMOTheme.warning)
             }
 
-            Text(appState.operatorSummary)
-                .font(.subheadline)
-                .foregroundColor(BMOTheme.textSecondary)
+            BuddyAsciiView(mood: buddyMood(for: status))
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                dashboardMetric("Workspace", value: "\(appState.workspaceStore.files.count)", icon: "folder")
+                dashboardMetric("Skills", value: "\(status.registeredSkillCount)", icon: "sparkles.rectangle.stack")
+                dashboardMetric("Receipts", value: "\(status.recentChanges.count)", icon: "checklist.checked")
+                dashboardMetric("Mac", value: appState.macRuntimeSnapshot == nil ? "pair" : "live", icon: "macbook.and.iphone")
+            }
         }
         .bmoCard()
     }
 
-    private var openClawDashboardCard: some View {
+    private var primaryFlowCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Start with Buddy")
+                .font(.headline)
+                .foregroundColor(BMOTheme.textPrimary)
+            Text("Use the same mobile loop as the Mac shell: choose workspace context, run a skill or task, inspect the result, and keep the receipt.")
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+
+            HStack(spacing: 8) {
+                Button("Open Buddy") {
+                    appState.selectedTab = .buddy
+                }
+                .buttonStyle(BMOButtonStyle())
+
+                Button("Pair Mac") {
+                    appState.selectedTab = .pairing
+                }
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+            }
+
+            HStack(spacing: 8) {
+                Button("Workspace") {
+                    appState.selectedTab = .files
+                }
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+
+                Button("Skills") {
+                    appState.selectedTab = .skills
+                }
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+            }
+        }
+        .bmoCard()
+    }
+
+    private var taskAndResultsCard: some View {
         let status = appState.buddyRuntimeStatus
         return VStack(alignment: .leading, spacing: 12) {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("BeMore Dashboard")
+                    Text("Tasks and results")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("One view for route, runtime, artifacts, skills, files, and receipts.")
+                    Text("Receipt-backed work is the proof surface on iPhone too.")
                         .font(.caption)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
                 Spacer()
-                StatusBadge(label: status.runtimeAvailable ? "Online" : "Needs setup", color: status.runtimeAvailable ? BMOTheme.success : BMOTheme.warning)
-            }
-
-            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
-                dashboardMetric("Artifacts", value: "\(appState.workspaceRuntime.artifacts.count)", icon: "doc.richtext")
-                dashboardMetric("Skills", value: "\(appState.workspaceRuntime.skills.count)", icon: "sparkles.rectangle.stack")
-                dashboardMetric("Files", value: "\(appState.workspaceStore.files.count)", icon: "folder")
-                dashboardMetric("Failures", value: "\(status.failedActions.count)", icon: "exclamationmark.triangle")
-            }
-
-            detailRow("Mac power mode", value: appState.macPowerModeSummary)
-
-            HStack(spacing: 8) {
-                Button("Regenerate Core") {
-                    lastReceipt = appState.regenerateArtifacts(target: "all")
-                }
-                .buttonStyle(BMOButtonStyle(isPrimary: false))
-
-                Button("Open Skills") {
-                    appState.selectedTab = .skills
-                }
-                .buttonStyle(BMOButtonStyle(isPrimary: false))
+                StatusBadge(label: "\(status.failedActions.count) blocked", color: status.failedActions.isEmpty ? BMOTheme.success : BMOTheme.warning)
             }
 
             HStack(spacing: 8) {
@@ -115,34 +139,65 @@ struct MissionControlView: View {
                 }
                 .buttonStyle(BMOButtonStyle())
             }
+
+            if status.recentChanges.isEmpty {
+                Text("Run a Buddy action, skill, or Mac inspection to create the next result.")
+                    .font(.caption)
+                    .foregroundColor(BMOTheme.textTertiary)
+            } else {
+                ForEach(Array(status.recentChanges.prefix(3)), id: \.id) { event in
+                    detailRow(event.type, value: event.message)
+                }
+            }
         }
         .bmoCard()
     }
 
-    private var stackContractCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Stack contract")
+    private var skillsCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Buddy skills")
+                    .font(.headline)
+                    .foregroundColor(BMOTheme.textPrimary)
+                Spacer()
+                StatusBadge(label: "\(appState.workspaceRuntime.skills.count) registered", color: BMOTheme.accent)
+            }
+            Text("Skills make Buddy more useful: they produce artifacts, receipts, and task context rather than decorative shortcuts.")
                 .font(.subheadline)
-                .fontWeight(.semibold)
                 .foregroundColor(BMOTheme.textSecondary)
+            Button("Open Skills") {
+                appState.selectedTab = .skills
+            }
+            .buttonStyle(BMOButtonStyle(isPrimary: false))
+        }
+        .bmoCard()
+    }
 
-            detailRow("Mode", value: appState.stackConfig.deploymentMode.title)
-            detailRow("Runtime endpoint", value: appState.stackConfig.gatewayURL)
-            detailRow("Role", value: appState.stackConfig.role)
-            detailRow("Goal", value: appState.stackConfig.goal)
-            detailRow("Node on iPhone", value: appState.stackConfig.installNodeOnThisPhone ? "Expected" : "Not expected")
-            detailRow("Desktop/server node", value: appState.stackConfig.installDesktopNode ? "Expected" : "Optional")
+    private var macPowerCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Mac power mode")
+                    .font(.headline)
+                    .foregroundColor(BMOTheme.textPrimary)
+                Spacer()
+                StatusBadge(label: appState.macRuntimeSnapshot == nil ? "Not paired" : "Paired", color: appState.macRuntimeSnapshot == nil ? BMOTheme.warning : BMOTheme.success)
+            }
+            Text(appState.macPowerModeSummary)
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+            Button("Inspect Mac runtime") {
+                Task { await appState.refreshMacRuntimeSnapshot() }
+            }
+            .buttonStyle(BMOButtonStyle(isPrimary: false))
         }
         .bmoCard()
     }
 
     private var routeCard: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Route control")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(BMOTheme.textSecondary)
-
+            Text("Runtime route")
+                .font(.headline)
+                .foregroundColor(BMOTheme.textPrimary)
             detailRow("Active route", value: appState.activeRouteTitle)
             detailRow("Target", value: appState.activeRouteDetail)
             detailRow("Health", value: appState.routeHealthSummary)
@@ -150,61 +205,12 @@ struct MissionControlView: View {
         .bmoCard()
     }
 
-    private var metricsCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Live local state")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(BMOTheme.textSecondary)
-
-            detailRow("Workspace", value: appState.workspaceStatusSummary)
-            detailRow("Messages", value: "\(appState.chatStore.messages.count)")
-            detailRow("Installed models", value: "\(appState.modelStore.installedModels.count)")
-            detailRow("Persistence", value: appState.persistenceSummary)
-        }
-        .bmoCard()
-    }
-
-    private var providerCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Providers")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(BMOTheme.textSecondary)
-
-            ForEach(ProviderKind.allCases) { provider in
-                let account = appState.providerStore.account(for: provider)
-                detailRow(provider.displayName, value: account.isEnabled ? account.modelSlug : "Not linked")
-            }
-        }
-        .bmoCard()
-    }
-
-    private var shellCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Shell tabs")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(BMOTheme.textSecondary)
-
-            Text(appState.orderedVisibleTabs.map(\.title).joined(separator: " • "))
-                .font(.subheadline)
-                .foregroundColor(BMOTheme.textPrimary)
-            Text("Manage tab order in Settings. Mission Control stays the stable landing surface for stack health and route truth.")
-                .font(.caption)
-                .foregroundColor(BMOTheme.textTertiary)
-        }
-        .bmoCard()
-    }
-
     private var stackSurfacesCard: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("BMO Stack Surfaces")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(BMOTheme.textSecondary)
-
-            Text("These briefs are bundled from real repo docs so the iOS shell can expose meaningful stack surfaces without pretending to reimplement the whole desktop operator stack.")
+            Text("Reference surfaces")
+                .font(.headline)
+                .foregroundColor(BMOTheme.textPrimary)
+            Text("Repo briefs stay available as supporting context, but Buddy Home is now the product center.")
                 .font(.caption)
                 .foregroundColor(BMOTheme.textTertiary)
 
@@ -222,9 +228,6 @@ struct MissionControlView: View {
                                 .font(.caption)
                                 .multilineTextAlignment(.leading)
                                 .foregroundColor(BMOTheme.textSecondary)
-                            Text(surface.sourcePath)
-                                .font(.caption2)
-                                .foregroundColor(BMOTheme.textTertiary)
                         }
 
                         Spacer()
@@ -238,12 +241,20 @@ struct MissionControlView: View {
                     }
                     .padding(12)
                     .background(BMOTheme.backgroundSecondary)
-                    .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusSmall, style: .continuous))
                 }
                 .buttonStyle(.plain)
             }
         }
         .bmoCard()
+    }
+
+    private func buddyMood(for status: BuddyRuntimeStatus) -> BuddyAnimationMood {
+        if !status.failedActions.isEmpty { return .thinking }
+        if appState.macRuntimeSnapshot?.processes.contains(where: { $0.status == "running" }) == true { return .working }
+        if status.recentChanges.isEmpty && appState.workspaceStore.files.isEmpty { return .sleepy }
+        if !status.recentChanges.isEmpty { return .happy }
+        return status.runtimeAvailable ? .idle : .thinking
     }
 
     private func detailRow(_ label: String, value: String) -> some View {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
@@ -47,7 +47,7 @@ struct SkillsView: View {
                 Spacer()
                 StatusBadge(label: "\(appState.workspaceRuntime.skills.count) registered", color: BMOTheme.accent)
             }
-            Text("Skills are loaded from `.openclaw/registry/skills.json` and run through the same receipt-backed Workspace Runtime used by local and cloud routes.")
+            Text("Skills run through the same receipt-backed BeMore workspace runtime used by Buddy, mobile actions, and Mac pairing.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
         }
@@ -125,10 +125,10 @@ struct SkillsView: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("ClawHub")
+                    Text("Buddy Skill Hub")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("Install starter skills into `.openclaw/registry/skills.json` with real README and manifest artifacts.")
+                    Text("Install starter skills into the BeMore workspace registry with real README, manifest, artifact, and receipt output.")
                         .font(.caption)
                         .foregroundColor(BMOTheme.textSecondary)
                 }


### PR DESCRIPTION
## Summary
- make iOS home/navigation Buddy-first to match the new BeMore Mac shell
- add state-driven Buddy ASCII rendering on iOS
- reframe Workspace, Skills, Results, and Mac pairing around the same product hierarchy
- remove stale Build 18 / ClawHub product-facing copy while preserving internal legacy type names

## Task contract
Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem
The iOS app was lagging the newer BeMore Mac Buddy-first shell and still exposed older product hierarchy/copy in the mobile home, navigation, skills, results, and pairing surfaces.

## Smallest useful wedge
Update the active BeMoreAgent iOS shell to center Buddy, reorder mobile navigation around Home/Buddy/Workspace/Skills/Results/Mac, add a state-driven Buddy ASCII view, and remove stale Build 18 / ClawHub product-facing copy while preserving internal legacy Swift type names.

## Verification plan
Run XcodeGen and an iOS simulator build for the active BeMoreAgent project.

## Rollback plan
Revert this PR to restore the previous mobile shell/copy and remove the new Buddy ASCII view.

## Validation
- cd apps/openclaw-shell-ios && xcodegen generate && xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath .build/DerivedData build
