### PR TITLE
Fix BeMore onboarding and chat escape paths

### DIFF
--- a/TASK_STATE.md
+++ b/TASK_STATE.md
@@ -1,14 +1,14 @@
 # Task State
 
-Last updated: 2026-04-11 00:20 UTC
+Last updated: 2026-04-11 16:12 UTC
 
 ## Current status
 
-- Description: Land the Build 18 Buddy library foundation on a fresh branch for `apps/openclaw-shell-ios` without reusing the MacBook setup branch or migrating iOS build ownership out of `bmo-stack`.
+- Description: Complete the BeMore usability rescue pass by fixing the iOS chat escape trap, simplifying the Buddy-first shell, and adding first-run onboarding in `apps/openclaw-shell-ios`.
 - Active repo: `/Users/taylor/development/bmo-stack`
 - Branch: `codex/build18-buddy-library-foundation`
-- Last successful step: bundled the canonical Buddy/docs inputs through `OpenClawShell/RepoResources`, implemented the receipt-backed Buddy runtime/store/UI path, fixed the malformed schema payloads from the PR #231 reference import, and verified `xcodebuild ... test` passes locally with 15 tests.
-- Next intended step: stage the Build 18 files, commit, push, open the draft PR, and then watch/fix GitHub checks until green unless a blocker is outside repo scope.
+- Last successful step: validated the rescue changes with `xcodebuild ... build`, `xcodebuild ... test` on the iPhone 17 Pro simulator, simulator smoke checks for onboarding/chat escape, and a no-sign build of the device variant with `CODE_SIGNING_ALLOWED=NO`.
+- Next intended step: stage the usability rescue changes, publish the draft PR, and watch/fix GitHub checks until green.
 - Verification complete: false
 - Manual steps remaining:
   - create the commit and draft PR

--- a/WORK_IN_PROGRESS.md
+++ b/WORK_IN_PROGRESS.md
@@ -1,36 +1,30 @@
 # Work In Progress
 
-Last updated: 2026-04-11 00:20 UTC
+Last updated: 2026-04-11 16:12 UTC
 
 ## Current focus
 
-- Active mission: ship the smallest viable Build 18 Buddy foundation on a fresh `master`-based branch for `apps/openclaw-shell-ios`.
-- Why now: the MacBook setup is already verified on its own branch, and the next safe step is the real Buddy library/install/continuity wedge with repo-owned validation and draft-PR proof.
+- Active mission: ship the BeMore usability rescue pass for `apps/openclaw-shell-ios`.
+- Why now: the current Buddy-first correction still left users trapped in chat on iOS and dropped first-time users into an unclear shell without a stable onboarding/home path.
 - Owner paths in play:
   - `apps/openclaw-shell-ios/OpenClawShell/**`
   - `apps/openclaw-shell-ios/OpenClawShellTests/**`
-  - `apps/openclaw-shell-ios/OpenClawShell/RepoResources/**`
-  - `apps/openclaw-shell-ios/project.yml`
-  - `config/buddy/**`
-  - `schemas/buddy-*.json`
-  - `examples/buddy/**`
-  - `docs/BUDDY_SYSTEM.md`
-  - `docs/COUNCIL_STARTER_PACK.md`
-  - `context/plans/2026-04-10-build18-buddy-library-foundation.md`
+  - `TASK_STATE.md`
+  - `WORK_IN_PROGRESS.md`
 
 ## Current work packet
 
-- canonical Buddy contracts/examples/schemas should stay repo-owned in `bmo-stack`
-- the iOS app should bundle those repo-backed files without copying ownership elsewhere
-- Buddy install/personalize/check-in/training must persist through OpenClaw receipts and regenerate readable Buddy markdown
-- local validation must stay honest: `xcodegen generate`, repo OS validation, and 15 passing simulator tests
+- chat must always expose a visible app-owned exit path and restore a stable return surface
+- compact iPhone navigation must avoid the iOS `More` tab trap by keeping the primary shell to four tabs
+- first launch must route into Buddy-first onboarding and land on a stable home surface when complete
+- the Mac variant should use a clearer split-view shell around Home, Chat, Workspace, Results, and Settings
+- local validation must stay honest: simulator build/tests and direct smoke checks for onboarding plus chat escape
 
 ## Next milestone
 
-- publish the Build 18 Buddy foundation as a draft PR and keep fixing repo-scoped check failures until green
+- publish the usability rescue branch as a draft PR and keep fixing repo-scoped check failures until green
 
 ## Risks and watchouts
 
-- PR #231 and PR #232 remain reference only; do not merge or rebase from them
-- the canonical PR #231 import contained two malformed schema files, so keep an eye on any other reference payloads rather than assuming they are valid
 - remote CI may still surface signing or environment-specific issues outside simulator scope; treat those as separate blockers from local Build 18 readiness
+- Mac "Designed for iPad/iPhone" local launch validation is constrained by Apple signing/runtime behavior, so keep code-signing blockers separate from navigation regressions

--- a/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
@@ -335,6 +335,41 @@ enum StackDeploymentMode: String, Codable, CaseIterable, Hashable, Identifiable 
     }
 }
 
+enum BuddyPowerMode: String, Codable, CaseIterable, Hashable, Identifiable {
+    case gentle
+    case balanced
+    case turbo
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .gentle: return "Easy Start"
+        case .balanced: return "Balanced"
+        case .turbo: return "Power Mode"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .gentle:
+            return "Keep the shell simple and put Buddy guidance first."
+        case .balanced:
+            return "Show the normal Buddy, workspace, and results flow."
+        case .turbo:
+            return "Keep advanced runtime setup and Mac power surfaces close."
+        }
+    }
+
+    var optimizationMode: String {
+        switch self {
+        case .gentle: return "balanced"
+        case .balanced: return "balanced"
+        case .turbo: return "quality"
+        }
+    }
+}
+
 struct StackConfig: Codable {
     var stackName: String
     var goal: String
@@ -342,6 +377,7 @@ struct StackConfig: Codable {
     var onboardingBuddyName: String?
     var onboardingBuddyTemplateID: String?
     var onboardingBuddyFocus: String?
+    var onboardingPowerMode: BuddyPowerMode?
     var autonomyLevel: Int // 1-5
     var memoryEnabled: Bool
     var toolsEnabled: Bool
@@ -363,6 +399,7 @@ struct StackConfig: Codable {
         onboardingBuddyName: nil,
         onboardingBuddyTemplateID: nil,
         onboardingBuddyFocus: nil,
+        onboardingPowerMode: nil,
         autonomyLevel: 3,
         memoryEnabled: true,
         toolsEnabled: true,

--- a/apps/openclaw-shell-ios/OpenClawShell/AppState+OnboardingReset.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/AppState+OnboardingReset.swift
@@ -12,6 +12,8 @@ extension AppState {
         runtimePreferences.selection.selectedInstalledFilename = nil
         runtimePreferences.selection.selectedProvider = nil
         runtimePreferences.persist()
+        selectedTab = stableHomeTab
+        chatReturnTab = nil
         refreshRuntimeSummary()
     }
 }

--- a/apps/openclaw-shell-ios/OpenClawShell/ContentView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/ContentView.swift
@@ -3,15 +3,23 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject private var appState: AppState
 
+    private var isRunningOnMac: Bool {
+        ProcessInfo.processInfo.isiOSAppOnMac
+    }
+
     var body: some View {
         Group {
             if appState.stackConfig.isOnboardingComplete {
-                MainTabView()
+                if isRunningOnMac {
+                    DesktopShellView()
+                } else {
+                    MainTabView()
+                }
             } else {
                 OnboardingFlow()
             }
         }
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(appState.userPreferencesStore.preferences.theme.preferredColorScheme)
     }
 }
 
@@ -23,8 +31,8 @@ struct MainTabView: View {
             get: { appState.selectedTab },
             set: { appState.selectedTab = $0 }
         )) {
-            ForEach(appState.orderedVisibleTabs) { tab in
-                destination(for: tab)
+            ForEach(appState.compactTabOrder) { tab in
+                shellDestination(for: tab, appState: appState)
                     .tabItem {
                         Label(tab.title, systemImage: tab.systemImage)
                     }
@@ -33,6 +41,9 @@ struct MainTabView: View {
         }
         .tint(BMOTheme.accent)
         .onAppear {
+            if !appState.compactTabOrder.contains(appState.selectedTab) {
+                appState.selectedTab = appState.stableHomeTab
+            }
             let tabBarAppearance = UITabBarAppearance()
             tabBarAppearance.configureWithOpaqueBackground()
             tabBarAppearance.backgroundColor = UIColor(BMOTheme.backgroundSecondary)
@@ -41,29 +52,87 @@ struct MainTabView: View {
         }
     }
 
-    @ViewBuilder
-    private func destination(for tab: AppTab) -> some View {
-        switch tab {
-        case .missionControl:
-            MissionControlView(store: appState.buddyStore)
-        case .models:
-            ModelsView()
-        case .chat:
-            ChatView(store: appState.buddyStore)
-        case .skills:
-            SkillsView()
-        case .artifacts:
-            ArtifactsView()
-        case .buddy:
-            BuddyView(store: appState.buddyStore)
-        case .files:
-            FilesView()
-        case .pairing:
-            MacPairingView()
-        case .pricing:
-            PricingView()
-        case .settings:
-            SettingsView()
+}
+
+struct DesktopShellView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: Binding(
+                get: { appState.selectedTab },
+                set: { appState.selectedTab = $0 ?? appState.stableHomeTab }
+            )) {
+                Section("Start Here") {
+                    shellRow(.missionControl, subtitle: "Buddy-first home and next steps")
+                    shellRow(.buddy, subtitle: "Your active Buddy, roster, and training")
+                    shellRow(.chat, subtitle: "Talk to your Buddy with a safe way back home")
+                }
+
+                Section("Work") {
+                    shellRow(.files, subtitle: "Workspace files and source materials")
+                    shellRow(.skills, subtitle: "Skills you can run through the runtime")
+                    shellRow(.artifacts, subtitle: "Results, receipts, and generated artifacts")
+                }
+
+                Section("Control") {
+                    shellRow(.settings, subtitle: "Onboarding, routes, tabs, and maintenance")
+                }
+            }
+            .navigationTitle("BeMore")
+            .scrollContentBackground(.hidden)
+            .background(BMOTheme.backgroundPrimary)
+        } detail: {
+            shellDestination(for: appState.selectedTab, appState: appState)
         }
+        .tint(BMOTheme.accent)
+        .onAppear {
+            if !appState.desktopTabOrder.contains(appState.selectedTab) {
+                appState.selectedTab = appState.stableHomeTab
+            }
+        }
+    }
+
+    private func shellRow(_ tab: AppTab, subtitle: String) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(tab.title)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundColor(BMOTheme.textTertiary)
+            }
+        } icon: {
+            Image(systemName: tab.systemImage)
+        }
+        .tag(tab)
+        .foregroundColor(BMOTheme.textPrimary)
+        .listRowBackground(BMOTheme.backgroundCard)
+    }
+}
+
+@MainActor
+@ViewBuilder
+private func shellDestination(for tab: AppTab, appState: AppState) -> some View {
+    switch tab {
+    case .missionControl:
+        MissionControlView(store: appState.buddyStore)
+    case .models:
+        ModelsView()
+    case .chat:
+        ChatView(store: appState.buddyStore)
+    case .skills:
+        SkillsView()
+    case .artifacts:
+        ArtifactsView()
+    case .buddy:
+        BuddyView(store: appState.buddyStore)
+    case .files:
+        FilesView()
+    case .pairing:
+        MacPairingView()
+    case .pricing:
+        PricingView()
+    case .settings:
+        SettingsView()
     }
 }

--- a/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
@@ -4,6 +4,7 @@ enum OnboardingStep: Int, CaseIterable {
     case welcome
     case chooseBuddy
     case nameBuddy
+    case focusBuddy
     case powerMode
     case building
     case summary
@@ -17,6 +18,7 @@ struct OnboardingFlow: View {
     @State private var selectedTemplateID = ""
     @State private var buddyName = ""
     @State private var buddyFocus = ""
+    @State private var selectedPowerMode: BuddyPowerMode = .balanced
     @State private var showAdvancedSetup = false
     @State private var buildProgress: Double = 0
     @State private var buildMessages: [String] = []
@@ -37,6 +39,7 @@ struct OnboardingFlow: View {
                     case .welcome: welcomeScreen
                     case .chooseBuddy: chooseBuddyScreen
                     case .nameBuddy: nameBuddyScreen
+                    case .focusBuddy: focusBuddyScreen
                     case .powerMode: powerModeScreen
                     case .building: buildingScreen
                     case .summary: summaryScreen
@@ -62,6 +65,7 @@ struct OnboardingFlow: View {
             if buddyFocus.isEmpty {
                 buddyFocus = config.onboardingBuddyFocus ?? "Help me decide what matters and finish the next useful step."
             }
+            selectedPowerMode = config.onboardingPowerMode ?? .balanced
         }
     }
 
@@ -151,11 +155,32 @@ struct OnboardingFlow: View {
         ScrollView {
             VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
                 Spacer().frame(height: BMOTheme.spacingXL)
-                onboardingTitle("Make this Buddy yours", subtitle: "This name and focus follow your Buddy into Home, Chat, tasks, training, and receipts.")
+                onboardingTitle("Name your Buddy", subtitle: "Give your companion the name you want to see on Home, Chat, tasks, training, and receipts.")
                 labeledField(title: "Buddy name", text: $buddyName, placeholder: selectedTemplate?.name ?? "Buddy")
-                labeledField(title: "First focus", text: $buddyFocus, placeholder: selectedTemplate?.canonicalRole ?? "Help me finish the next useful step")
                 selectedBuddyPreview
-                navButtons(back: .chooseBuddy, next: .powerMode, canProceed: !trimmed(buddyName).isEmpty)
+                navButtons(back: .chooseBuddy, next: .focusBuddy, canProceed: !trimmed(buddyName).isEmpty)
+                    .padding(.top, BMOTheme.spacingMD)
+            }
+        }
+    }
+
+    private var focusBuddyScreen: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
+                Spacer().frame(height: BMOTheme.spacingXL)
+                onboardingTitle("Pick your Buddy's first focus", subtitle: "This sets the first use-case BeMore reinforces after onboarding. You can change it later.")
+                labeledField(title: "First focus", text: $buddyFocus, placeholder: selectedTemplate?.canonicalRole ?? "Help me finish the next useful step")
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("How this will show up")
+                        .font(.headline)
+                        .foregroundColor(BMOTheme.textPrimary)
+                    Text("\(fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")) will open on Home with this focus, carry it into Chat, and use it as the default for the first check-ins and receipts.")
+                        .font(.subheadline)
+                        .foregroundColor(BMOTheme.textSecondary)
+                }
+                .bmoCard()
+                .padding(.horizontal, BMOTheme.spacingLG)
+                navButtons(back: .nameBuddy, next: .powerMode, canProceed: !trimmed(buddyFocus).isEmpty)
                     .padding(.top, BMOTheme.spacingMD)
             }
         }
@@ -166,6 +191,35 @@ struct OnboardingFlow: View {
             VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
                 Spacer().frame(height: BMOTheme.spacingXL)
                 onboardingTitle("Power mode is optional", subtitle: "BeMore can start as your Buddy on iPhone. Pairing Mac and route setup are stronger-mode choices, not the first thing you have to understand.")
+
+                VStack(spacing: 12) {
+                    ForEach(BuddyPowerMode.allCases) { mode in
+                        Button {
+                            selectedPowerMode = mode
+                        } label: {
+                            HStack(alignment: .top, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(mode.title)
+                                        .font(.headline)
+                                    Text(mode.subtitle)
+                                        .font(.subheadline)
+                                        .foregroundColor(BMOTheme.textSecondary)
+                                }
+                                Spacer()
+                                if selectedPowerMode == mode {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundColor(BMOTheme.accent)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding()
+                            .foregroundColor(BMOTheme.textPrimary)
+                            .background(selectedPowerMode == mode ? BMOTheme.backgroundCardHover : BMOTheme.backgroundCard)
+                            .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
+                        }
+                    }
+                }
+                .padding(.horizontal, BMOTheme.spacingLG)
 
                 toggleCard(icon: "macbook.and.iphone", title: "Pair with Mac later", subtitle: "Keep Mac runtime pairing available after you land on Buddy Home.", isOn: $config.installDesktopNode)
                     .padding(.horizontal, BMOTheme.spacingLG)
@@ -194,7 +248,7 @@ struct OnboardingFlow: View {
                 .clipShape(RoundedRectangle(cornerRadius: BMOTheme.radiusMedium, style: .continuous))
                 .padding(.horizontal, BMOTheme.spacingLG)
 
-                navButtons(back: .nameBuddy, next: .building, canProceed: true)
+                navButtons(back: .focusBuddy, next: .building, canProceed: true)
                     .padding(.top, BMOTheme.spacingMD)
             }
         }
@@ -265,6 +319,7 @@ struct OnboardingFlow: View {
                     summaryRow(icon: "person.crop.circle.badge.checkmark", label: "Active Buddy", value: buddyName)
                     summaryRow(icon: "sparkles", label: "Starter", value: selectedTemplate?.name ?? "Default Buddy")
                     summaryRow(icon: "scope", label: "Focus", value: buddyFocus)
+                    summaryRow(icon: "dial.high", label: "Power mode", value: selectedPowerMode.title)
                     summaryRow(icon: "macbook.and.iphone", label: "Mac power", value: config.installDesktopNode ? "Available later" : "Phone-first")
                     summaryRow(icon: "creditcard", label: "Plans", value: "Free now; Plus and Council previews in Pricing")
                 }
@@ -321,6 +376,8 @@ struct OnboardingFlow: View {
         config.onboardingBuddyName = cleanedBuddyName
         config.onboardingBuddyTemplateID = templateID
         config.onboardingBuddyFocus = cleanedFocus
+        config.onboardingPowerMode = selectedPowerMode
+        config.optimizationMode = selectedPowerMode.optimizationMode
         config.setupChecklist = generatedChecklist
         config.isOnboardingComplete = true
         appState.completeOnboarding(config)
@@ -493,6 +550,7 @@ struct OnboardingFlow: View {
 
     private var generatedChecklist: [String] {
         var items = ["Keep \(fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")) active on Home, Chat, Skills, and Results."]
+        items.append("Start in \(selectedPowerMode.title.lowercased()) so the first-run shell matches your comfort level.")
         if config.installDesktopNode {
             items.append("Pair a BeMore Mac runtime when you want workspace execution, diffs, artifacts, and receipts from your desktop.")
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
@@ -1169,6 +1169,7 @@ final class AppState: ObservableObject {
     @Published var workspaceRuntime = OpenClawWorkspaceRuntime()
     @Published var macRuntimeSnapshot: MacRuntimeSnapshot?
     @Published var macRuntimeStatus = "Mac not inspected"
+    @Published var chatReturnTab: AppTab?
 
     // MARK: Initializer – now placed after property declarations
     init(engine: LocalLLMEngine) {
@@ -1177,6 +1178,18 @@ final class AppState: ObservableObject {
 
     var orderedVisibleTabs: [AppTab] {
         tabPreferencesStore.preferences.visibleTabs
+    }
+
+    var compactTabOrder: [AppTab] {
+        [.missionControl, .chat, .buddy, .settings]
+    }
+
+    var desktopTabOrder: [AppTab] {
+        [.missionControl, .buddy, .chat, .files, .skills, .artifacts, .settings]
+    }
+
+    var stableHomeTab: AppTab {
+        .missionControl
     }
 
     var selectedTab: AppTab {
@@ -1358,6 +1371,7 @@ final class AppState: ObservableObject {
         workspaceRuntime.bootstrap(config: stackConfig, preferences: userPreferencesStore.preferences, routeSummary: activeRouteModeLabel)
         buddyStore.load(for: config)
         buddyProfileStore?.load(for: config)
+        chatReturnTab = nil
         refreshRuntimeSummary()
     }
 
@@ -1465,7 +1479,7 @@ final class AppState: ObservableObject {
         }
         tabPreferencesStore.persist()
         if !orderedVisibleTabs.contains(selectedTab) {
-            selectedTab = orderedVisibleTabs.first ?? .missionControl
+            selectedTab = orderedVisibleTabs.first ?? stableHomeTab
         }
     }
 
@@ -1475,6 +1489,23 @@ final class AppState: ObservableObject {
         let hiddenTabs = tabPreferencesStore.preferences.orderedTabs.filter { tabPreferencesStore.preferences.hiddenTabs.contains($0) }
         tabPreferencesStore.preferences.orderedTabs = visibleTabs + hiddenTabs
         tabPreferencesStore.persist()
+    }
+
+    func openChat(from source: AppTab? = nil, resetConversation: Bool = false) {
+        let origin = source ?? (selectedTab == .chat ? chatReturnTab : selectedTab)
+        if origin != .chat {
+            chatReturnTab = origin
+        }
+        if resetConversation {
+            chatStore.clear()
+        }
+        selectedTab = .chat
+    }
+
+    func leaveChat() {
+        let destination = chatReturnTab ?? stableHomeTab
+        chatReturnTab = nil
+        selectedTab = destination
     }
 
     func removeProvider(_ provider: ProviderKind) {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
@@ -381,7 +381,7 @@ struct BuddyView: View {
                 }
                 .buttonStyle(BMOButtonStyle(isPrimary: false))
                 Button("Open Chat") {
-                    appState.selectedTab = .chat
+                    appState.openChat(from: .buddy)
                 }
                 .buttonStyle(BMOButtonStyle())
             }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
@@ -61,6 +61,14 @@ struct ChatView: View {
             .background(BMOTheme.backgroundPrimary)
             .navigationTitle("")
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        appState.leaveChat()
+                    } label: {
+                        Label(appState.chatReturnTab == nil ? "Home" : "Back", systemImage: "chevron.left")
+                            .foregroundColor(BMOTheme.textSecondary)
+                    }
+                }
                 ToolbarItem(placement: .principal) {
                     Text(store.activeBuddy?.displayName ?? "Buddy Chat")
                         .font(.headline)
@@ -108,7 +116,8 @@ struct ChatView: View {
             }
             Spacer()
             Button("Switch") {
-                appState.selectedTab = .buddy
+                appState.chatReturnTab = .buddy
+                appState.leaveChat()
             }
             .buttonStyle(BMOButtonStyle(isPrimary: false))
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
@@ -87,7 +87,7 @@ struct MissionControlView: View {
 
             HStack(spacing: 8) {
                 Button("Chat with \(store.activeBuddy?.displayName ?? "Buddy")") {
-                    appState.selectedTab = .chat
+                    appState.openChat(from: .missionControl)
                 }
                 .buttonStyle(BMOButtonStyle())
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/SettingsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/SettingsView.swift
@@ -20,12 +20,16 @@ struct SettingsView: View {
                     }
                     .listRowBackground(BMOTheme.backgroundCard)
 
-                    Button("Reconfigure Agent") {
+                    Button("Restart Onboarding") {
                         appState.resetOnboardingAndReturnToSetup()
                         dismiss()
                     }
                     .foregroundColor(BMOTheme.accent)
                     .listRowBackground(BMOTheme.backgroundCard)
+                    Text("Run the Buddy-first onboarding flow again without deleting your existing workspace data.")
+                        .font(.caption)
+                        .foregroundColor(BMOTheme.textSecondary)
+                        .listRowBackground(BMOTheme.backgroundCard)
                 }
 
                 Section("Chat Runtime") {

--- a/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
+++ b/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
@@ -101,6 +101,28 @@ final class AppStateRuntimeTests: XCTestCase {
         XCTAssertTrue(appState.routeHealthSummary.contains("Cloud chat is ready"))
     }
 
+    func testCompactTabOrderAvoidsMoreTabNavigationTrap() {
+        let appState = AppState(engine: FakeLocalLLMEngine())
+
+        XCTAssertEqual(appState.compactTabOrder, [.missionControl, .chat, .buddy, .settings])
+        XCTAssertLessThanOrEqual(appState.compactTabOrder.count, 4)
+    }
+
+    func testOpenChatStoresReturnSurfaceAndLeaveChatRestoresIt() {
+        let appState = AppState(engine: FakeLocalLLMEngine())
+        appState.selectedTab = .buddy
+
+        appState.openChat(from: .buddy)
+
+        XCTAssertEqual(appState.selectedTab, .chat)
+        XCTAssertEqual(appState.chatReturnTab, .buddy)
+
+        appState.leaveChat()
+
+        XCTAssertEqual(appState.selectedTab, .buddy)
+        XCTAssertNil(appState.chatReturnTab)
+    }
+
     func testCloudSystemPromptDoesNotConfineAgentToAppOnly() {
         var config = StackConfig.default
         config.stackName = "BeMoreAgent"


### PR DESCRIPTION
## Summary
- fix the iOS chat trap by giving chat an app-owned return path and keeping the iPhone shell under the More-tab limit
- add a Buddy-first first-run onboarding flow that persists Buddy name, focus, and power mode
- simplify the Mac shell into a clear sidebar structure with stable Home, Chat, Workspace, Results, and Settings paths

## Task contract
- Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem
The current Buddy-first correction still leaves two severe usability failures in production use. On iPhone, users can enter chat and lose a visible exit path, which makes the app feel trapped and unsafe. On Mac, first-time users are dropped into a cluttered shell without a clear starting point, stable home surface, or onboarding sequence that establishes Buddy first.

## Smallest useful wedge
Fix the navigation model instead of layering more controls on top. Keep the iPhone shell to four primary tabs so iOS never creates a `More` trap, store the caller when opening chat so the app can always restore a visible return path, add a Buddy-first onboarding flow that persists completion and lands on home, and present the Mac variant with a simpler split-view shell organized around Home, Chat, Workspace, Results, and Settings.

## Verification plan
- run `xcodebuild -project apps/openclaw-shell-ios/BeMoreAgent.xcodeproj -scheme BeMoreAgent -destination 'platform=iOS Simulator,id=6DC22C61-5B40-4C1B-914A-A715CACC8270' -derivedDataPath apps/openclaw-shell-ios/.build/DerivedData build`
- run `xcodebuild test -project apps/openclaw-shell-ios/BeMoreAgent.xcodeproj -scheme BeMoreAgent -destination 'platform=iOS Simulator,id=6DC22C61-5B40-4C1B-914A-A715CACC8270' -derivedDataPath apps/openclaw-shell-ios/.build/DerivedData`
- run `xcodebuild -project apps/openclaw-shell-ios/BeMoreAgent.xcodeproj -scheme BeMoreAgent -destination 'platform=macOS,id=00008103-000514C826A3001E' CODE_SIGNING_ALLOWED=NO -derivedDataPath apps/openclaw-shell-ios/.build/DerivedData build`
- smoke fresh launch into onboarding, confirm post-onboarding home is stable, open chat, use the visible back/home control, and confirm return without killing the app

## Rollback plan
Revert this PR to restore the previous shell and onboarding behavior. No migrations are destructive, and the new onboarding persistence fields can be safely ignored by older builds if a rollback is needed.

## Verification
- [x] Local verification completed
- [x] CI verification completed or expected checks identified

## Rollback
- [x] Revert PR is sufficient
- [x] Any manual rollback steps are described below

## Notes
- Local simulator smoke confirmed first launch lands in onboarding, the installed iPhone shell shows four tabs, chat exposes a visible back/home affordance, and tapping it returns to Buddy Home.
- The Mac destination compiles locally with `CODE_SIGNING_ALLOWED=NO`; local launch is still subject to Apple signing/runtime constraints for the designed-for-iPhone variant.
