### PR TITLE
Simplify the default iOS Buddy navigation

### DIFF
--- a/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
@@ -481,7 +481,7 @@ struct ShellPreferences: Codable, Hashable {
 
     static let `default` = ShellPreferences(
         orderedTabs: [.missionControl, .buddy, .chat, .skills, .artifacts, .files, .pairing, .pricing, .models, .settings],
-        hiddenTabs: [],
+        hiddenTabs: [.pairing, .pricing, .models],
         selectedTab: .missionControl
     )
 


### PR DESCRIPTION
## Summary
- keeps the primary iOS tab bar focused on Home, Buddy, Chat, Skills, Results, Workspace, and Settings
- demotes Mac pairing, pricing, and model setup from default tabs while preserving them through tab management/settings

## Task contract
Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem
The iOS default tab bar still exposed too much setup and monetization/admin surface area for a Buddy-first product feel.

## Smallest useful wedge
Hide pairing, pricing, and models by default so the first-run shell stays companion-first without deleting any power surfaces.

## Verification plan
- Build BeMoreAgent for iOS Simulator.
- Let PR checks rerun the repo readiness and iOS validation lanes.

## Rollback plan
Revert this one-line ShellPreferences default change if the team wants those secondary surfaces visible by default again.

## Validation
- xcodebuild -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build