### PR TITLE
Make BeMore iOS Buddy-first

### DIFF
--- a/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
@@ -339,6 +339,9 @@ struct StackConfig: Codable {
     var stackName: String
     var goal: String
     var role: String
+    var onboardingBuddyName: String?
+    var onboardingBuddyTemplateID: String?
+    var onboardingBuddyFocus: String?
     var autonomyLevel: Int // 1-5
     var memoryEnabled: Bool
     var toolsEnabled: Bool
@@ -357,6 +360,9 @@ struct StackConfig: Codable {
         stackName: "BeMoreAgent",
         goal: "",
         role: "",
+        onboardingBuddyName: nil,
+        onboardingBuddyTemplateID: nil,
+        onboardingBuddyFocus: nil,
         autonomyLevel: 3,
         memoryEnabled: true,
         toolsEnabled: true,
@@ -428,6 +434,7 @@ enum AppTab: String, Codable, CaseIterable, Hashable, Identifiable {
     case pairing
     case models
     case chat
+    case pricing
     case settings
 
     var id: String { rawValue }
@@ -442,6 +449,7 @@ enum AppTab: String, Codable, CaseIterable, Hashable, Identifiable {
         case .pairing: return "Mac"
         case .models: return "Models"
         case .chat: return "Chat"
+        case .pricing: return "Pricing"
         case .settings: return "Settings"
         }
     }
@@ -456,6 +464,7 @@ enum AppTab: String, Codable, CaseIterable, Hashable, Identifiable {
         case .pairing: return "macbook.and.iphone"
         case .models: return "cpu"
         case .chat: return "message.fill"
+        case .pricing: return "creditcard.fill"
         case .settings: return "gearshape.fill"
         }
     }
@@ -471,7 +480,7 @@ struct ShellPreferences: Codable, Hashable {
     var selectedTab: AppTab
 
     static let `default` = ShellPreferences(
-        orderedTabs: [.missionControl, .buddy, .files, .skills, .artifacts, .pairing, .models, .chat, .settings],
+        orderedTabs: [.missionControl, .buddy, .chat, .skills, .artifacts, .files, .pairing, .pricing, .models, .settings],
         hiddenTabs: [],
         selectedTab: .missionControl
     )

--- a/apps/openclaw-shell-ios/OpenClawShell/BuddyInstanceStore.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/BuddyInstanceStore.swift
@@ -287,6 +287,31 @@ final class BuddyProfileStore: ObservableObject {
         }
     }
 
+    func ensureStarterBuddy(templateID: String, displayName: String, focus: String, using appState: AppState) {
+        if contracts == nil {
+            load(for: appState.stackConfig)
+        }
+        guard let template = templates.first(where: { $0.templateID == templateID || $0.id == templateID }) ?? templates.first else {
+            loadError = "No starter Buddy templates are available."
+            return
+        }
+
+        if let existing = installedBuddies.first(where: { $0.templateId == template.templateID || $0.templateId == template.id }) {
+            makeActive(existing, using: appState)
+        } else {
+            install(template: template, using: appState)
+        }
+
+        let cleanedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanedFocus = focus.trimmingCharacters(in: .whitespacesAndNewlines)
+        personalizeActive(
+            displayName: cleanedName.isEmpty ? template.name : cleanedName,
+            nickname: nil,
+            currentFocus: cleanedFocus.isEmpty ? template.canonicalRole : cleanedFocus,
+            using: appState
+        )
+    }
+
     private func mutate(using appState: AppState, operation: (BuddyCanonicalResources) throws -> BuddyPersistenceBundle) {
         guard let contracts else {
             loadError = "Buddy contracts are not loaded yet."

--- a/apps/openclaw-shell-ios/OpenClawShell/ContentView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/ContentView.swift
@@ -45,21 +45,23 @@ struct MainTabView: View {
     private func destination(for tab: AppTab) -> some View {
         switch tab {
         case .missionControl:
-            MissionControlView()
+            MissionControlView(store: appState.buddyStore)
         case .models:
             ModelsView()
         case .chat:
-            ChatView()
+            ChatView(store: appState.buddyStore)
         case .skills:
             SkillsView()
         case .artifacts:
             ArtifactsView()
         case .buddy:
-            BuddyView()
+            BuddyView(store: appState.buddyStore)
         case .files:
             FilesView()
         case .pairing:
             MacPairingView()
+        case .pricing:
+            PricingView()
         case .settings:
             SettingsView()
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/Info.plist
+++ b/apps/openclaw-shell-ios/OpenClawShell/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.2</string>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>21</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
@@ -2,17 +2,22 @@ import SwiftUI
 
 enum OnboardingStep: Int, CaseIterable {
     case welcome
-    case intent
-    case operatorProfile
-    case stackSetup
+    case chooseBuddy
+    case nameBuddy
+    case powerMode
     case building
     case summary
 }
 
 struct OnboardingFlow: View {
     @EnvironmentObject private var appState: AppState
+    @StateObject private var buddyStore = BuddyProfileStore()
     @State private var step: OnboardingStep = .welcome
     @State private var config = StackConfig.default
+    @State private var selectedTemplateID = ""
+    @State private var buddyName = ""
+    @State private var buddyFocus = ""
+    @State private var showAdvancedSetup = false
     @State private var buildProgress: Double = 0
     @State private var buildMessages: [String] = []
 
@@ -30,9 +35,9 @@ struct OnboardingFlow: View {
                 Group {
                     switch step {
                     case .welcome: welcomeScreen
-                    case .intent: intentScreen
-                    case .operatorProfile: operatorProfileScreen
-                    case .stackSetup: stackSetupScreen
+                    case .chooseBuddy: chooseBuddyScreen
+                    case .nameBuddy: nameBuddyScreen
+                    case .powerMode: powerModeScreen
                     case .building: buildingScreen
                     case .summary: summaryScreen
                     }
@@ -46,6 +51,17 @@ struct OnboardingFlow: View {
         .preferredColorScheme(.dark)
         .onAppear {
             config = appState.stackConfig
+            buddyStore.load(for: appState.stackConfig)
+            appState.buddyStore.load(for: appState.stackConfig)
+            if selectedTemplateID.isEmpty {
+                selectedTemplateID = buddyStore.templates.first?.templateID ?? ""
+            }
+            if buddyName.isEmpty {
+                buddyName = config.onboardingBuddyName ?? "Buddy"
+            }
+            if buddyFocus.isEmpty {
+                buddyFocus = config.onboardingBuddyFocus ?? "Help me decide what matters and finish the next useful step."
+            }
         }
     }
 
@@ -69,33 +85,32 @@ struct OnboardingFlow: View {
         VStack(spacing: BMOTheme.spacingLG) {
             Spacer()
 
-            Image(systemName: "point.3.connected.trianglepath.dotted")
-                .font(.system(size: 64))
-                .foregroundColor(BMOTheme.accent)
-                .shadow(color: BMOTheme.accentGlow, radius: 20)
+            BuddyAsciiView(mood: .happy)
+                .padding(.horizontal, BMOTheme.spacingXL)
 
-            Text("BeMoreAgent")
+            Text("Welcome to BeMore")
                 .font(.system(size: 36, weight: .bold))
                 .foregroundColor(BMOTheme.textPrimary)
+                .multilineTextAlignment(.center)
 
-            Text("Build the mobile front door for a real BeMore stack, based on the answers you give here.")
+            Text("Start with a Buddy. Runtime pairing, models, and power mode come after your companion has an identity.")
                 .font(.body)
                 .foregroundColor(BMOTheme.textSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, BMOTheme.spacingXL)
 
             VStack(alignment: .leading, spacing: 10) {
-                featureRow("Generate a concrete stack profile instead of fake setup copy")
-                featureRow("Target a real BeMore runtime and Mac pairing flow")
-                featureRow("Show honest readiness for local runtime, providers, and shell surfaces")
+                featureRow("Choose the Buddy who will be with you on Home, Chat, Skills, and Results")
+                featureRow("Name them and set their first focus")
+                featureRow("Add Mac power mode later when you want a stronger runtime")
             }
             .padding(.horizontal, BMOTheme.spacingXL)
 
             Spacer()
 
-            Button("Build my stack") {
+            Button("Create my Buddy") {
                 withAnimation(.easeInOut(duration: 0.35)) {
-                    step = .intent
+                    step = .chooseBuddy
                 }
             }
             .buttonStyle(BMOButtonStyle())
@@ -104,175 +119,82 @@ struct OnboardingFlow: View {
         }
     }
 
-    private var intentScreen: some View {
+    private var chooseBuddyScreen: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
                 Spacer().frame(height: BMOTheme.spacingXL)
 
-                Text("What stack are we setting up?")
-                    .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(BMOTheme.textPrimary)
-                    .padding(.horizontal, BMOTheme.spacingLG)
+                onboardingTitle("Choose your first Buddy", subtitle: "Pick a starter archetype. You can own more Buddies later, but this one becomes your active companion now.")
 
-                Text("This should match the real BeMore deployment the app is going to represent.")
-                    .font(.subheadline)
-                    .foregroundColor(BMOTheme.textSecondary)
-                    .padding(.horizontal, BMOTheme.spacingLG)
-
-                VStack(spacing: 12) {
-                    ForEach(StackDeploymentMode.allCases) { mode in
-                        Button {
-                            config.deploymentMode = mode
-                        } label: {
-                            VStack(alignment: .leading, spacing: 8) {
-                                HStack {
-                                    Text(mode.title)
-                                        .font(.headline)
-                                    Spacer()
-                                    if config.deploymentMode == mode {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .foregroundColor(BMOTheme.accent)
-                                    }
-                                }
-                                Text(mode.subtitle)
-                                    .font(.caption)
-                                    .foregroundColor(BMOTheme.textSecondary)
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding()
-                            .foregroundColor(BMOTheme.textPrimary)
-                            .background(config.deploymentMode == mode ? BMOTheme.backgroundCardHover : BMOTheme.backgroundCard)
-                            .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
-                        }
-                    }
-                }
-                .padding(.horizontal, BMOTheme.spacingLG)
-
-                labeledField(title: "Stack name", text: $config.stackName, placeholder: "BeMoreAgent")
-                labeledField(title: "Primary goal", text: $config.goal, placeholder: "Run my own BeMore stack")
-                labeledField(title: "Runtime endpoint", text: $config.gatewayURL, placeholder: "https://bemore.example.com")
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                labeledField(title: "Admin / public domain", text: $config.adminDomain, placeholder: "example.com")
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-
-                navButtons(back: .welcome, next: .operatorProfile, canProceed: canContinueFromIntent)
-                    .padding(.top, BMOTheme.spacingMD)
-            }
-        }
-    }
-
-    private var operatorProfileScreen: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
-                Spacer().frame(height: BMOTheme.spacingXL)
-
-                Text("Who is this stack for?")
-                    .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(BMOTheme.textPrimary)
-                    .padding(.horizontal, BMOTheme.spacingLG)
-
-                labeledField(title: "Operator name", text: $config.operatorName, placeholder: "Cody")
-                labeledField(title: "Role", text: $config.role, placeholder: "Builder, founder, operator")
-
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Autonomy")
-                        .font(.headline)
-                        .foregroundColor(BMOTheme.textPrimary)
-                    Text("How aggressively should the stack try to act on its own once connected?")
-                        .font(.caption)
+                if buddyStore.templates.isEmpty {
+                    Text("Buddy templates are still loading. Continue and BeMore will use the default Buddy when it is ready.")
+                        .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
-                    HStack {
-                        Text("Guarded")
-                            .font(.caption)
-                            .foregroundColor(BMOTheme.textTertiary)
-                        Slider(value: Binding(get: { Double(config.autonomyLevel) }, set: { config.autonomyLevel = Int($0) }), in: 1...5, step: 1)
-                            .tint(BMOTheme.accent)
-                        Text("Autonomous")
-                            .font(.caption)
-                            .foregroundColor(BMOTheme.textTertiary)
-                    }
-                }
-                .bmoCard()
-                .padding(.horizontal, BMOTheme.spacingLG)
-
-                toggleCard(icon: "brain", title: "Memory", subtitle: "Persist operator context and stack state locally on device", isOn: $config.memoryEnabled)
-                    .padding(.horizontal, BMOTheme.spacingLG)
-                toggleCard(icon: "wrench.and.screwdriver", title: "Tools", subtitle: "Allow tool and API actions when the connected stack supports them", isOn: $config.toolsEnabled)
-                    .padding(.horizontal, BMOTheme.spacingLG)
-                toggleCard(icon: "app.badge", title: "Notifications", subtitle: "Enable push surfaces for node events and stack health", isOn: $config.enableNotifications)
-                    .padding(.horizontal, BMOTheme.spacingLG)
-
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Optimization")
-                        .font(.headline)
-                        .foregroundColor(BMOTheme.textPrimary)
-                    HStack(spacing: 10) {
-                        ForEach(["speed", "balanced", "quality"], id: \.self) { mode in
-                            Button {
-                                config.optimizationMode = mode
-                            } label: {
-                                Text(mode.capitalized)
-                                    .font(.subheadline)
-                                    .fontWeight(.medium)
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 12)
-                                    .foregroundColor(config.optimizationMode == mode ? BMOTheme.backgroundPrimary : BMOTheme.textSecondary)
-                                    .background(config.optimizationMode == mode ? BMOTheme.accent : BMOTheme.backgroundSecondary)
-                                    .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusSmall, style: .continuous))
-                            }
+                        .bmoCard()
+                        .padding(.horizontal, BMOTheme.spacingLG)
+                } else {
+                    VStack(spacing: 12) {
+                        ForEach(buddyStore.templates) { template in
+                            buddyTemplateButton(template)
                         }
                     }
+                    .padding(.horizontal, BMOTheme.spacingLG)
                 }
-                .bmoCard()
-                .padding(.horizontal, BMOTheme.spacingLG)
 
-                navButtons(back: .intent, next: .stackSetup, canProceed: !trimmed(config.operatorName).isEmpty && !trimmed(config.role).isEmpty)
+                navButtons(back: .welcome, next: .nameBuddy, canProceed: !selectedTemplateID.isEmpty || buddyStore.templates.isEmpty)
                     .padding(.top, BMOTheme.spacingMD)
             }
         }
     }
 
-    private var stackSetupScreen: some View {
+    private var nameBuddyScreen: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
                 Spacer().frame(height: BMOTheme.spacingXL)
+                onboardingTitle("Make this Buddy yours", subtitle: "This name and focus follow your Buddy into Home, Chat, tasks, training, and receipts.")
+                labeledField(title: "Buddy name", text: $buddyName, placeholder: selectedTemplate?.name ?? "Buddy")
+                labeledField(title: "First focus", text: $buddyFocus, placeholder: selectedTemplate?.canonicalRole ?? "Help me finish the next useful step")
+                selectedBuddyPreview
+                navButtons(back: .chooseBuddy, next: .powerMode, canProceed: !trimmed(buddyName).isEmpty)
+                    .padding(.top, BMOTheme.spacingMD)
+            }
+        }
+    }
 
-                Text("What should this app stand up?")
-                    .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(BMOTheme.textPrimary)
+    private var powerModeScreen: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
+                Spacer().frame(height: BMOTheme.spacingXL)
+                onboardingTitle("Power mode is optional", subtitle: "BeMore can start as your Buddy on iPhone. Pairing Mac and route setup are stronger-mode choices, not the first thing you have to understand.")
+
+                toggleCard(icon: "macbook.and.iphone", title: "Pair with Mac later", subtitle: "Keep Mac runtime pairing available after you land on Buddy Home.", isOn: $config.installDesktopNode)
+                    .padding(.horizontal, BMOTheme.spacingLG)
+                toggleCard(icon: "bell.badge", title: "Buddy notifications", subtitle: "Allow BeMore to remind you about Buddy tasks, results, and check-ins when enabled.", isOn: $config.enableNotifications)
                     .padding(.horizontal, BMOTheme.spacingLG)
 
-                Text("This is the contract the shell should reflect after onboarding.")
-                    .font(.subheadline)
-                    .foregroundColor(BMOTheme.textSecondary)
-                    .padding(.horizontal, BMOTheme.spacingLG)
-
-                toggleCard(icon: "iphone", title: "Install node on this phone", subtitle: "Treat iPhone capabilities as part of the self-hosted stack surface", isOn: $config.installNodeOnThisPhone)
-                    .padding(.horizontal, BMOTheme.spacingLG)
-                toggleCard(icon: "desktopcomputer", title: "Expect desktop / server node", subtitle: "Assume a host runtime or desktop companion is part of the stack", isOn: $config.installDesktopNode)
-                    .padding(.horizontal, BMOTheme.spacingLG)
-
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Generated setup checklist")
+                DisclosureGroup(isExpanded: $showAdvancedSetup) {
+                    VStack(spacing: BMOTheme.spacingMD) {
+                        labeledField(title: "Runtime endpoint", text: $config.gatewayURL, placeholder: "https://bemore.example.com")
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                        labeledField(title: "Public domain", text: $config.adminDomain, placeholder: "example.com")
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                        toggleCard(icon: "wrench.and.screwdriver", title: "Tools", subtitle: "Allow tool and API actions when the connected runtime supports them.", isOn: $config.toolsEnabled)
+                        toggleCard(icon: "brain", title: "Memory", subtitle: "Persist Buddy and operator context locally on device.", isOn: $config.memoryEnabled)
+                    }
+                    .padding(.top, BMOTheme.spacingMD)
+                } label: {
+                    Text("Advanced runtime setup")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
-                    ForEach(generatedChecklist, id: \.self) { item in
-                        HStack(alignment: .top, spacing: 8) {
-                            Image(systemName: "checklist")
-                                .foregroundColor(BMOTheme.accent)
-                                .padding(.top, 2)
-                            Text(item)
-                                .font(.subheadline)
-                                .foregroundColor(BMOTheme.textSecondary)
-                        }
-                    }
                 }
-                .bmoCard()
+                .padding(BMOTheme.spacingMD)
+                .background(BMOTheme.backgroundCard)
+                .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
                 .padding(.horizontal, BMOTheme.spacingLG)
 
-                navButtons(back: .operatorProfile, next: .building, canProceed: true)
+                navButtons(back: .nameBuddy, next: .building, canProceed: true)
                     .padding(.top, BMOTheme.spacingMD)
             }
         }
@@ -291,12 +213,12 @@ struct OnboardingFlow: View {
                     .stroke(BMOTheme.accent, style: StrokeStyle(lineWidth: 4, lineCap: .round))
                     .frame(width: 120, height: 120)
                     .rotationEffect(.degrees(-90))
-                Image(systemName: "server.rack")
+                Image(systemName: "heart.text.square.fill")
                     .font(.system(size: 36))
                     .foregroundColor(BMOTheme.accent)
             }
 
-            Text("Building your stack profile...")
+            Text("Waking \(buddyName)")
                 .font(.system(size: 24, weight: .bold))
                 .foregroundColor(BMOTheme.textPrimary)
 
@@ -321,115 +243,36 @@ struct OnboardingFlow: View {
         .onAppear { runBuildSequence() }
     }
 
-    private func runBuildSequence() {
-        config.setupChecklist = generatedChecklist
-        buildProgress = 0
-        buildMessages = []
-
-        let steps = [
-            (0.2, "Saving operator profile for \(trimmed(config.operatorName).isEmpty ? "this device" : trimmed(config.operatorName))"),
-            (0.4, "Targeting runtime endpoint \(trimmed(config.gatewayURL))"),
-            (0.6, config.installNodeOnThisPhone ? "Marking this iPhone as a node-capable surface" : "Skipping local node install on this phone"),
-            (0.8, config.installDesktopNode ? "Expecting a desktop or server runtime companion" : "Running in phone-only mode"),
-            (1.0, "Stack profile ready. The shell will show actual readiness instead of pretending setup is complete.")
-        ]
-
-        for (index, (progress, message)) in steps.enumerated() {
-            DispatchQueue.main.asyncAfter(deadline: .now() + Double(index) * 0.5) {
-                withAnimation(.easeOut(duration: 0.35)) {
-                    buildProgress = progress
-                    buildMessages.append(message)
-                }
-            }
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + Double(steps.count) * 0.5 + 0.4) {
-            withAnimation(.easeInOut(duration: 0.35)) {
-                step = .summary
-            }
-        }
-    }
-
     private var summaryScreen: some View {
         ScrollView {
             VStack(spacing: BMOTheme.spacingLG) {
                 Spacer().frame(height: BMOTheme.spacingXL)
 
-                Image(systemName: "checkmark.seal.fill")
-                    .font(.system(size: 48))
-                    .foregroundColor(BMOTheme.success)
+                BuddyAsciiView(mood: .levelUp)
+                    .padding(.horizontal, BMOTheme.spacingXL)
 
-                Text(trimmed(config.stackName).isEmpty ? "BeMoreAgent" : trimmed(config.stackName))
+                Text("\(buddyName) is ready")
                     .font(.system(size: 28, weight: .bold))
                     .foregroundColor(BMOTheme.textPrimary)
 
-                Text("Your iPhone shell now reflects a real BeMore setup profile.")
+                Text("You’ll land on Buddy Home. Chat, Skills, Results, and Mac power mode all point back to this active Buddy.")
                     .font(.subheadline)
                     .foregroundColor(BMOTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, BMOTheme.spacingLG)
 
                 VStack(spacing: 12) {
-                    summaryRow(icon: "person.crop.circle", label: "Operator", value: trimmed(config.operatorName))
-                    summaryRow(icon: "briefcase", label: "Role", value: trimmed(config.role))
-                    summaryRow(icon: "link", label: "Runtime", value: trimmed(config.gatewayURL))
-                    summaryRow(icon: "switch.2", label: "Mode", value: config.deploymentMode.title)
-                    summaryRow(icon: "gauge.open.with.lines.needle.33percent", label: "Autonomy", value: "\(config.autonomyLevel)/5")
-                    summaryRow(icon: "brain", label: "Memory", value: config.memoryEnabled ? "On" : "Off")
-                    summaryRow(icon: "wrench.and.screwdriver", label: "Tools", value: config.toolsEnabled ? "On" : "Off")
+                    summaryRow(icon: "person.crop.circle.badge.checkmark", label: "Active Buddy", value: buddyName)
+                    summaryRow(icon: "sparkles", label: "Starter", value: selectedTemplate?.name ?? "Default Buddy")
+                    summaryRow(icon: "scope", label: "Focus", value: buddyFocus)
+                    summaryRow(icon: "macbook.and.iphone", label: "Mac power", value: config.installDesktopNode ? "Available later" : "Phone-first")
+                    summaryRow(icon: "creditcard", label: "Plans", value: "Free now; Plus and Council previews in Pricing")
                 }
                 .bmoCard()
                 .padding(.horizontal, BMOTheme.spacingLG)
 
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Next steps the app expects")
-                        .font(.headline)
-                        .foregroundColor(BMOTheme.textPrimary)
-                    ForEach(config.setupChecklist, id: \.self) { item in
-                        Text("• \(item)")
-                            .font(.subheadline)
-                            .foregroundColor(BMOTheme.textSecondary)
-                    }
-                }
-                .bmoCard()
-                .padding(.horizontal, BMOTheme.spacingLG)
-
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Primary Agent")
-                        .font(.caption)
-                        .foregroundColor(BMOTheme.textTertiary)
-                    HStack(spacing: 12) {
-                        Circle()
-                            .fill(BMOTheme.accent)
-                            .frame(width: 40, height: 40)
-                            .overlay(
-                                Image(systemName: "cpu")
-                                    .foregroundColor(BMOTheme.backgroundPrimary)
-                            )
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("BMO Agent")
-                                .font(.headline)
-                                .foregroundColor(BMOTheme.textPrimary)
-                            Text(primaryAgentSummary)
-                                .font(.caption)
-                                .foregroundColor(BMOTheme.textSecondary)
-                        }
-                    }
-                    Text(primaryAgentDetail)
-                        .font(.caption)
-                        .foregroundColor(BMOTheme.textTertiary)
-                }
-                .bmoCard()
-                .padding(.horizontal, BMOTheme.spacingLG)
-
-                Button("Launch shell") {
-                    config.stackName = fallback(config.stackName, defaultValue: "BeMoreAgent")
-                    config.goal = fallback(config.goal, defaultValue: "Run a self-hosted BeMore stack")
-                    config.role = fallback(config.role, defaultValue: "Operator")
-                    config.operatorName = fallback(config.operatorName, defaultValue: "Operator")
-                    config.gatewayURL = fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")
-                    config.adminDomain = fallback(config.adminDomain, defaultValue: "prismtek.dev")
-                    config.setupChecklist = generatedChecklist
-                    config.isOnboardingComplete = true
-                    appState.completeOnboarding(config)
+                Button("Go to Buddy Home") {
+                    finishOnboarding()
                 }
                 .buttonStyle(BMOButtonStyle())
                 .padding(.top, BMOTheme.spacingMD)
@@ -439,13 +282,131 @@ struct OnboardingFlow: View {
         }
     }
 
+    private func runBuildSequence() {
+        buildProgress = 0
+        buildMessages = []
+        let name = fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")
+        let steps = [
+            (0.25, "Creating \(name) as your active Buddy"),
+            (0.50, "Linking Buddy to Home, Chat, Skills, and Results"),
+            (0.75, config.installDesktopNode ? "Keeping Mac power mode available as an optional upgrade" : "Starting in phone-first mode"),
+            (1.0, "Preparing your Buddy-first BeMore shell")
+        ]
+        for (index, (progress, message)) in steps.enumerated() {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(index) * 0.5) {
+                withAnimation(.easeOut(duration: 0.35)) {
+                    buildProgress = progress
+                    buildMessages.append(message)
+                }
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double(steps.count) * 0.5 + 0.4) {
+            withAnimation(.easeInOut(duration: 0.35)) {
+                step = .summary
+            }
+        }
+    }
+
+    private func finishOnboarding() {
+        let cleanedBuddyName = fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")
+        let cleanedFocus = fallback(buddyFocus, defaultValue: selectedTemplate?.canonicalRole ?? "Finish the next useful step")
+        let templateID = selectedTemplate?.templateID ?? selectedTemplateID
+
+        config.stackName = fallback(config.stackName, defaultValue: "BeMore")
+        config.goal = cleanedFocus
+        config.role = selectedTemplate?.canonicalRole ?? "Buddy companion"
+        config.operatorName = fallback(config.operatorName, defaultValue: "Builder")
+        config.gatewayURL = fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")
+        config.adminDomain = fallback(config.adminDomain, defaultValue: "prismtek.dev")
+        config.onboardingBuddyName = cleanedBuddyName
+        config.onboardingBuddyTemplateID = templateID
+        config.onboardingBuddyFocus = cleanedFocus
+        config.setupChecklist = generatedChecklist
+        config.isOnboardingComplete = true
+        appState.completeOnboarding(config)
+        appState.buddyStore.ensureStarterBuddy(templateID: templateID, displayName: cleanedBuddyName, focus: cleanedFocus, using: appState)
+        appState.selectedTab = .missionControl
+    }
+
+    private var selectedTemplate: CouncilStarterBuddyTemplate? {
+        buddyStore.templates.first(where: { $0.templateID == selectedTemplateID || $0.id == selectedTemplateID }) ?? buddyStore.templates.first
+    }
+
+    private var selectedBuddyPreview: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Your active Buddy")
+                .font(.headline)
+                .foregroundColor(BMOTheme.textPrimary)
+            Text(selectedTemplate?.ascii.baseSilhouette ?? "  /\\_/\\\n ( o.o )\n  > ^ <")
+                .font(.system(.caption, design: .monospaced))
+                .foregroundColor(BMOTheme.accent)
+            Text("\(fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")) will become the Buddy shown on Home and in Chat.")
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+        }
+        .bmoCard()
+        .padding(.horizontal, BMOTheme.spacingLG)
+    }
+
+    private func buddyTemplateButton(_ template: CouncilStarterBuddyTemplate) -> some View {
+        Button {
+            selectedTemplateID = template.templateID
+            if buddyName == "Buddy" || buddyName.isEmpty {
+                buddyName = template.name
+            }
+            if buddyFocus.isEmpty {
+                buddyFocus = template.canonicalRole
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(template.name)
+                            .font(.headline)
+                        Text(template.starterRole)
+                            .font(.subheadline)
+                            .foregroundColor(BMOTheme.textSecondary)
+                    }
+                    Spacer()
+                    if selectedTemplateID == template.templateID {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(BMOTheme.accent)
+                    }
+                }
+                Text(template.onboardingCopy)
+                    .font(.subheadline)
+                    .foregroundColor(BMOTheme.textSecondary)
+                Text(template.ascii.baseSilhouette)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundColor(BMOTheme.accent)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .foregroundColor(BMOTheme.textPrimary)
+            .background(selectedTemplateID == template.templateID ? BMOTheme.backgroundCardHover : BMOTheme.backgroundCard)
+            .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
+        }
+    }
+
+    private func onboardingTitle(_ title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 28, weight: .bold))
+                .foregroundColor(BMOTheme.textPrimary)
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+        }
+        .padding(.horizontal, BMOTheme.spacingLG)
+    }
+
     @ViewBuilder
     private func labeledField(title: String, text: Binding<String>, placeholder: String) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-            TextField(placeholder, text: text)
+            TextField(placeholder, text: text, axis: title == "First focus" ? .vertical : .horizontal)
                 .textFieldStyle(.plain)
                 .padding()
                 .background(BMOTheme.backgroundCard)
@@ -453,33 +414,6 @@ struct OnboardingFlow: View {
                 .foregroundColor(BMOTheme.textPrimary)
         }
         .padding(.horizontal, BMOTheme.spacingLG)
-    }
-
-    private var primaryAgentSummary: String {
-        appState.usesStubRuntime
-            ? "Local-first shell • route setup after launch"
-            : "On-device runtime available after model install"
-    }
-
-    private var primaryAgentDetail: String {
-        appState.usesStubRuntime
-            ? "This build still uses the stub local runtime. Launch into Mission Control, then use Models to link a cloud route or prepare a local model."
-            : "Finish onboarding, then use Models to select an installed on-device route."
-    }
-
-    private func summaryRow(icon: String, label: String, value: String) -> some View {
-        HStack(alignment: .top) {
-            Image(systemName: icon)
-                .frame(width: 24)
-                .foregroundColor(BMOTheme.accent)
-            Text(label)
-                .foregroundColor(BMOTheme.textSecondary)
-            Spacer()
-            Text(value.isEmpty ? "Not set" : value)
-                .fontWeight(.medium)
-                .multilineTextAlignment(.trailing)
-                .foregroundColor(BMOTheme.textPrimary)
-        }
     }
 
     private func toggleCard(icon: String, title: String, subtitle: String, isOn: Binding<Bool>) -> some View {
@@ -520,7 +454,7 @@ struct OnboardingFlow: View {
 
             Spacer()
 
-            Button("Continue") {
+            Button(next == .building ? "Start BeMore" : "Continue") {
                 withAnimation(.easeInOut(duration: 0.35)) { step = next }
             }
             .buttonStyle(BMOButtonStyle())
@@ -542,28 +476,30 @@ struct OnboardingFlow: View {
         }
     }
 
-    private var canContinueFromIntent: Bool {
-        !trimmed(config.stackName).isEmpty && !trimmed(config.goal).isEmpty && !trimmed(config.gatewayURL).isEmpty && !trimmed(config.adminDomain).isEmpty
+    private func summaryRow(icon: String, label: String, value: String) -> some View {
+        HStack(alignment: .top) {
+            Image(systemName: icon)
+                .frame(width: 24)
+                .foregroundColor(BMOTheme.accent)
+            Text(label)
+                .foregroundColor(BMOTheme.textSecondary)
+            Spacer()
+            Text(value.isEmpty ? "Not set" : value)
+                .fontWeight(.medium)
+                .multilineTextAlignment(.trailing)
+                .foregroundColor(BMOTheme.textPrimary)
+        }
     }
 
     private var generatedChecklist: [String] {
-        var items: [String] = []
-        if config.deploymentMode == .bootstrapSelfHosted {
-            items.append("Provision or verify a BeMore runtime endpoint at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
-            items.append("Set runtime and pairing/public URL values to match \(fallback(config.adminDomain, defaultValue: "prismtek.dev")).")
-        } else {
-            items.append("Pair this app to the existing BeMore runtime endpoint at \(fallback(config.gatewayURL, defaultValue: "https://prismtek.dev")).")
-        }
-        if config.installNodeOnThisPhone {
-            items.append("Treat this iPhone as a node surface with notification, camera, and device capability permissions.")
-        }
+        var items = ["Keep \(fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")) active on Home, Chat, Skills, and Results."]
         if config.installDesktopNode {
-            items.append("Keep a desktop or server node online so the shell has a real self-hosted stack to connect to.")
+            items.append("Pair a BeMore Mac runtime when you want workspace execution, diffs, artifacts, and receipts from your desktop.")
         }
         if config.toolsEnabled {
-            items.append("Enable only the tools the operator actually wants exposed through the stack.")
+            items.append("Enable only the tools you want this Buddy to use through the connected runtime.")
         }
-        items.append("Verify local runtime readiness honestly. Do not claim on-device inference is live unless the runtime bridge is actually present.")
+        items.append("Use Pricing to compare free Buddy slots, Plus runtime capacity, and Council/marketplace access before upgrading.")
         return items
     }
 

--- a/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
@@ -1155,6 +1155,7 @@ final class AppState: ObservableObject {
     @Published var modelStore = ModelCatalogStore()
     @Published var workspaceStore = WorkspaceStore()
     @Published var chatStore = ChatStore()
+    @Published var buddyStore = BuddyProfileStore()
     @Published var providerStore = ProviderStore()
     @Published var runtimePreferences = RuntimePreferencesStore()
     @Published var tabPreferencesStore = TabPreferencesStore()
@@ -1328,6 +1329,7 @@ final class AppState: ObservableObject {
         runtimePreferences.load()
         tabPreferencesStore.load()
         userPreferencesStore.load()
+        buddyStore.load(for: stackConfig)
         workspaceRuntime.bootstrap(config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
         refreshGemmaState()
         refreshRuntimeSummary()
@@ -1354,6 +1356,7 @@ final class AppState: ObservableObject {
         }
         persistStackConfig()
         workspaceRuntime.bootstrap(config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
+        buddyStore.load(for: config)
         buddyProfileStore?.load(for: config)
         refreshRuntimeSummary()
     }
@@ -1740,7 +1743,7 @@ final class AppState: ObservableObject {
                     config: stackConfig,
                     operatorName: operatorDisplayName,
                     routeLabel: routeLabel
-                ) + "\n\nWorkspace Runtime: Available inside BeMore. Ask for actions through the runtime contract; do not claim files, memory, skills, or sandbox commands changed unless a BeMore receipt confirms it. Registered skills: \(workspaceRuntime.skills.map(\.name).joined(separator: ", ")). Canonical artifacts: soul.md, user.md, memory.md, session.md, skills.md.\n\nMac Power Mode: \(macPowerModeSummary)"
+                ) + "\n\n\(activeBuddyChatContext)\n\nWorkspace Runtime: Available inside BeMore. Ask for actions through the runtime contract; do not claim files, memory, skills, or sandbox commands changed unless a BeMore receipt confirms it. Registered skills: \(workspaceRuntime.skills.map(\.name).joined(separator: ", ")). Canonical artifacts: soul.md, user.md, memory.md, session.md, skills.md.\n\nMac Power Mode: \(macPowerModeSummary)"
             )
         ]
 
@@ -1762,6 +1765,14 @@ final class AppState: ObservableObject {
         }
 
         return messages
+    }
+
+    private var activeBuddyChatContext: String {
+        guard let buddy = buddyStore.activeBuddy else {
+            return "Active Buddy: none yet. Encourage the user to create or install a Buddy before treating chat as personalized."
+        }
+        let focus = buddy.state.currentFocus ?? "no active focus"
+        return "Active Buddy: \(buddy.displayName). Role: \(buddy.identity.role). Class: \(buddy.identity.class). Mood: \(buddy.state.mood). Focus: \(focus). Reply as the BeMore companion connected to this Buddy identity, and keep visible work tied to Buddy tasks, skills, receipts, and results."
     }
 
     private func generatedSetupChecklist(for config: StackConfig) -> [String] {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
@@ -9,7 +9,7 @@ private struct BuddyPersonalizationDraft {
 
 struct BuddyView: View {
     @EnvironmentObject private var appState: AppState
-    @StateObject private var store = BuddyProfileStore()
+    @ObservedObject var store: BuddyProfileStore
     @State private var checkInNote = ""
     @State private var trainingNote = ""
     @State private var personalizationDraft = BuddyPersonalizationDraft()
@@ -19,9 +19,8 @@ struct BuddyView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
-                    runtimeCard
-
                     if let activeBuddy = store.activeBuddy {
+                        myBuddyHeader(for: activeBuddy)
                         activeBuddyCard(for: activeBuddy)
                         actionCard(for: activeBuddy)
                         recentEventsCard(for: activeBuddy)
@@ -29,11 +28,10 @@ struct BuddyView: View {
                         emptyStateCard
                     }
 
-                    libraryCard
+                    rosterCard
+                    marketplaceCard
 
-                    if store.installedBuddies.isEmpty == false {
-                        rosterCard
-                    }
+                    trainingAndManagementCard
 
                     if let receipt = store.lastReceipt {
                         receiptCard(receipt)
@@ -52,53 +50,42 @@ struct BuddyView: View {
         }
         .task {
             store.load(for: appState.stackConfig)
-            appState.buddyProfileStore = store
-        }
-        .onDisappear {
-            if appState.buddyProfileStore === store {
-                appState.buddyProfileStore = nil
-            }
         }
         .sheet(isPresented: $isShowingPersonalizationSheet) {
             personalizationSheet
         }
     }
 
-    private var runtimeCard: some View {
+    private func myBuddyHeader(for buddy: BuddyInstance) -> some View {
         let status = appState.buddyRuntimeStatus
+        let template = store.contracts?.templateForInstance(buddy)
         return VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Buddy Runtime")
-                        .font(.headline)
+                    Text("My Buddy")
+                        .font(.caption.weight(.semibold))
+                        .foregroundColor(BMOTheme.textTertiary)
+                    Text(buddy.displayName)
+                        .font(.system(size: 30, weight: .bold))
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("Structured Buddy templates, installable local instances, readable continuity files, and receipt-backed updates.")
+                    Text(template?.onboardingCopy ?? "\(buddy.displayName) is the active companion for chat, skills, tasks, receipts, and results.")
                         .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
                 Spacer()
                 StatusBadge(
-                    label: status.runtimeAvailable ? "Runtime Ready" : "Runtime Missing",
+                    label: status.runtimeAvailable ? "Connected" : "Phone-first",
                     color: status.runtimeAvailable ? BMOTheme.success : BMOTheme.warning
                 )
             }
 
-            HStack(spacing: BMOTheme.spacingSM) {
-                metricPill(title: "Installed", value: "\(status.installedBuddyCount)")
-                metricPill(title: "Active", value: status.hasActiveBuddy ? "Yes" : "No")
-                metricPill(title: "Skills", value: "\(status.registeredSkillCount)")
-                metricPill(title: "Failures", value: "\(status.failedActions.count)")
-            }
+            BuddyAsciiView(mood: buddyMood(for: buddy), compact: true)
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Suggested next actions")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundColor(BMOTheme.textPrimary)
-                ForEach(status.suggestedNextActions, id: \.self) { suggestion in
-                    Text("• \(suggestion)")
-                        .font(.caption)
-                        .foregroundColor(BMOTheme.textSecondary)
-                }
+            HStack(spacing: BMOTheme.spacingSM) {
+                metricPill(title: "Owned", value: "\(status.installedBuddyCount)")
+                metricPill(title: "Skills", value: "\(status.registeredSkillCount)")
+                metricPill(title: "Level", value: "\(buddy.progression.level)")
+                metricPill(title: "Bond", value: "\(buddy.progression.bond)")
             }
         }
         .bmoCard()
@@ -259,21 +246,21 @@ struct BuddyView: View {
         .bmoCard()
     }
 
-    private var libraryCard: some View {
+    private var marketplaceCard: some View {
         let installedTemplateIDs = Set(store.installedBuddies.map(\.templateId))
 
         return VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Council Starter Pack")
+                    Text("Discover Buddies")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("BeMore Buddy templates bundled with local continuity, training, and receipt-backed state.")
+                    Text("A curated Buddy marketplace beta. Install starter Buddies now; premium creator Buddies can live here when billing is ready.")
                         .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
                 Spacer()
-                StatusBadge(label: "\(store.templates.count) templates", color: BMOTheme.accent)
+                StatusBadge(label: "Marketplace beta", color: BMOTheme.accent)
             }
 
             ForEach(store.templates) { template in
@@ -289,7 +276,7 @@ struct BuddyView: View {
                         }
                         Spacer()
                         if installedTemplateIDs.contains(template.templateID) {
-                            StatusBadge(label: "Installed", color: BMOTheme.success)
+                            StatusBadge(label: store.activeBuddy?.templateId == template.templateID ? "Active" : "Owned", color: BMOTheme.success)
                         } else {
                             Button("Install") {
                                 store.install(template: template, using: appState)
@@ -325,47 +312,84 @@ struct BuddyView: View {
 
     private var rosterCard: some View {
         VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
-            Text("Installed Buddy Roster")
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("My Buddy Roster")
+                        .font(.headline)
+                        .foregroundColor(BMOTheme.textPrimary)
+                    Text("Owned Buddies stay separate from marketplace templates. Equip one active Buddy at a time.")
+                        .font(.caption)
+                        .foregroundColor(BMOTheme.textSecondary)
+                }
+                Spacer()
+                StatusBadge(label: "\(store.installedBuddies.count) owned", color: BMOTheme.accent)
+            }
+
+            if store.installedBuddies.isEmpty {
+                Text("Install your first Buddy from Discover to start a roster.")
+                    .font(.subheadline)
+                    .foregroundColor(BMOTheme.textSecondary)
+            } else {
+                ForEach(store.installedBuddies) { buddy in
+                    let isActive = store.activeBuddy?.instanceId == buddy.instanceId
+                    let template = store.contracts?.templateForInstance(buddy)
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(alignment: .top) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(buddy.displayName)
+                                    .font(.headline)
+                                    .foregroundColor(BMOTheme.textPrimary)
+                                Text(template?.name ?? buddy.identity.role)
+                                    .font(.subheadline)
+                                    .foregroundColor(BMOTheme.textSecondary)
+                            }
+                            Spacer()
+                            if isActive {
+                                StatusBadge(label: "Active", color: BMOTheme.accent)
+                            } else {
+                                Button("Equip") {
+                                    store.makeActive(buddy, using: appState)
+                                }
+                                .buttonStyle(BMOButtonStyle(isPrimary: false))
+                            }
+                        }
+
+                        Text("Focus: \(buddy.state.currentFocus ?? "No active focus")")
+                            .font(.subheadline)
+                            .foregroundColor(BMOTheme.textSecondary)
+
+                        HStack(spacing: BMOTheme.spacingSM) {
+                            metricPill(title: "Level", value: "\(buddy.progression.level)")
+                            metricPill(title: "Bond", value: "\(buddy.progression.bond)")
+                            metricPill(title: "Mood", value: buddy.state.mood.capitalized)
+                        }
+                    }
+                    .padding(BMOTheme.spacingMD)
+                    .background(BMOTheme.backgroundSecondary)
+                    .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
+                }
+            }
+        }
+        .bmoCard()
+    }
+
+    private var trainingAndManagementCard: some View {
+        VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
+            Text("Training and Plans")
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-
-            ForEach(store.installedBuddies) { buddy in
-                let isActive = store.activeBuddy?.instanceId == buddy.instanceId
-                let template = store.contracts?.templateForInstance(buddy)
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(alignment: .top) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(buddy.displayName)
-                                .font(.headline)
-                                .foregroundColor(BMOTheme.textPrimary)
-                            Text(template?.name ?? buddy.identity.role)
-                                .font(.subheadline)
-                                .foregroundColor(BMOTheme.textSecondary)
-                        }
-                        Spacer()
-                        if isActive {
-                            StatusBadge(label: "Active", color: BMOTheme.accent)
-                        } else {
-                            Button("Make Active") {
-                                store.makeActive(buddy, using: appState)
-                            }
-                            .buttonStyle(BMOButtonStyle(isPrimary: false))
-                        }
-                    }
-
-                    Text("Focus: \(buddy.state.currentFocus ?? "No active focus")")
-                        .font(.subheadline)
-                        .foregroundColor(BMOTheme.textSecondary)
-
-                    HStack(spacing: BMOTheme.spacingSM) {
-                        metricPill(title: "Level", value: "\(buddy.progression.level)")
-                        metricPill(title: "Bond", value: "\(buddy.progression.bond)")
-                        metricPill(title: "Mood", value: buddy.state.mood.capitalized)
-                    }
+            Text("Training grows your active Buddy. Pricing controls future Buddy slots, premium marketplace access, and higher runtime capacity.")
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+            HStack {
+                Button("Open Pricing") {
+                    appState.selectedTab = .pricing
                 }
-                .padding(BMOTheme.spacingMD)
-                .background(BMOTheme.backgroundSecondary)
-                .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+                Button("Open Chat") {
+                    appState.selectedTab = .chat
+                }
+                .buttonStyle(BMOButtonStyle())
             }
         }
         .bmoCard()
@@ -498,6 +522,21 @@ struct BuddyView: View {
             return BMOTheme.warning
         default:
             return BMOTheme.textSecondary
+        }
+    }
+
+    private func buddyMood(for buddy: BuddyInstance) -> BuddyAnimationMood {
+        switch buddy.state.mood.lowercased() {
+        case "happy", "excited":
+            return .happy
+        case "working":
+            return .working
+        case "thinking":
+            return .thinking
+        case "sleepy", "tired":
+            return .sleepy
+        default:
+            return .idle
         }
     }
 }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
@@ -2,12 +2,15 @@ import SwiftUI
 
 struct ChatView: View {
     @EnvironmentObject private var appState: AppState
+    @ObservedObject var store: BuddyProfileStore
     @State private var prompt = ""
     @FocusState private var isInputFocused: Bool
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
+                buddyChatHeader
+
                 ScrollViewReader { proxy in
                     ScrollView {
                         LazyVStack(spacing: 12) {
@@ -59,7 +62,7 @@ struct ChatView: View {
             .navigationTitle("")
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    Text("Chat")
+                    Text(store.activeBuddy?.displayName ?? "Buddy Chat")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
                 }
@@ -85,8 +88,32 @@ struct ChatView: View {
             }
             .onAppear {
                 appState.workspaceRuntime.refreshMetadata()
+                store.load(for: appState.stackConfig)
             }
         }
+    }
+
+    private var buddyChatHeader: some View {
+        HStack(alignment: .center, spacing: 12) {
+            BuddyAsciiView(mood: buddyMood, compact: true)
+                .frame(width: 126)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Chatting with \(store.activeBuddy?.displayName ?? "your Buddy")")
+                    .font(.headline)
+                    .foregroundColor(BMOTheme.textPrimary)
+                Text(buddyChatSubtitle)
+                    .font(.caption)
+                    .foregroundColor(BMOTheme.textSecondary)
+                    .lineLimit(2)
+            }
+            Spacer()
+            Button("Switch") {
+                appState.selectedTab = .buddy
+            }
+            .buttonStyle(BMOButtonStyle(isPrimary: false))
+        }
+        .padding(BMOTheme.spacingMD)
+        .background(BMOTheme.backgroundSecondary)
     }
 
     private var fileChipsBar: some View {
@@ -135,7 +162,7 @@ struct ChatView: View {
             }
 
             HStack(alignment: .bottom, spacing: 10) {
-                TextField("Message your agent...", text: $prompt, axis: .vertical)
+                TextField("Message \(store.activeBuddy?.displayName ?? "your Buddy")...", text: $prompt, axis: .vertical)
                     .focused($isInputFocused)
                     .textFieldStyle(.plain)
                     .font(.body)
@@ -179,12 +206,35 @@ struct ChatView: View {
 
     private var statusLine: String {
         if let account = appState.selectedProviderAccount {
-            return "Direct cloud chat via \(account.provider.displayName) • \(account.modelSlug)"
+            return "\(store.activeBuddy?.displayName ?? "Buddy") via \(account.provider.displayName) • \(account.modelSlug)"
         }
         if let model = appState.selectedInstalledModel {
-            return appState.usesStubRuntime ? "Local model selected, runtime not included in this build" : "On-device model • \(model.displayName)"
+            return appState.usesStubRuntime ? "Local model selected, runtime not included in this build" : "\(store.activeBuddy?.displayName ?? "Buddy") on-device • \(model.displayName)"
         }
         return "Route not configured. Link a cloud provider to chat in this build."
+    }
+
+    private var buddyChatSubtitle: String {
+        guard let buddy = store.activeBuddy else {
+            return "Create a Buddy so chat has a real companion identity."
+        }
+        return "\(buddy.identity.role) • \(buddy.state.currentFocus ?? "ready for the next useful step")"
+    }
+
+    private var buddyMood: BuddyAnimationMood {
+        guard let buddy = store.activeBuddy else { return .thinking }
+        switch buddy.state.mood.lowercased() {
+        case "happy", "excited":
+            return .happy
+        case "working":
+            return .working
+        case "thinking":
+            return .thinking
+        case "sleepy", "tired":
+            return .sleepy
+        default:
+            return appState.chatStore.isGenerating ? .thinking : .idle
+        }
     }
 }
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MissionControlView: View {
     @EnvironmentObject private var appState: AppState
+    @ObservedObject var store: BuddyProfileStore
     @State private var selectedSurface: RepoSurface?
     @State private var lastReceipt: OpenClawReceipt?
     @State private var sandboxCommand = "ls"
@@ -18,8 +19,6 @@ struct MissionControlView: View {
                     taskAndResultsCard
                     skillsCard
                     macPowerCard
-                    routeCard
-                    stackSurfacesCard
                 }
                 .padding(.horizontal, BMOTheme.spacingMD)
                 .padding(.bottom, BMOTheme.spacingXL)
@@ -38,33 +37,37 @@ struct MissionControlView: View {
             .sheet(item: $selectedSurface) { surface in
                 RepoSurfaceDetailView(surface: surface)
             }
-            .onAppear { appState.workspaceRuntime.refreshMetadata() }
+            .onAppear {
+                appState.workspaceRuntime.refreshMetadata()
+                store.load(for: appState.stackConfig)
+            }
         }
     }
 
     private var buddyHomeCard: some View {
         let status = appState.buddyRuntimeStatus
+        let buddy = store.activeBuddy
         return VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("BeMore")
+                    Text("My Buddy")
                         .font(.caption.weight(.semibold))
                         .foregroundColor(BMOTheme.textTertiary)
-                    Text("Buddy keeps the work moving.")
+                    Text(buddy?.displayName ?? "Choose your Buddy")
                         .font(.system(size: 30, weight: .bold))
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text(appState.operatorSummary)
+                    Text(homeSubtitle(for: buddy))
                         .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
                 Spacer()
-                StatusBadge(label: status.runtimeAvailable ? "Buddy ready" : "Needs setup", color: status.runtimeAvailable ? BMOTheme.success : BMOTheme.warning)
+                StatusBadge(label: buddy == nil ? "Needs Buddy" : status.runtimeAvailable ? "Ready" : "Phone-first", color: buddy == nil ? BMOTheme.warning : status.runtimeAvailable ? BMOTheme.success : BMOTheme.accent)
             }
 
-            BuddyAsciiView(mood: buddyMood(for: status))
+            BuddyAsciiView(mood: buddyMood(for: status, buddy: buddy))
 
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
-                dashboardMetric("Workspace", value: "\(appState.workspaceStore.files.count)", icon: "folder")
+                dashboardMetric("Owned", value: "\(store.installedBuddies.count)", icon: "person.2.fill")
                 dashboardMetric("Skills", value: "\(status.registeredSkillCount)", icon: "sparkles.rectangle.stack")
                 dashboardMetric("Receipts", value: "\(status.recentChanges.count)", icon: "checklist.checked")
                 dashboardMetric("Mac", value: appState.macRuntimeSnapshot == nil ? "pair" : "live", icon: "macbook.and.iphone")
@@ -78,30 +81,30 @@ struct MissionControlView: View {
             Text("Start with Buddy")
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-            Text("Use the same mobile loop as the Mac shell: choose workspace context, run a skill or task, inspect the result, and keep the receipt.")
+            Text("Talk to your active Buddy, train them, run a skill, or inspect the latest result. Runtime setup stays secondary until you ask for more power.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
 
             HStack(spacing: 8) {
-                Button("Open Buddy") {
-                    appState.selectedTab = .buddy
+                Button("Chat with \(store.activeBuddy?.displayName ?? "Buddy")") {
+                    appState.selectedTab = .chat
                 }
                 .buttonStyle(BMOButtonStyle())
 
-                Button("Pair Mac") {
-                    appState.selectedTab = .pairing
+                Button("Train Buddy") {
+                    appState.selectedTab = .buddy
                 }
                 .buttonStyle(BMOButtonStyle(isPrimary: false))
             }
 
             HStack(spacing: 8) {
-                Button("Workspace") {
-                    appState.selectedTab = .files
+                Button("Discover") {
+                    appState.selectedTab = .buddy
                 }
                 .buttonStyle(BMOButtonStyle(isPrimary: false))
 
-                Button("Skills") {
-                    appState.selectedTab = .skills
+                Button("Plans") {
+                    appState.selectedTab = .pricing
                 }
                 .buttonStyle(BMOButtonStyle(isPrimary: false))
             }
@@ -114,7 +117,7 @@ struct MissionControlView: View {
         return VStack(alignment: .leading, spacing: 12) {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Tasks and results")
+                    Text("\(store.activeBuddy?.displayName ?? "Buddy")'s next result")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
                     Text("Receipt-backed work is the proof surface on iPhone too.")
@@ -141,7 +144,7 @@ struct MissionControlView: View {
             }
 
             if status.recentChanges.isEmpty {
-                Text("Run a Buddy action, skill, or Mac inspection to create the next result.")
+                Text("Run a Buddy action, skill, or Mac inspection to create the next receipt-backed result.")
                     .font(.caption)
                     .foregroundColor(BMOTheme.textTertiary)
             } else {
@@ -193,18 +196,6 @@ struct MissionControlView: View {
         .bmoCard()
     }
 
-    private var routeCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Runtime route")
-                .font(.headline)
-                .foregroundColor(BMOTheme.textPrimary)
-            detailRow("Active route", value: appState.activeRouteTitle)
-            detailRow("Target", value: appState.activeRouteDetail)
-            detailRow("Health", value: appState.routeHealthSummary)
-        }
-        .bmoCard()
-    }
-
     private var stackSurfacesCard: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Reference surfaces")
@@ -249,12 +240,34 @@ struct MissionControlView: View {
         .bmoCard()
     }
 
-    private func buddyMood(for status: BuddyRuntimeStatus) -> BuddyAnimationMood {
+    private func buddyMood(for status: BuddyRuntimeStatus, buddy: BuddyInstance?) -> BuddyAnimationMood {
+        if let buddy {
+            switch buddy.state.mood.lowercased() {
+            case "happy", "excited":
+                return .happy
+            case "working":
+                return .working
+            case "thinking":
+                return .thinking
+            case "sleepy", "tired":
+                return .sleepy
+            default:
+                break
+            }
+        }
         if !status.failedActions.isEmpty { return .thinking }
         if appState.macRuntimeSnapshot?.processes.contains(where: { $0.status == "running" }) == true { return .working }
         if status.recentChanges.isEmpty && appState.workspaceStore.files.isEmpty { return .sleepy }
         if !status.recentChanges.isEmpty { return .happy }
         return status.runtimeAvailable ? .idle : .thinking
+    }
+
+    private func homeSubtitle(for buddy: BuddyInstance?) -> String {
+        guard let buddy else {
+            return "Create or install a Buddy before setup details take over the product."
+        }
+        let focus = buddy.state.currentFocus ?? "ready for the next useful step"
+        return "\(buddy.identity.role) • \(focus)"
     }
 
     private func detailRow(_ label: String, value: String) -> some View {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/PricingView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/PricingView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct PricingView: View {
+    private let plans: [PricingPlan] = [
+        PricingPlan(
+            name: "BeMore Free",
+            price: "$0",
+            subtitle: "Start with one active Buddy and the phone-first workflow.",
+            features: ["1 active Buddy", "Starter Buddy marketplace", "Local receipts and results", "Manual Mac pairing"]
+        ),
+        PricingPlan(
+            name: "BeMore Plus",
+            price: "$12/mo preview",
+            subtitle: "More Buddy capacity and stronger runtime usage when billing is enabled.",
+            features: ["More Buddy slots", "Higher runtime/task capacity", "More saved skills", "Priority model routing options"]
+        ),
+        PricingPlan(
+            name: "Buddy Council",
+            price: "$29/mo preview",
+            subtitle: "For teams of Buddies, councils, premium marketplace access, and power users.",
+            features: ["Council/team Buddy rosters", "Premium and creator Buddies", "Advanced Mac power mode", "Expanded receipts and artifact history"]
+        )
+    ]
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: BMOTheme.spacingMD) {
+                    headerCard
+                    ForEach(plans) { plan in
+                        planCard(plan)
+                    }
+                    billingStatusCard
+                }
+                .padding(.horizontal, BMOTheme.spacingMD)
+                .padding(.bottom, BMOTheme.spacingXL)
+            }
+            .background(BMOTheme.backgroundPrimary)
+            .navigationTitle("Pricing")
+            .toolbarBackground(BMOTheme.backgroundPrimary, for: .navigationBar)
+        }
+    }
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Plans grow with your Buddy")
+                .font(.system(size: 30, weight: .bold))
+                .foregroundColor(BMOTheme.textPrimary)
+            Text("Billing is not connected in this build yet, but the product model is now explicit: free Buddy ownership, Plus runtime power, and Council/marketplace expansion.")
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+            StatusBadge(label: "Billing preview", color: BMOTheme.accent)
+        }
+        .bmoCard()
+    }
+
+    private func planCard(_ plan: PricingPlan) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(plan.name)
+                        .font(.title3.bold())
+                        .foregroundColor(BMOTheme.textPrimary)
+                    Text(plan.subtitle)
+                        .font(.subheadline)
+                        .foregroundColor(BMOTheme.textSecondary)
+                }
+                Spacer()
+                Text(plan.price)
+                    .font(.headline)
+                    .foregroundColor(BMOTheme.accent)
+            }
+
+            ForEach(plan.features, id: \.self) { feature in
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(BMOTheme.success)
+                    Text(feature)
+                        .font(.subheadline)
+                        .foregroundColor(BMOTheme.textSecondary)
+                }
+            }
+        }
+        .bmoCard()
+    }
+
+    private var billingStatusCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Upgrade path")
+                .font(.headline)
+                .foregroundColor(BMOTheme.textPrimary)
+            Text("Upgrade buttons stay disabled until StoreKit or server billing is wired. The app now has a real pricing surface without pretending checkout is live.")
+                .font(.subheadline)
+                .foregroundColor(BMOTheme.textSecondary)
+            Button("Checkout not enabled yet") {}
+                .buttonStyle(BMOButtonStyle(isPrimary: false))
+                .disabled(true)
+                .opacity(0.55)
+        }
+        .bmoCard()
+    }
+}
+
+private struct PricingPlan: Identifiable {
+    var id: String { name }
+    let name: String
+    let price: String
+    let subtitle: String
+    let features: [String]
+}


### PR DESCRIPTION
## Summary
- rewrites BeMoreAgent onboarding around creating/naming the first Buddy before optional runtime setup
- centers Home, Buddy, and Chat on one app-level active Buddy store
- adds Buddy marketplace and pricing surfaces, and bumps BeMoreAgent to build 21

## Task contract
- Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem
BeMoreAgent still opened with too much runtime/setup/admin weight, while Buddy identity, Chat, marketplace, and pricing were not structurally central enough.

## Smallest useful wedge
Make onboarding create a named first Buddy before optional power mode, make Home/Chat/Buddy share one active Buddy store, add marketplace and pricing MVP surfaces, and preserve the existing iOS release path with build 21.

## Verification plan
Run the BeMoreAgent simulator build and rely on PR CI for readiness, smoke, workflow lint, CodeQL, and the BeMoreAgent generation/build lane.

## Rollback plan
Revert this PR commit to return to the prior BeMoreAgent shell and build number.

## Verification
- `cd apps/openclaw-shell-ios && xcodegen generate && xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination generic/platform=iOS\ Simulator -derivedDataPath .build/DerivedData build`
- Result: `** BUILD SUCCEEDED **`

## Rollback
Revert this PR commit to return to the prior BeMoreAgent shell and build number.