### PR TITLE
feat: add Buddy capability runtime contracts

### DIFF
--- a/config/contracts/app-package.schema.json
+++ b/config/contracts/app-package.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "App Package",
+  "type": "object",
+  "required": ["kind", "apiVersion", "id", "version", "metadata", "capability", "permissions", "inputs", "outputs", "artifactTypes", "eventTypes", "uiHooks", "install", "runtimeBindingRules"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": { "const": "app-package" },
+    "apiVersion": { "const": "buddy.prismtek/v1" },
+    "id": { "type": "string" },
+    "version": { "type": "string" },
+    "metadata": { "type": "object" },
+    "capability": {
+      "type": "object",
+      "required": ["skills"],
+      "properties": {
+        "skills": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "permissions": { "type": "object" },
+    "inputs": { "type": "object" },
+    "outputs": { "type": "object" },
+    "artifactTypes": { "type": "array", "items": { "type": "string" } },
+    "eventTypes": { "type": "array", "items": { "type": "string" } },
+    "uiHooks": { "type": "object" },
+    "install": { "type": "object" },
+    "runtimeBindingRules": {
+      "type": "object",
+      "required": ["memoryPolicy", "routingPolicy"],
+      "properties": {
+        "memoryPolicy": { "const": "shared-runtime-only" },
+        "routingPolicy": { "const": "shared-runtime-only" }
+      }
+    }
+  }
+}

--- a/config/contracts/buddy-binding.schema.json
+++ b/config/contracts/buddy-binding.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Buddy Binding",
+  "type": "object",
+  "required": ["kind", "apiVersion", "id", "version", "metadata", "binding", "persona", "permissions", "ui", "runtimeRules"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": { "const": "buddy-binding" },
+    "apiVersion": { "const": "buddy.prismtek/v1" },
+    "id": { "type": "string" },
+    "version": { "type": "string" },
+    "metadata": { "type": "object" },
+    "binding": { "type": "object" },
+    "persona": { "type": "object" },
+    "permissions": { "type": "object" },
+    "ui": { "type": "object" },
+    "config": { "type": "object" },
+    "runtimeRules": {
+      "type": "object",
+      "required": ["planner", "policyNamespace", "routeNamespace"],
+      "properties": {
+        "planner": { "const": "shared-buddy-runtime" },
+        "policyNamespace": { "const": "shared/global" },
+        "routeNamespace": { "const": "shared/global" }
+      }
+    }
+  }
+}

--- a/config/contracts/installed-package.schema.json
+++ b/config/contracts/installed-package.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Installed Package",
+  "type": "object",
+  "required": ["kind", "id", "packageId", "packageVersion", "bindingId", "scope", "status", "config"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": { "const": "installed-package" },
+    "id": { "type": "string" },
+    "packageId": { "type": "string" },
+    "packageVersion": { "type": "string" },
+    "bindingId": { "type": "string" },
+    "scope": { "enum": ["user", "workspace", "project", "repo"] },
+    "status": { "enum": ["installed", "disabled", "error"] },
+    "config": { "type": "object" }
+  }
+}

--- a/config/contracts/skill-package.schema.json
+++ b/config/contracts/skill-package.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Skill Package",
+  "type": "object",
+  "required": ["kind", "apiVersion", "id", "version", "metadata", "permissions", "inputs", "outputs", "artifactTypes", "eventTypes", "uiHooks", "install", "runtimeBindingRules"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": { "const": "skill-package" },
+    "apiVersion": { "const": "buddy.prismtek/v1" },
+    "id": { "type": "string" },
+    "version": { "type": "string" },
+    "metadata": { "type": "object" },
+    "permissions": { "type": "object" },
+    "inputs": { "type": "object" },
+    "outputs": { "type": "object" },
+    "artifactTypes": { "type": "array", "items": { "type": "string" } },
+    "eventTypes": { "type": "array", "items": { "type": "string" } },
+    "uiHooks": { "type": "object" },
+    "install": { "type": "object" },
+    "runtimeBindingRules": {
+      "type": "object",
+      "required": ["memoryPolicy", "routingPolicy"],
+      "properties": {
+        "memoryPolicy": { "const": "shared-runtime-only" },
+        "routingPolicy": { "const": "shared-runtime-only" }
+      }
+    }
+  }
+}

--- a/docs/CAPABILITY_MODEL.md
+++ b/docs/CAPABILITY_MODEL.md
@@ -1,0 +1,58 @@
+# Buddy Capability Model
+
+## Core rule
+
+- skills/apps define capability
+- Buddy Runtime provides intelligence
+- no skill/app gets its own routing, memory, policy, or hidden runtime identity
+
+## Runtime-owned objects
+
+### Skill Package
+
+A bounded capability contract executed through the shared Buddy Runtime.
+
+### App Package
+
+A user-facing workflow surface that bundles one or more skills behind a product concept.
+
+### Buddy Binding
+
+A runtime contract that assigns a Buddy identity to a skill/app.
+
+### Installed Package
+
+A persisted instance record created after installation.
+
+## Ownership split
+
+### `bmo-stack`
+
+Owns:
+
+- canonical capability schemas
+- package execution rules
+- tool permission model
+- runtime binding rules
+- package validation
+- artifact and event taxonomy
+- shared routing, policy, and memory ownership
+
+### `prismtek-apps`
+
+Owns:
+
+- Buddy Workshop product surfaces
+- install/config UI
+- app cards and app shells
+- installed skills/apps lists
+- artifact rendering and receipts views
+- product adapters that call the shared Buddy Runtime
+
+## Hard constraints
+
+- no daemon sprawl
+- no hidden services
+- no per-app mini brains
+- no ownership confusion
+- generated skills/apps must land in real repos, not donor-only or local-only runtime code

--- a/scripts/validate-capability-contracts.mjs
+++ b/scripts/validate-capability-contracts.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const requiredFiles = [
+  'docs/CAPABILITY_MODEL.md',
+  'config/contracts/skill-package.schema.json',
+  'config/contracts/app-package.schema.json',
+  'config/contracts/buddy-binding.schema.json',
+  'config/contracts/installed-package.schema.json',
+];
+
+const requiredKinds = {
+  'config/contracts/skill-package.schema.json': 'skill-package',
+  'config/contracts/app-package.schema.json': 'app-package',
+  'config/contracts/buddy-binding.schema.json': 'buddy-binding',
+  'config/contracts/installed-package.schema.json': 'installed-package',
+};
+
+for (const file of requiredFiles) {
+  const fullPath = resolve(process.cwd(), file);
+  if (!existsSync(fullPath)) {
+    console.error(`Missing required capability contract file: ${file}`);
+    process.exit(1);
+  }
+}
+
+for (const [file, expectedKind] of Object.entries(requiredKinds)) {
+  const fullPath = resolve(process.cwd(), file);
+  const parsed = JSON.parse(readFileSync(fullPath, 'utf8'));
+  if (parsed.type !== 'object') {
+    console.error(`${file} must declare type=object`);
+    process.exit(1);
+  }
+  if (!parsed.properties || parsed.properties.kind?.const !== expectedKind) {
+    console.error(`${file} must lock kind.const=${expectedKind}`);
+    process.exit(1);
+  }
+}
+
+console.log('Capability contracts validated.');


### PR DESCRIPTION
## Why
This starts the runtime-owned side of the Buddy capability model so skills/apps stay bounded capabilities and Buddies operate them through one shared runtime.

## What this changes
- adds `docs/CAPABILITY_MODEL.md`
- adds canonical schema files for `skill-package`, `app-package`, `buddy-binding`, and `installed-package`
- adds `scripts/validate-capability-contracts.mjs` so the contract has a concrete runtime validation entrypoint

## Boundary
- runtime schemas, execution rules, policy, routing, and memory stay in `bmo-stack`
- product surfaces, config UI, app cards, and package browsing stay in `prismtek-apps`

## Follow-up
The next pass should wire the validator into CI and connect these manifests to real skill/app registry flows.
