### PR TITLE
Render the active Buddy across iOS

### DIFF
--- a/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
@@ -337,7 +337,7 @@ struct OnboardingFlow: View {
             Text("Your active Buddy")
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-            Text(selectedTemplate?.ascii.baseSilhouette ?? "  /\\_/\\\n ( o.o )\n  > ^ <")
+            Text(selectedTemplate?.ascii.baseSilhouette ?? "    /\\\n  < o  o >\n  /|  v |\\\n /_|____|_\\")
                 .font(.system(.caption, design: .monospaced))
                 .foregroundColor(BMOTheme.accent)
             Text("\(fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")) will become the Buddy shown on Home and in Chat.")

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyAsciiView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyAsciiView.swift
@@ -7,9 +7,12 @@ enum BuddyAnimationMood {
     case working
     case sleepy
     case levelUp
+    case needsAttention
 }
 
 struct BuddyAsciiView: View {
+    var buddy: BuddyInstance?
+    var template: CouncilStarterBuddyTemplate?
     let mood: BuddyAnimationMood
     var compact = false
     @State private var tick = 0
@@ -28,7 +31,7 @@ struct BuddyAsciiView: View {
                     tick += 1
                 }
             }
-            .accessibilityLabel("Buddy \(label)")
+            .accessibilityLabel("\(buddy?.displayName ?? "Buddy") \(label)")
     }
 
     private var label: String {
@@ -39,6 +42,7 @@ struct BuddyAsciiView: View {
         case .working: return "working"
         case .sleepy: return "sleepy"
         case .levelUp: return "level up"
+        case .needsAttention: return "needs attention"
         }
     }
 
@@ -48,41 +52,91 @@ struct BuddyAsciiView: View {
     }
 
     private var framesForMood: [String] {
+        if let template {
+            let state = moodKey
+            if state == "idle", template.ascii.idleFrames.isEmpty == false {
+                return template.ascii.idleFrames
+            }
+            if let expression = template.ascii.expressions[state] {
+                return [expression, template.ascii.baseSilhouette]
+            }
+            return activeTemplateFallbackFrames(for: template.ascii.baseSilhouette)
+        }
         switch mood {
         case .idle:
             return [
-                Self.make(["   /\\_/\\", "  ( o.o )", "  /| _ |\\", "   /   \\", "  _|   |_"]),
-                Self.make(["   /\\_/\\", "  ( o.o )", "  /| _ |\\", "   /   \\", "   |___|"])
+                Self.make(["    /\\", "  < o  o >", "  /|  v |\\", " /_|____|_\\", "   /_  _\\"]),
+                Self.make(["    /\\", "  < o  o >", "  /|  v |\\", " /_|____|_\\", "   \\_  _/"])
             ]
         case .happy:
             return [
-                Self.make(["   /\\_/\\", "  ( ^.^ )", "  /| * |\\", "   / \\ \\", "  _| |_|"]),
-                Self.make(["  \\/\\_/\\/", "  ( ^o^ )", "  /| * |\\", "   / \\ \\", "  _| |_|"])
+                Self.make(["  \\ /\\ /", "  < ^  ^ >", "  /|  * |\\", " /_|____|_\\", "    /  \\"]),
+                Self.make([" *  /\\  *", "  < ^  o >", "  /|  * |\\", " /_|____|_\\", "    \\  /"])
             ]
         case .thinking:
             return [
-                Self.make(["   /\\_/\\", "  ( o.o )  ?", "  /| _ |\\", "   /   \\", "   |___|"]),
-                Self.make(["   /\\_/\\", "  ( o_o )  ..", "  /| _ |\\", "   /   \\", "   |___|"])
+                Self.make(["    /\\   ?", "  < o  o >", "  /|  ? |\\", " /_|____|_\\", "    /  \\"]),
+                Self.make(["    /\\  ..", "  < o  O >", "  /|  ? |\\", " /_|____|_\\", "    \\  /"])
             ]
         case .working:
             return [
-                Self.make(["    .-.", "  <(o o)> *", "   /| # |\\", "  /_|___|_\\", "    \\ /"]),
-                Self.make(["    .-.", "  <(o o)> **", "   /| # |\\", "  /_|___|_\\", "    / \\"])
+                Self.make(["    /\\  #", "  < >  < >", "  /| [ ]|\\", " /_|____|_\\", "   /_  _\\"]),
+                Self.make(["    /\\  ##", "  < >  < >", "  /| [*]|\\", " /_|____|_\\", "   \\_  _/"])
             ]
         case .sleepy:
             return [
-                Self.make(["   /\\_/\\", "  ( -.- ) z", "  /| _ |\\", "   /   \\", "   |___|"]),
-                Self.make(["   /\\_/\\", "  ( -.- ) zz", "  /| _ |\\", "   /   \\", "  _|___|_"])
+                Self.make(["    /\\   z", "  < -  - >", "  /|  . |\\", " /_|____|_\\", "    /__\\"]),
+                Self.make(["    /\\  zz", "  < -  - >", "  /|  . |\\", " /_|____|_\\", "   _/  \\_"])
             ]
         case .levelUp:
             return [
-                Self.make(["  * /\\_/\\ *", "   ( ^.^ )", "  /|[*]|\\", "   / \\ \\", "  _| |_|"]),
-                Self.make([" **/\\_/\\**", "   ( ^o^ )", "  /|[*]|\\", "   / \\ \\", "  _| |_|"])
+                Self.make([" ** /\\ **", "  < ^  ^ >", "  /|{*}|\\", " /_|____|_\\", "    /  \\"]),
+                Self.make(["*** /\\ ***", "  < ^  o >", "  /|{*}|\\", " /_|____|_\\", "    \\  /"])
             ]
+        case .needsAttention:
+            return [
+                Self.make([" !  /\\  !", "  < o  o >", "  /|  ! |\\", " /_|____|_\\", "    /  \\"]),
+                Self.make([" !! /\\ !!", "  < O  o >", "  /|  ! |\\", " /_|____|_\\", "    \\  /"])
+            ]
+        }
+    }
+
+    private func activeTemplateFallbackFrames(for silhouette: String) -> [String] {
+        switch mood {
+        case .idle:
+            return [silhouette]
+        case .happy:
+            return [Self.wrap(silhouette, top: "\\   /", bottom: "  YES"), Self.wrap(silhouette, top: " \\ / ", bottom: "  <3 ")]
+        case .thinking:
+            return [Self.wrap(silhouette, top: "  ? ", bottom: "  ..."), Self.wrap(silhouette, top: " ?  ", bottom: "  hmm")]
+        case .working:
+            return [Self.wrap(silhouette, top: "  ##", bottom: "[work]"), Self.wrap(silhouette, top: " ###", bottom: "[build]")]
+        case .sleepy:
+            return [Self.wrap(silhouette, top: "   z", bottom: " rest"), Self.wrap(silhouette, top: "  zz", bottom: " slow")]
+        case .levelUp:
+            return [Self.wrap(silhouette, top: "** **", bottom: "LEVEL"), Self.wrap(silhouette, top: "*****", bottom: " UP! ")]
+        case .needsAttention:
+            return [Self.wrap(silhouette, top: " ! !", bottom: "check"), Self.wrap(silhouette, top: "!! !!", bottom: " care")]
+        }
+    }
+
+    private var moodKey: String {
+        switch mood {
+        case .idle: return buddy?.visual?.currentAnimationState ?? buddy?.state.mood ?? "idle"
+        case .happy: return "happy"
+        case .thinking: return "thinking"
+        case .working: return "working"
+        case .sleepy: return "sleepy"
+        case .levelUp: return "levelUp"
+        case .needsAttention: return "needsAttention"
         }
     }
 
     private static func make(_ lines: [String]) -> String {
         lines.joined(separator: "\n")
+    }
+
+    private static func wrap(_ silhouette: String, top: String, bottom: String) -> String {
+        "\(top)\n\(silhouette.trimmingCharacters(in: .newlines))\n\(bottom)"
     }
 }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
@@ -79,7 +79,7 @@ struct BuddyView: View {
                 )
             }
 
-            BuddyAsciiView(mood: buddyMood(for: buddy), compact: true)
+            BuddyAsciiView(buddy: buddy, template: template, mood: buddyMood(for: buddy), compact: true)
 
             HStack(spacing: BMOTheme.spacingSM) {
                 metricPill(title: "Owned", value: "\(status.installedBuddyCount)")
@@ -115,13 +115,7 @@ struct BuddyView: View {
                 }
             }
 
-            Text(asciiArt(for: buddy, template: template))
-                .font(.system(.body, design: .monospaced))
-                .foregroundColor(BMOTheme.accent)
-                .padding(BMOTheme.spacingMD)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(BMOTheme.backgroundSecondary)
-                .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
+            BuddyAsciiView(buddy: buddy, template: template, mood: buddyMood(for: buddy))
 
             Text(template?.onboardingCopy ?? "Buddy profile is ready for the BeMore runtime.")
                 .font(.subheadline)
@@ -535,6 +529,8 @@ struct BuddyView: View {
             return .thinking
         case "sleepy", "tired":
             return .sleepy
+        case "needsattention", "needs attention", "stressed":
+            return .needsAttention
         default:
             return .idle
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
@@ -95,7 +95,7 @@ struct ChatView: View {
 
     private var buddyChatHeader: some View {
         HStack(alignment: .center, spacing: 12) {
-            BuddyAsciiView(mood: buddyMood, compact: true)
+            BuddyAsciiView(buddy: store.activeBuddy, template: store.activeBuddy.flatMap { store.contracts?.templateForInstance($0) }, mood: buddyMood, compact: true)
                 .frame(width: 126)
             VStack(alignment: .leading, spacing: 4) {
                 Text("Chatting with \(store.activeBuddy?.displayName ?? "your Buddy")")
@@ -232,6 +232,8 @@ struct ChatView: View {
             return .thinking
         case "sleepy", "tired":
             return .sleepy
+        case "needsattention", "needs attention", "stressed":
+            return .needsAttention
         default:
             return appState.chatStore.isGenerating ? .thinking : .idle
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
@@ -64,7 +64,7 @@ struct MissionControlView: View {
                 StatusBadge(label: buddy == nil ? "Needs Buddy" : status.runtimeAvailable ? "Ready" : "Phone-first", color: buddy == nil ? BMOTheme.warning : status.runtimeAvailable ? BMOTheme.success : BMOTheme.accent)
             }
 
-            BuddyAsciiView(mood: buddyMood(for: status, buddy: buddy))
+            BuddyAsciiView(buddy: buddy, template: buddy.flatMap { store.contracts?.templateForInstance($0) }, mood: buddyMood(for: status, buddy: buddy))
 
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
                 dashboardMetric("Owned", value: "\(store.installedBuddies.count)", icon: "person.2.fill")
@@ -251,11 +251,13 @@ struct MissionControlView: View {
                 return .thinking
             case "sleepy", "tired":
                 return .sleepy
+            case "needsattention", "needs attention", "stressed":
+                return .needsAttention
             default:
                 break
             }
         }
-        if !status.failedActions.isEmpty { return .thinking }
+        if !status.failedActions.isEmpty { return .needsAttention }
         if appState.macRuntimeSnapshot?.processes.contains(where: { $0.status == "running" }) == true { return .working }
         if status.recentChanges.isEmpty && appState.workspaceStore.files.isEmpty { return .sleepy }
         if !status.recentChanges.isEmpty { return .happy }

--- a/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
+++ b/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
@@ -136,7 +136,7 @@ final class AppStateRuntimeTests: XCTestCase {
         XCTAssertFalse(cleaned.localizedCaseInsensitiveContains("private chain"))
     }
 
-    func testWorkspaceBootstrapCreatesCanonicalOpenClawArtifacts() throws {
+    func testWorkspaceBootstrapCreatesCanonicalBeMoreArtifacts() throws {
         let runtime = OpenClawWorkspaceRuntime()
         var config = StackConfig.default
         config.stackName = "BeMore"
@@ -153,7 +153,7 @@ final class AppStateRuntimeTests: XCTestCase {
         XCTAssertTrue(soul.contains("one agent, one workspace"))
         let skillsMarkdown = try runtime.readFile("skills.md")
         XCTAssertTrue(skillsMarkdown.contains("## Installed skills"))
-        XCTAssertTrue(skillsMarkdown.contains("## ClawHub starters"))
+        XCTAssertTrue(skillsMarkdown.contains("## Buddy Skill Hub starters"))
         XCTAssertTrue(skillsMarkdown.contains("File Crafter"))
         XCTAssertTrue(skillsMarkdown.contains("Chat should not treat old skill artifacts as active context"))
         XCTAssertTrue(runtime.skills.contains(where: { $0.id == BuiltInSkillRegistry.pokemonTeamBuilderID }))


### PR DESCRIPTION
## Summary
- routes Home, Buddy, and Chat Buddy visuals through the active Buddy instance/template
- replaces the generic onboarding fallback cat art with a BeMore Buddy silhouette
- adds active-template fallback animation frames for working, sleepy, level-up, and needs-attention states
- updates the workspace artifact test to the current BeMore/Buddy Skill Hub contract

## Task contract
Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem
iOS still let generic Buddy placeholder art carry key surfaces, making the active Buddy feel less singular and less personal.

## Smallest useful wedge
Render Home, Buddy, Chat, and onboarding completion/fallback paths from the active Buddy/template when available, and keep a non-cat BeMore fallback for unconfigured states.

## Verification plan
- Build BeMoreAgent for iOS Simulator.
- Run the targeted workspace artifact test that changed with the BeMore/Buddy Skill Hub contract.
- Search touched iOS surfaces for the old placeholder cat patterns.

## Rollback plan
Revert commit 0d6fe6b if the active-Buddy renderer causes an iOS regression; the change is isolated to Buddy-facing views, onboarding fallback art, and one test assertion.

## Validation
- xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO -only-testing:BeMoreAgentTests/AppStateRuntimeTests/testWorkspaceBootstrapCreatesCanonicalBeMoreArtifacts test
- rg placeholder cat pattern sweep across iOS surfaces