### PR TITLE
Bump BeMoreAgent build for Buddy parity upload

### DIFF
--- a/apps/openclaw-shell-ios/OpenClawShell/Info.plist
+++ b/apps/openclaw-shell-ios/OpenClawShell/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.2</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
## Summary
- bump BeMoreAgent CFBundleVersion from 19 to 20 so the Buddy parity shell can upload to TestFlight after build 19 was already used

## Task contract
Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem
The Buddy parity merge reached App Store Connect, but TestFlight rejected build 19 because build number 19 had already been uploaded.

## Smallest useful wedge
Increment the iOS build number to 20 without changing app code.

## Verification plan
Run XcodeGen and an iOS simulator build for the active BeMoreAgent project, then let the existing Build & TestFlight workflow archive and upload build 20 on master after merge.

## Rollback plan
Revert this PR to restore CFBundleVersion 19 if the build bump is not needed.

## Validation
- cd apps/openclaw-shell-ios && xcodegen generate && xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath .build/DerivedData build
