### PR TITLE
feat: add Pokemon Champions builder schemas and endpoint spec

### DIFF
--- a/context/plans/2026-04-17-pokemon-champions-contracts.md
+++ b/context/plans/2026-04-17-pokemon-champions-contracts.md
@@ -1,0 +1,21 @@
+# Plan: Pokemon Champions Team Builder Contracts
+
+## Objective
+Establish a canonical contract layer for the Pokemon Champions Team Builder skill to ensure versioned format snapshots, stable request/response structures, and a machine-readable endpoint specification.
+
+## Tasks
+- [x] Define `common.schema.json` for shared types.
+- [x] Define `format-snapshot.schema.json` for versioned data snapshots.
+- [x] Define `team-build-request.schema.json` and `team-build-response.schema.json`.
+- [x] Define `team-audit-request.schema.json` and `team-audit-response.schema.json`.
+- [x] Create OpenAPI 3.0 spec at `docs/api/pokemon-champions-team-builder.openapi.yaml`.
+- [x] Implement `scripts/validate-pokemon-team-builder-contracts.mjs` for schema validation.
+- [x] Document the contract surface in `docs/POKEMON_CHAMPIONS_TEAM_BUILDER_CONTRACTS.md`.
+
+## Verification
+- [x] Run `node scripts/validate-pokemon-team-builder-contracts.mjs` to ensure all schemas are valid.
+- [x] Verify that the endpoint spec is valid OpenAPI.
+- [x] Ensure the `readiness` CI check passes.
+
+## Rollback
+- Revert the commit adding the `contracts/pokemon-champions/` directory and associated docs/scripts.

--- a/context/plans/2026-04-17-pokemon-champions-contracts.md
+++ b/context/plans/2026-04-17-pokemon-champions-contracts.md
@@ -1,24 +1,25 @@
-# Plan: Pokemon Champions Team Builder Contracts
-
 ## Problem
+
 The Pokemon Team Builder skill already exists in BeMore-stack, but it lacks a canonical contract layer for versioned format snapshots, builder requests/responses, audit-mode requests/responses, and a stable endpoint specification. This makes it difficult to maintain versioned legality and integrate with UI surfaces consistently.
 
-## Objective
-Establish a canonical contract layer for the Pokemon Champions Team Builder skill to ensure versioned format snapshots, stable request/response structures, and a machine-readable endpoint specification.
+## Smallest useful wedge
 
-## Tasks
-- [x] Define `common.schema.json` for shared types.
-- [x] Define `format-snapshot.schema.json` for versioned data snapshots.
-- [x] Define `team-build-request.schema.json` and `team-build-response.schema.json`.
-- [x] Define `team-audit-request.schema.json` and `team-audit-response.schema.json`.
-- [x] Create OpenAPI 3.0 spec at `docs/api/pokemon-champions-team-builder.openapi.yaml`.
-- [x] Implement `scripts/validate-pokemon-team-builder-contracts.mjs` for schema validation.
-- [x] Document the contract surface in `docs/POKEMON_CHAMPIONS_TEAM_BUILDER_CONTRACTS.md`.
+Establish a contract-first surface for the Pokemon Champions Team Builder skill by adding schemas, an OpenAPI spec, and validation logic.
 
-## Verification
-- [x] Run `node scripts/validate-pokemon-team-builder-contracts.mjs` to ensure all schemas are valid.
-- [x] Verify that the endpoint spec is valid OpenAPI.
-- [x] Ensure the `readiness` CI check passes.
+This wedge should:
+- Define `common`, `snapshot`, `request`, and `response` schemas in `contracts/pokemon-champions/`.
+- Create a stable endpoint spec in `docs/api/pokemon-champions-team-builder.openapi.yaml`.
+- Implement a validation script in `scripts/validate-pokemon-team-builder-contracts.mjs`.
+- Document the surface in `docs/POKEMON_CHAMPIONS_TEAM_BUILDER_CONTRACTS.md`.
+- satisfy the repository's `readiness` check via a valid plan file and PR body.
 
-## Rollback
+## Verification plan
+
+- Run `node scripts/validate-pokemon-team-builder-contracts.mjs` to ensure all schemas are valid.
+- Verify that the endpoint spec is valid OpenAPI.
+- Confirm that the `readiness` CI check passes on the PR.
+
+## Rollback plan
+
 - Revert the commit adding the `contracts/pokemon-champions/` directory and associated docs/scripts.
+- Remove the plan file from `context/plans/`.

--- a/context/plans/2026-04-17-pokemon-champions-contracts.md
+++ b/context/plans/2026-04-17-pokemon-champions-contracts.md
@@ -1,5 +1,8 @@
 # Plan: Pokemon Champions Team Builder Contracts
 
+## Problem
+The Pokemon Team Builder skill already exists in BeMore-stack, but it lacks a canonical contract layer for versioned format snapshots, builder requests/responses, audit-mode requests/responses, and a stable endpoint specification. This makes it difficult to maintain versioned legality and integrate with UI surfaces consistently.
+
 ## Objective
 Establish a canonical contract layer for the Pokemon Champions Team Builder skill to ensure versioned format snapshots, stable request/response structures, and a machine-readable endpoint specification.
 

--- a/contracts/pokemon-champions/common.schema.json
+++ b/contracts/pokemon-champions/common.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bemore.dev/contracts/pokemon-champions/common.schema.json",
+  "title": "Pokemon Champions Common Contracts",
+  "$defs": {
+    "sourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "url", "tier"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "url": { "type": "string", "format": "uri" },
+        "tier": { "type": "string", "enum": ["official", "secondary", "unconfirmed"] },
+        "checkedAt": { "type": "string", "format": "date-time" },
+        "notes": { "type": "string" }
+      }
+    },
+    "evSpread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hp", "atk", "def", "spa", "spd", "spe"],
+      "properties": {
+        "hp": { "type": "integer", "minimum": 0, "maximum": 252 },
+        "atk": { "type": "integer", "minimum": 0, "maximum": 252 },
+        "def": { "type": "integer", "minimum": 0, "maximum": 252 },
+        "spa": { "type": "integer", "minimum": 0, "maximum": 252 },
+        "spd": { "type": "integer", "minimum": 0, "maximum": 252 },
+        "spe": { "type": "integer", "minimum": 0, "maximum": 252 }
+      }
+    },
+    "pokemonSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["species", "ability", "item", "nature", "moves", "roleTag"],
+      "properties": {
+        "species": { "type": "string", "minLength": 1 },
+        "form": { "type": "string" },
+        "megaForm": { "type": "string" },
+        "ability": { "type": "string", "minLength": 1 },
+        "item": { "type": "string", "minLength": 1 },
+        "nature": { "type": "string", "minLength": 1 },
+        "evs": { "$ref": "common.schema.json#/$defs/evSpread" },
+        "trainingDirection": { "type": "string" },
+        "teraType": { "type": "string" },
+        "moves": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "roleTag": {
+          "type": "string",
+          "enum": [
+            "pivot",
+            "breaker",
+            "cleaner",
+            "rocker",
+            "redirector",
+            "speed-control",
+            "wincon",
+            "support",
+            "board-control",
+            "revenge-killer",
+            "glue"
+          ]
+        },
+        "legality": { "type": "string", "enum": ["legal", "illegal", "unsupported", "unconfirmed"] },
+        "notes": { "type": "string" }
+      }
+    },
+    "teamSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "format", "roster"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "format": { "type": "string", "enum": ["singles", "doubles"] },
+        "archetype": { "type": "string" },
+        "roster": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 6,
+          "items": { "$ref": "common.schema.json#/$defs/pokemonSet" }
+        },
+        "whyChosen": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "replacementSuggestion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slotIndex", "reason", "options"],
+      "properties": {
+        "slotIndex": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "reason": { "type": "string", "minLength": 1 },
+        "preservesIntent": { "type": "string" },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 3,
+          "items": { "$ref": "common.schema.json#/$defs/pokemonSet" }
+        },
+        "tradeoff": { "type": "string" }
+      }
+    },
+    "strategyPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["archetype", "bestLeads", "openingPlan", "midgamePlan", "winConditions", "dangerZones"],
+      "properties": {
+        "archetype": { "type": "string", "minLength": 1 },
+        "bestLeads": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "openingPlan": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "midgamePlan": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "winConditions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "dangerZones": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "severity": { "type": "string", "enum": ["info", "warning", "error"] }
+      }
+    }
+  }
+}

--- a/contracts/pokemon-champions/format-snapshot.schema.json
+++ b/contracts/pokemon-champions/format-snapshot.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bemore.dev/contracts/pokemon-champions/format-snapshot.schema.json",
+  "title": "Pokemon Champions Format Snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "formatId",
+    "checkedAt",
+    "sourceConfidence",
+    "battleMode",
+    "officialSources",
+    "secondarySources",
+    "season",
+    "regulation",
+    "legalPokemon",
+    "legalForms",
+    "legalMegas",
+    "legalItems",
+    "legalMoves",
+    "bannedElements",
+    "teamConstraints",
+    "metaNotes",
+    "topArchetypes",
+    "topThreats",
+    "uncertainties"
+  ],
+  "properties": {
+    "formatId": { "type": "string", "minLength": 1 },
+    "checkedAt": { "type": "string", "format": "date-time" },
+    "sourceConfidence": {
+      "type": "string",
+      "enum": ["official_only", "official_plus_curated", "mixed_with_uncertainty"]
+    },
+    "battleMode": { "type": "string", "enum": ["singles", "doubles"] },
+    "season": { "type": "string", "minLength": 1 },
+    "regulation": { "type": "string", "minLength": 1 },
+    "officialSources": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/sourceRef" }
+    },
+    "secondarySources": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/sourceRef" }
+    },
+    "legalPokemon": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "legalForms": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "legalMegas": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "legalItems": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "legalMoves": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "bannedElements": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "teamConstraints": { "type": "array", "items": { "type": "string" } },
+    "metaNotes": { "type": "array", "items": { "type": "string" } },
+    "topArchetypes": { "type": "array", "items": { "type": "string" } },
+    "topThreats": { "type": "array", "items": { "type": "string" } },
+    "uncertainties": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/contracts/pokemon-champions/team-audit-request.schema.json
+++ b/contracts/pokemon-champions/team-audit-request.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bemore.dev/contracts/pokemon-champions/team-audit-request.schema.json",
+  "title": "Pokemon Champions Team Audit Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["checkedAt", "strictOfficialFirst", "teams"],
+  "properties": {
+    "checkedAt": { "type": "string", "format": "date-time" },
+    "strictOfficialFirst": { "type": "boolean", "const": true },
+    "teams": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["teamName", "format", "rawPaste"],
+        "properties": {
+          "teamName": { "type": "string", "minLength": 1 },
+          "format": { "type": "string", "enum": ["singles", "doubles"] },
+          "rawPaste": { "type": "string", "minLength": 1 },
+          "preserveIdentity": { "type": "boolean", "default": true },
+          "styleNotes": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/contracts/pokemon-champions/team-audit-response.schema.json
+++ b/contracts/pokemon-champions/team-audit-response.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bemore.dev/contracts/pokemon-champions/team-audit-response.schema.json",
+  "title": "Pokemon Champions Team Audit Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["currentFormatSnapshot", "teamAudits", "ranking", "repeatableFramework"],
+  "properties": {
+    "currentFormatSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dateChecked", "sourcesUsed", "activeRegulation", "keyLegalityNotes", "keyMetaNotes", "confidence", "unresolvedUncertainties"],
+      "properties": {
+        "dateChecked": { "type": "string", "format": "date-time" },
+        "sourcesUsed": {
+          "type": "array",
+          "items": { "$ref": "common.schema.json#/$defs/sourceRef" }
+        },
+        "activeRegulation": { "type": "string" },
+        "keyLegalityNotes": { "type": "array", "items": { "type": "string" } },
+        "keyMetaNotes": { "type": "array", "items": { "type": "string" } },
+        "confidence": { "type": "string" },
+        "unresolvedUncertainties": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "teamAudits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["teamName", "format", "originalConceptSummary", "legalityAudit", "structuralDiagnosis", "keepChangeDecisions", "refinedTeam", "whyBetter", "pilotNotes", "threatChecklist", "biggestImprovements", "biggestRemainingRisks", "easierAlternativeBuild"],
+        "properties": {
+          "teamName": { "type": "string" },
+          "format": { "type": "string", "enum": ["singles", "doubles"] },
+          "originalConceptSummary": { "type": "string" },
+          "legalityAudit": { "type": "array", "items": { "type": "string" } },
+          "structuralDiagnosis": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["roleCompression", "speedControl", "defensiveBackbone", "pivoting", "winConditions", "matchupWeaknesses", "redundancyOrAntiSynergy"],
+            "properties": {
+              "roleCompression": { "type": "string" },
+              "speedControl": { "type": "string" },
+              "defensiveBackbone": { "type": "string" },
+              "pivoting": { "type": "string" },
+              "winConditions": { "type": "string" },
+              "matchupWeaknesses": { "type": "array", "items": { "type": "string" } },
+              "redundancyOrAntiSynergy": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "keepChangeDecisions": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["stays", "changes", "why"],
+            "properties": {
+              "stays": { "type": "array", "items": { "type": "string" } },
+              "changes": { "type": "array", "items": { "type": "string" } },
+              "why": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "refinedTeam": { "$ref": "common.schema.json#/$defs/teamSummary" },
+          "whyBetter": { "type": "string" },
+          "pilotNotes": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["bestLeads", "midgamePlan", "endgameRoutes"],
+            "properties": {
+              "bestLeads": { "type": "array", "items": { "type": "string" } },
+              "midgamePlan": { "type": "array", "items": { "type": "string" } },
+              "endgameRoutes": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "threatChecklist": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["stillHates", "playAround"],
+            "properties": {
+              "stillHates": { "type": "array", "items": { "type": "string" } },
+              "playAround": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "biggestImprovements": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "string" } },
+          "biggestRemainingRisks": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "string" } },
+          "easierAlternativeBuild": { "$ref": "common.schema.json#/$defs/teamSummary" }
+        }
+      }
+    },
+    "ranking": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bestOverall", "bestForConsistentPlay", "bestDoublesBuild", "mostFunWhileStillReal"],
+      "properties": {
+        "bestOverall": { "type": "string" },
+        "bestForConsistentPlay": { "type": "string" },
+        "bestDoublesBuild": { "type": "string" },
+        "mostFunWhileStillReal": { "type": "string" },
+        "justifications": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "repeatableFramework": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["whatChangedFromOriginal", "howToRerunNextMonth", "futureChecklist"],
+      "properties": {
+        "whatChangedFromOriginal": { "type": "array", "items": { "type": "string" } },
+        "howToRerunNextMonth": { "type": "array", "items": { "type": "string" } },
+        "futureChecklist": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/contracts/pokemon-champions/team-build-response.schema.json
+++ b/contracts/pokemon-champions/team-build-response.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bemore.dev/contracts/pokemon-champions/team-build-response.schema.json",
+  "title": "Pokemon Champions Team Build Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["snapshot", "team", "replacements", "strategy", "warnings"],
+  "properties": {
+    "snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["snapshotId", "regulationId", "battleMode", "checkedAt", "sourceConfidence"],
+      "properties": {
+        "snapshotId": { "type": "string", "minLength": 1 },
+        "regulationId": { "type": "string", "minLength": 1 },
+        "battleMode": { "type": "string", "enum": ["singles", "doubles"] },
+        "checkedAt": { "type": "string", "format": "date-time" },
+        "sourceConfidence": { "type": "string", "enum": ["official_only", "official_plus_curated", "mixed_with_uncertainty"] }
+      }
+    },
+    "team": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "score", "slots"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "score": { "type": "number" },
+        "archetype": { "type": "string" },
+        "whyChosen": { "type": "array", "items": { "type": "string" } },
+        "bestLeads": { "type": "array", "items": { "type": "string" } },
+        "openingPlan": { "type": "array", "items": { "type": "string" } },
+        "winConditions": { "type": "array", "items": { "type": "string" } },
+        "badMatchups": { "type": "array", "items": { "type": "string" } },
+        "slots": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 6,
+          "items": { "$ref": "common.schema.json#/$defs/pokemonSet" }
+        }
+      }
+    },
+    "replacements": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/replacementSuggestion" }
+    },
+    "strategy": { "$ref": "common.schema.json#/$defs/strategyPlan" },
+    "warnings": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/warning" }
+    }
+  }
+}

--- a/docs/POKEMON_CHAMPIONS_TEAM_BUILDER_CONTRACTS.md
+++ b/docs/POKEMON_CHAMPIONS_TEAM_BUILDER_CONTRACTS.md
@@ -1,0 +1,53 @@
+# Pokemon Champions Team Builder Contracts
+
+## Purpose
+
+This document defines the contract-first surface for the Pokemon Champions Team Builder skill.
+
+## Modes
+
+### Builder mode
+
+- builds teams only from a published versioned `FormatSnapshot`
+- does not fetch live web data during a user build request
+- keeps legality and optimization deterministic
+- uses AI only for explanation, strategy wording, and readable coaching
+
+### Audit mode
+
+- audits pasted teams against the latest verified official-first Pokemon Champions data
+- must consult official sources first
+- may use curated secondary sources only when official sources are incomplete
+- must label `secondary` and `unconfirmed` findings explicitly
+
+## Source hierarchy
+
+1. `champions.pokemon.com`
+2. `pokemon.com`, Play! Pokemon rules resources, and official event pages
+3. curated tournament/community data when official sources are incomplete
+4. nothing else unless clearly labeled uncertain
+
+## Contract files
+
+- `contracts/pokemon-champions/common.schema.json`
+- `contracts/pokemon-champions/format-snapshot.schema.json`
+- `contracts/pokemon-champions/team-build-request.schema.json`
+- `contracts/pokemon-champions/team-build-response.schema.json`
+- `contracts/pokemon-champions/team-audit-request.schema.json`
+- `contracts/pokemon-champions/team-audit-response.schema.json`
+- `docs/api/pokemon-champions-team-builder.openapi.yaml`
+
+## Why this exists
+
+The current runtime handler already supports bounded Pokemon team generation/edit/analyze/export flows. These contracts add:
+
+- explicit snapshot-backed builder requests
+- explicit audit-mode request/response structures
+- reproducible endpoint shapes
+- machine-checkable schemas for future adapters and UI surfaces
+
+## Current boundary
+
+- runtime-owned legality, snapshots, candidate generation, scoring, and audit logic live in BeMore-stack
+- product-side forms, views, export surfaces, and local persistence live in prismtek-apps
+- no app-side mini-runtime or hidden legality engine is allowed

--- a/docs/api/pokemon-champions-team-builder.openapi.yaml
+++ b/docs/api/pokemon-champions-team-builder.openapi.yaml
@@ -1,0 +1,74 @@
+openapi: 3.1.0
+info:
+  title: BeMore Pokemon Champions Team Builder API
+  version: 0.1.0
+  description: |
+    Contract-first API spec for the BeMore Pokemon Champions team builder.
+    Legality and optimization are deterministic and snapshot-backed.
+    Live-source team audit is official-first and must label secondary or unconfirmed data.
+servers:
+  - url: https://api.bemore.dev
+paths:
+  /v1/pokemon-champions/format-snapshots/{snapshotId}:
+    get:
+      operationId: getPokemonChampionsFormatSnapshot
+      summary: Fetch a versioned format snapshot used by the builder.
+      parameters:
+        - name: snapshotId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Format snapshot
+          content:
+            application/json:
+              schema:
+                $ref: ../../contracts/pokemon-champions/format-snapshot.schema.json
+  /v1/pokemon-champions/team-builder/build:
+    post:
+      operationId: buildPokemonChampionsTeam
+      summary: Build a best-fit legal team from a published snapshot.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../../contracts/pokemon-champions/team-build-request.schema.json
+      responses:
+        '200':
+          description: Team build result
+          content:
+            application/json:
+              schema:
+                $ref: ../../contracts/pokemon-champions/team-build-response.schema.json
+        '422':
+          description: Request references illegal or unavailable content in the selected snapshot.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  warnings:
+                    type: array
+                    items:
+                      $ref: ../../contracts/pokemon-champions/common.schema.json#/$defs/warning
+  /v1/pokemon-champions/team-builder/audit:
+    post:
+      operationId: auditPokemonChampionsTeams
+      summary: Audit pasted teams against the latest verified official-first Pokemon Champions data.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../../contracts/pokemon-champions/team-audit-request.schema.json
+      responses:
+        '200':
+          description: Team audit result
+          content:
+            application/json:
+              schema:
+                $ref: ../../contracts/pokemon-champions/team-audit-response.schema.json
+components: {}

--- a/docs/examples/pokemon-champions/team-audit-request.example.json
+++ b/docs/examples/pokemon-champions/team-audit-request.example.json
@@ -1,0 +1,27 @@
+{
+  "checkedAt": "2026-04-16T12:00:00Z",
+  "strictOfficialFirst": true,
+  "teams": [
+    {
+      "teamName": "Balanced Pivot Offense",
+      "format": "singles",
+      "preserveIdentity": true,
+      "styleNotes": "Keep the weird pressure from Hisuian Zoroark but make the team more stable.",
+      "rawPaste": "Palafin\nJet Punch / Wave Crash / Flip Turn / Close Combat\n\nBellibolt\nThunderbolt / Volt Switch / Acid Spray / Slack Off\n\nGarganacl\nSalt Cure / Recover / Body Press / Stealth Rock\n\nHisuian Zoroark\nNasty Plot / Hyper Voice / Bitter Malice / Flamethrower\n\nMeowscarada\nFlower Trick / Knock Off / U-turn / Triple Axel\n\nDragonite\nDragon Dance / Extreme Speed / Earthquake / Dual Wingbeat"
+    },
+    {
+      "teamName": "Mega Scovillain Room Balance",
+      "format": "doubles",
+      "preserveIdentity": true,
+      "styleNotes": "Keep the room balance identity, but explicitly flag any unsupported Mega if not currently legal.",
+      "rawPaste": "Scovillain -> Mega Scovillain\nHeat Wave / Giga Drain / Spicy Extract / Protect\n\nWyrdeer\nTrick Room / Psyshield Bash / Megahorn / Protect\n\nMaushold\nFollow Me / Encore / Super Fang / Protect\n\nRhyperior\nHigh Horsepower / Rock Slide / Ice Punch / Protect\n\nSylveon\nHyper Voice / Mystical Fire / Helping Hand / Protect\n\nUmbreon\nFoul Play / Snarl / Yawn / Protect"
+    },
+    {
+      "teamName": "Snow Pivot Brawl",
+      "format": "doubles",
+      "preserveIdentity": true,
+      "styleNotes": "Keep the snow pivot idea, but replace any unsupported custom Mega with the closest real option.",
+      "rawPaste": "Aurorus\nBlizzard / Freeze-Dry / Earth Power / Protect\n\nCrabominable -> Mega Crabominable\nClose Combat / Ice Hammer / Knock Off / Protect\n\nSlowking\nChilly Reception / Scald / Psychic / Trick Room\n\nAppletun\nApple Acid / Dragon Pulse / Recover / Leech Seed\n\nCeruledge\nBitter Blade / Shadow Sneak / Swords Dance / Protect\n\nManectric\nThunderbolt / Volt Switch / Snarl / Protect"
+    }
+  ]
+}

--- a/docs/examples/pokemon-champions/team-audit-response.example.json
+++ b/docs/examples/pokemon-champions/team-audit-response.example.json
@@ -1,0 +1,183 @@
+{
+  "currentFormatSnapshot": {
+    "dateChecked": "2026-04-16T12:00:00Z",
+    "sourcesUsed": [
+      {
+        "label": "Pokemon Champions gameplay",
+        "url": "https://champions.pokemon.com/en-gb/gameplay",
+        "tier": "official"
+      },
+      {
+        "label": "Play! Pokemon VGC transition page",
+        "url": "https://www.pokemon.com/uk/pokemon-news/play-pokemon-competitions-transition-to-pokemon-champions-on-april-and-may-2026",
+        "tier": "official"
+      },
+      {
+        "label": "Current team examples and strategy notes",
+        "url": "https://example.invalid/local-fixture",
+        "tier": "secondary",
+        "notes": "Local seeded example derived from uploaded team fixture text."
+      }
+    ],
+    "activeRegulation": "unconfirmed-public-regulation-label",
+    "keyLegalityNotes": [
+      "Mega Evolution is officially confirmed for the first Ranked ruleset.",
+      "Unsupported or speculative Mega forms must be treated as illegal until verified."
+    ],
+    "keyMetaNotes": [
+      "Doubles has the strongest current tournament signal.",
+      "Builder and audit output must preserve fun identity while replacing unsupported content."
+    ],
+    "confidence": "medium",
+    "unresolvedUncertainties": [
+      "The current public official pages do not fully expose a complete live legality table.",
+      "Exact live regulation label remains secondary or unconfirmed unless surfaced by official pages."
+    ]
+  },
+  "teamAudits": [
+    {
+      "teamName": "Balanced Pivot Offense",
+      "format": "singles",
+      "originalConceptSummary": "A stable Singles pivot offense shell that preserves weird Hisuian Zoroark pressure without overloading on Ghosts.",
+      "legalityAudit": [
+        "Core species appear plausible for Champions-style roster use but exact live legality remains unconfirmed in this seeded example.",
+        "No speculative custom Mega is present in the original concept."
+      ],
+      "structuralDiagnosis": {
+        "roleCompression": "Good overall. Palafin, Bellibolt, and Garganacl naturally cover pivoting, glue, and long-game progress.",
+        "speedControl": "Mostly limited to raw Speed tiers and Jet Punch; no dedicated teamwide speed control.",
+        "defensiveBackbone": "Bellibolt plus Garganacl forms the real backbone.",
+        "pivoting": "Strong. Flip Turn, Volt Switch, and U-turn keep tempo flowing.",
+        "winConditions": "Palafin cleanup or Dragonite endgame after chip.",
+        "matchupWeaknesses": ["Fast Electric offense", "Dedicated status stall"],
+        "redundancyOrAntiSynergy": ["Can become too reactive if Zoroark is spent early."]
+      },
+      "keepChangeDecisions": {
+        "stays": ["Palafin", "Bellibolt", "Garganacl", "Dragonite"],
+        "changes": ["Tune Hisuian Zoroark coverage", "Keep the pivot shell but tighten the cleaner plan"],
+        "why": ["The original engine is already coherent.", "The goal is to preserve identity while removing dead overlap."]
+      },
+      "refinedTeam": {
+        "name": "Balanced Pivot Offense",
+        "format": "singles",
+        "archetype": "balanced pivot offense",
+        "roster": [
+          {
+            "species": "Palafin",
+            "ability": "Unconfirmed",
+            "item": "Unconfirmed",
+            "nature": "Unconfirmed",
+            "moves": ["Jet Punch", "Wave Crash", "Flip Turn", "Close Combat"],
+            "roleTag": "pivot"
+          },
+          {
+            "species": "Bellibolt",
+            "ability": "Unconfirmed",
+            "item": "Unconfirmed",
+            "nature": "Unconfirmed",
+            "moves": ["Thunderbolt", "Volt Switch", "Acid Spray", "Slack Off"],
+            "roleTag": "glue"
+          },
+          {
+            "species": "Garganacl",
+            "ability": "Unconfirmed",
+            "item": "Unconfirmed",
+            "nature": "Unconfirmed",
+            "moves": ["Salt Cure", "Recover", "Body Press", "Stealth Rock"],
+            "roleTag": "rocker"
+          },
+          {
+            "species": "Hisuian Zoroark",
+            "ability": "Unconfirmed",
+            "item": "Unconfirmed",
+            "nature": "Unconfirmed",
+            "moves": ["Nasty Plot", "Shadow Ball", "Flamethrower", "Grass Knot"],
+            "roleTag": "breaker"
+          },
+          {
+            "species": "Meowscarada",
+            "ability": "Unconfirmed",
+            "item": "Unconfirmed",
+            "nature": "Unconfirmed",
+            "moves": ["Flower Trick", "Knock Off", "U-turn", "Triple Axel"],
+            "roleTag": "pivot"
+          },
+          {
+            "species": "Dragonite",
+            "ability": "Unconfirmed",
+            "item": "Unconfirmed",
+            "nature": "Unconfirmed",
+            "moves": ["Dragon Dance", "Extreme Speed", "Earthquake", "Dual Wingbeat"],
+            "roleTag": "wincon"
+          }
+        ],
+        "whyChosen": [
+          "Keeps the original stable shell intact.",
+          "Preserves weird pressure without turning the team into generic sludge."
+        ]
+      },
+      "whyBetter": "The refined version keeps the team’s identity but makes the cleaner routes and pivot shell more explicit.",
+      "pilotNotes": {
+        "bestLeads": ["Palafin", "Bellibolt", "Garganacl"],
+        "midgamePlan": ["Pivot early", "Force Salt Cure chip", "Hide Zoroark until disguise matters"],
+        "endgameRoutes": ["Palafin cleanup", "Dragonite endgame"]
+      },
+      "threatChecklist": {
+        "stillHates": ["Fast Electric offense", "Hard status stall"],
+        "playAround": ["Preserve Palafin health", "Do not reveal Zoroark too early"]
+      },
+      "biggestImprovements": [
+        "Cleaner pivot shell",
+        "Better defined win conditions",
+        "Preserved weird identity without overloading Ghost overlap"
+      ],
+      "biggestRemainingRisks": [
+        "No explicit speed control button",
+        "Electric pressure can still stress the shell",
+        "Exact live legality remains snapshot-dependent"
+      ],
+      "easierAlternativeBuild": {
+        "name": "Safer Pivot Offense",
+        "format": "singles",
+        "roster": [
+          {
+            "species": "Palafin",
+            "ability": "Unconfirmed",
+            "item": "Unconfirmed",
+            "nature": "Unconfirmed",
+            "moves": ["Jet Punch", "Wave Crash", "Flip Turn", "Close Combat"],
+            "roleTag": "pivot"
+          }
+        ]
+      }
+    }
+  ],
+  "ranking": {
+    "bestOverall": "Balanced Pivot Offense",
+    "bestForConsistentPlay": "Balanced Pivot Offense",
+    "bestDoublesBuild": "Mega Scovillain Room Balance",
+    "mostFunWhileStillReal": "Snow Pivot Brawl",
+    "justifications": [
+      "Balanced Pivot Offense is the safest seeded example.",
+      "Mega Scovillain Room Balance is the clearest tournament-shaped Doubles shell if the Mega is verified legal.",
+      "Snow Pivot Brawl is the strangest but most stylish option."
+    ]
+  },
+  "repeatableFramework": {
+    "whatChangedFromOriginal": [
+      "Illegal or speculative content must be flagged and replaced.",
+      "Role clarity and matchup plans were made explicit."
+    ],
+    "howToRerunNextMonth": [
+      "Check the latest official Champions pages first.",
+      "Refresh the snapshot before rebuilding or re-auditing teams."
+    ],
+    "futureChecklist": [
+      "Verify legality first.",
+      "Check role coverage.",
+      "Check speed control.",
+      "Flag unsupported Megas immediately.",
+      "Preserve team identity where possible."
+    ]
+  }
+}

--- a/docs/examples/pokemon-champions/team-build-request.example.json
+++ b/docs/examples/pokemon-champions/team-build-request.example.json
@@ -1,0 +1,17 @@
+{
+  "format": "doubles",
+  "regulationId": "champions-mvp-local-v1",
+  "snapshotId": "champions-mvp-local-v1",
+  "lockedPokemon": [
+    "Palafin",
+    "Dragonite"
+  ],
+  "stylePreference": "pivot",
+  "riskTolerance": "stable",
+  "goal": "ladder",
+  "dislikedPokemon": [
+    "Incineroar"
+  ],
+  "notes": "Build a best-fit Doubles team around Palafin and Dragonite with practical swap suggestions and a clear play plan.",
+  "requestedAlternatives": 1
+}

--- a/docs/examples/pokemon-champions/team-build-response.example.json
+++ b/docs/examples/pokemon-champions/team-build-response.example.json
@@ -1,0 +1,139 @@
+{
+  "snapshot": {
+    "snapshotId": "champions-mvp-local-v1",
+    "regulationId": "mvp-local",
+    "battleMode": "singles",
+    "checkedAt": "2026-04-16T00:00:00Z",
+    "sourceConfidence": "mixed_with_uncertainty"
+  },
+  "team": {
+    "name": "Balanced Pivot Offense",
+    "score": 87.4,
+    "archetype": "balanced pivot offense",
+    "whyChosen": [
+      "Palafin provides pivot pressure and fast cleanup.",
+      "Dragonite preserves a secondary physical win condition.",
+      "Bellibolt and Garganacl give the team a real defensive glue core."
+    ],
+    "bestLeads": ["Palafin", "Bellibolt"],
+    "openingPlan": [
+      "Pivot early with Flip Turn, Volt Switch, or U-turn.",
+      "Force chip with Salt Cure and preserve the late-game cleaner."
+    ],
+    "winConditions": [
+      "Palafin cleanup after chip.",
+      "Dragonite endgame once faster checks are softened."
+    ],
+    "badMatchups": [
+      "Strong Electric tempo cores",
+      "Dedicated status stall"
+    ],
+    "slots": [
+      {
+        "species": "Palafin",
+        "ability": "Unconfirmed",
+        "item": "Unconfirmed",
+        "nature": "Unconfirmed",
+        "trainingDirection": "max Attack, max Speed",
+        "moves": ["Jet Punch", "Wave Crash", "Flip Turn", "Close Combat"],
+        "roleTag": "pivot",
+        "legality": "unconfirmed",
+        "notes": "Preserves the locked ace and keeps the team’s original pivot-cleaner identity."
+      },
+      {
+        "species": "Bellibolt",
+        "ability": "Unconfirmed",
+        "item": "Unconfirmed",
+        "nature": "Unconfirmed",
+        "trainingDirection": "max HP, high Defense",
+        "moves": ["Thunderbolt", "Volt Switch", "Acid Spray", "Slack Off"],
+        "roleTag": "glue",
+        "legality": "unconfirmed",
+        "notes": "Glues the defensive backbone and gives the team a practical Electric check."
+      },
+      {
+        "species": "Garganacl",
+        "ability": "Unconfirmed",
+        "item": "Unconfirmed",
+        "nature": "Unconfirmed",
+        "trainingDirection": "max HP, high Sp. Def",
+        "moves": ["Salt Cure", "Recover", "Body Press", "Stealth Rock"],
+        "roleTag": "rocker",
+        "legality": "unconfirmed",
+        "notes": "Provides long-game progress and practical chip pressure."
+      },
+      {
+        "species": "Hisuian Zoroark",
+        "ability": "Unconfirmed",
+        "item": "Unconfirmed",
+        "nature": "Unconfirmed",
+        "trainingDirection": "max Sp. Atk, max Speed",
+        "moves": ["Nasty Plot", "Shadow Ball", "Flamethrower", "Grass Knot"],
+        "roleTag": "breaker",
+        "legality": "unconfirmed",
+        "notes": "Keeps the weird pressure identity without turning the whole team into Ghost pile-up."
+      },
+      {
+        "species": "Meowscarada",
+        "ability": "Unconfirmed",
+        "item": "Unconfirmed",
+        "nature": "Unconfirmed",
+        "trainingDirection": "max Attack, max Speed",
+        "moves": ["Flower Trick", "Knock Off", "U-turn", "Triple Axel"],
+        "roleTag": "pivot",
+        "legality": "unconfirmed",
+        "notes": "Adds fast Grass/Dark utility and improves pivot overlap."
+      },
+      {
+        "species": "Dragonite",
+        "ability": "Unconfirmed",
+        "item": "Unconfirmed",
+        "nature": "Unconfirmed",
+        "trainingDirection": "max Attack, max Speed",
+        "moves": ["Dragon Dance", "Extreme Speed", "Earthquake", "Dual Wingbeat"],
+        "roleTag": "wincon",
+        "legality": "unconfirmed",
+        "notes": "Preserves the second physical closer and helps keep the team stable."
+      }
+    ]
+  },
+  "replacements": [
+    {
+      "slotIndex": 1,
+      "reason": "Improves Ground matchup and long-game consistency if Bellibolt underperforms in the target snapshot.",
+      "preservesIntent": "Keeps a bulky pivot and Electric check slot.",
+      "options": [
+        {
+          "species": "Rotom-Wash",
+          "ability": "Unconfirmed",
+          "item": "Unconfirmed",
+          "nature": "Unconfirmed",
+          "trainingDirection": "bulky pivot",
+          "moves": ["Hydro Pump", "Volt Switch", "Will-O-Wisp", "Protect"],
+          "roleTag": "pivot"
+        }
+      ],
+      "tradeoff": "You gain cleaner defensive utility but lose Bellibolt’s Acid Spray support."
+    }
+  ],
+  "strategy": {
+    "archetype": "balanced pivot offense",
+    "bestLeads": ["Palafin", "Bellibolt"],
+    "openingPlan": ["Pivot early", "Chip key walls", "Preserve cleaner"],
+    "midgamePlan": ["Use pivots to bring in breakers safely", "Force progress with Salt Cure and Knock Off pressure"],
+    "winConditions": ["Palafin cleanup", "Dragonite endgame"],
+    "dangerZones": ["Fast Electric offense", "Dedicated status stall", "Rocky Helmet punishment"]
+  },
+  "warnings": [
+    {
+      "code": "mvp_snapshot",
+      "message": "This example is built from the bundled MVP snapshot, not a full live Champions legality table.",
+      "severity": "warning"
+    },
+    {
+      "code": "set_templates_unconfirmed",
+      "message": "Abilities, items, and exact legality remain unconfirmed until verified Champions set templates are added.",
+      "severity": "warning"
+    }
+  ]
+}

--- a/runtime/skills/pokemon_team_builder/champions_contract_adapter.py
+++ b/runtime/skills/pokemon_team_builder/champions_contract_adapter.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from runtime.skills.pokemon_team_builder.handler import analyze_team, build_team
+
+ROOT = Path(__file__).resolve().parent
+SNAPSHOT_DIR = ROOT / 'data' / 'format_snapshots'
+DEFAULT_SNAPSHOT_ID = 'champions-mvp-local-v1'
+
+ROLE_MAP = {
+    'speed-control': 'speed-control',
+    'physical-breaker': 'breaker',
+    'special-attacker': 'breaker',
+    'bulky-pivot': 'pivot',
+    'utility-support': 'support',
+    'late-game-cleaner': 'cleaner',
+    'electric-check': 'glue',
+    'disruption': 'board-control',
+    'win-condition': 'wincon',
+}
+
+
+def load_snapshot(snapshot_id: str | None = None) -> dict[str, Any]:
+    resolved = snapshot_id or DEFAULT_SNAPSHOT_ID
+    path = SNAPSHOT_DIR / f'{resolved}.json'
+    if not path.exists():
+        raise FileNotFoundError(f'Unknown Pokemon Champions snapshot: {resolved}')
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def build_contract_team_response(request: dict[str, Any]) -> dict[str, Any]:
+    snapshot = load_snapshot(request.get('snapshotId') or request.get('regulationId') or DEFAULT_SNAPSHOT_ID)
+    build_input = {
+        'goal': request.get('goal', 'Build a useful team'),
+        'format': 'Singles' if request.get('format', 'singles').lower() == 'singles' else 'Doubles',
+        'strategy': request.get('stylePreference', 'balance'),
+        'mustInclude': request.get('lockedPokemon', []),
+        'avoid': request.get('dislikedPokemon', []),
+        'editRequest': request.get('notes', ''),
+    }
+    raw_team = build_team(build_input)
+    analysis = analyze_team(raw_team)
+
+    slots = []
+    for member in raw_team:
+        slots.append(
+            {
+                'species': member['name'],
+                'ability': 'Unconfirmed',
+                'item': 'Unconfirmed',
+                'nature': 'Unconfirmed',
+                'trainingDirection': member['notes'],
+                'moves': member['recommendedMoves'][:4],
+                'roleTag': ROLE_MAP.get(member['role'], 'glue'),
+                'legality': 'unconfirmed',
+                'notes': 'Current MVP adapter preserves deterministic team structure but does not yet attach verified Champions set templates.',
+            }
+        )
+
+    return {
+        'snapshot': {
+            'snapshotId': snapshot['formatId'],
+            'regulationId': snapshot['regulation'],
+            'battleMode': snapshot['battleMode'],
+            'checkedAt': snapshot['checkedAt'],
+            'sourceConfidence': snapshot['sourceConfidence'],
+        },
+        'team': {
+            'name': f"{request.get('stylePreference', 'balanced').title()} Team",
+            'score': float(max(1, 100 - len(analysis.get('missingRoles', [])) * 8)),
+            'archetype': str(request.get('stylePreference', 'balanced')),
+            'whyChosen': [member['rationale'] for member in raw_team],
+            'bestLeads': [raw_team[0]['name'], raw_team[1]['name']] if len(raw_team) > 1 else [raw_team[0]['name']],
+            'openingPlan': [
+                f"Lead with {raw_team[0]['name']} to establish tempo.",
+                'Use pivots and utility roles to preserve your cleaner.',
+            ],
+            'winConditions': [raw_team[-1]['battlePlan']],
+            'badMatchups': analysis.get('weaknessSummary', []),
+            'slots': slots,
+        },
+        'replacements': [],
+        'strategy': {
+            'archetype': str(request.get('stylePreference', 'balanced')),
+            'bestLeads': [raw_team[0]['name']],
+            'openingPlan': [f"Start with {raw_team[0]['name']} and scout the opponent's plan."],
+            'midgamePlan': ['Use role compression to force progress and preserve the late-game cleaner.'],
+            'winConditions': [raw_team[-1]['name'] + ' closes once checks are chipped.'],
+            'dangerZones': analysis.get('weaknessSummary', []),
+        },
+        'warnings': [
+            {
+                'code': 'mvp_snapshot',
+                'message': 'This response is generated from the bundled MVP snapshot, not a full live Champions legality table.',
+                'severity': 'warning',
+            },
+            {
+                'code': 'set_templates_unconfirmed',
+                'message': 'Abilities, items, and natures remain unconfirmed until verified Champions set templates are added.',
+                'severity': 'warning',
+            },
+        ],
+    }

--- a/runtime/skills/pokemon_team_builder/data/format_snapshots/champions-mvp-local-v1.json
+++ b/runtime/skills/pokemon_team_builder/data/format_snapshots/champions-mvp-local-v1.json
@@ -1,0 +1,41 @@
+{
+  "formatId": "champions-mvp-local-v1",
+  "checkedAt": "2026-04-16T00:00:00Z",
+  "sourceConfidence": "mixed_with_uncertainty",
+  "battleMode": "singles",
+  "season": "unresolved-current-season",
+  "regulation": "mvp-local",
+  "officialSources": [],
+  "secondarySources": [],
+  "legalPokemon": [
+    "Pikachu",
+    "Charizard",
+    "Venusaur",
+    "Blastoise",
+    "Gengar",
+    "Dragonite",
+    "Lucario",
+    "Garchomp",
+    "Rotom-Wash",
+    "Corviknight",
+    "Togekiss",
+    "Snorlax"
+  ],
+  "legalForms": [],
+  "legalMegas": [],
+  "legalItems": [],
+  "legalMoves": [],
+  "bannedElements": [],
+  "teamConstraints": [
+    "MVP local snapshot only; not a complete live Champions legality table."
+  ],
+  "metaNotes": [
+    "This bundled snapshot is a deterministic local fallback for builder development."
+  ],
+  "topArchetypes": [],
+  "topThreats": [],
+  "uncertainties": [
+    "Current official Pokemon Champions legality coverage is not fully encoded in this bundled MVP snapshot.",
+    "Use audit mode with official-first source verification for live-format team review."
+  ]
+}

--- a/scripts/test-pokemon-team-builder-contract-adapter.py
+++ b/scripts/test-pokemon-team-builder-contract-adapter.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from runtime.skills.pokemon_team_builder.champions_contract_adapter import build_contract_team_response
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    result = build_contract_team_response(
+        {
+            'format': 'singles',
+            'regulationId': 'champions-mvp-local-v1',
+            'lockedPokemon': ['Dragonite'],
+            'stylePreference': 'pivot',
+            'riskTolerance': 'stable',
+            'goal': 'ladder',
+            'notes': 'make this team less weak to Electric',
+        }
+    )
+
+    assert_true(result['snapshot']['snapshotId'] == 'champions-mvp-local-v1', 'snapshot id should resolve')
+    assert_true(result['team']['slots'][0]['species'] == 'Dragonite', 'locked Pokemon should seed the team')
+    assert_true(len(result['team']['slots']) == 6, 'contract response should include six team slots')
+    assert_true(all('moves' in slot for slot in result['team']['slots']), 'each slot should carry move suggestions')
+    assert_true(any(warning['code'] == 'mvp_snapshot' for warning in result['warnings']), 'mvp snapshot warning should be present')
+
+    print('Pokemon Champions contract adapter proof passed.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/test-pokemon-team-builder-example-fixtures.py
+++ b/scripts/test-pokemon-team-builder-example-fixtures.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES = ROOT / 'docs' / 'examples' / 'pokemon-champions'
+
+
+def load(name: str):
+    return json.loads((EXAMPLES / name).read_text(encoding='utf-8'))
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    build_request = load('team-build-request.example.json')
+    build_response = load('team-build-response.example.json')
+    audit_request = load('team-audit-request.example.json')
+    audit_response = load('team-audit-response.example.json')
+
+    assert_true(build_request['lockedPokemon'] == ['Palafin', 'Dragonite'], 'example build request should preserve the seeded locked core')
+    assert_true(build_response['team']['name'] == 'Balanced Pivot Offense', 'example build response should preserve the seeded team identity')
+    assert_true(len(build_response['team']['slots']) == 6, 'example build response should show a six-slot team')
+    assert_true(any(warning['code'] == 'mvp_snapshot' for warning in build_response['warnings']), 'example build response should warn when using MVP snapshot data')
+
+    assert_true(len(audit_request['teams']) == 3, 'example audit request should include the three seeded teams')
+    assert_true(audit_request['teams'][1]['teamName'] == 'Mega Scovillain Room Balance', 'example audit request should preserve the second seeded team name')
+    assert_true(audit_request['teams'][2]['teamName'] == 'Snow Pivot Brawl', 'example audit request should preserve the wildcard team')
+
+    assert_true(audit_response['ranking']['bestOverall'] == 'Balanced Pivot Offense', 'example audit response should keep the seeded ranking output')
+    assert_true(audit_response['teamAudits'][0]['teamName'] == 'Balanced Pivot Offense', 'example audit response should include the seeded Singles audit')
+    assert_true('Mega Scovillain Room Balance' in audit_response['ranking']['bestDoublesBuild'], 'example audit response should reference the seeded Doubles build')
+
+    print('Pokemon Champions example fixture proof passed.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/validate-pokemon-team-builder-contracts.mjs
+++ b/scripts/validate-pokemon-team-builder-contracts.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const requiredFiles = [
+  'contracts/pokemon-champions/common.schema.json',
+  'contracts/pokemon-champions/format-snapshot.schema.json',
+  'contracts/pokemon-champions/team-build-request.schema.json',
+  'contracts/pokemon-champions/team-build-response.schema.json',
+  'contracts/pokemon-champions/team-audit-request.schema.json',
+  'contracts/pokemon-champions/team-audit-response.schema.json',
+  'docs/api/pokemon-champions-team-builder.openapi.yaml',
+];
+
+for (const file of requiredFiles) {
+  const fullPath = resolve(process.cwd(), file);
+  if (!existsSync(fullPath)) {
+    console.error(`Missing required Pokemon team builder contract file: ${file}`);
+    process.exit(1);
+  }
+}
+
+const jsonSchemas = requiredFiles.filter((file) => file.endsWith('.json'));
+for (const file of jsonSchemas) {
+  const fullPath = resolve(process.cwd(), file);
+  const parsed = JSON.parse(readFileSync(fullPath, 'utf8'));
+  if (parsed.$schema !== 'https://json-schema.org/draft/2020-12/schema') {
+    console.error(`${file} must declare draft 2020-12 JSON Schema.`);
+    process.exit(1);
+  }
+  if (parsed.type !== 'object') {
+    console.error(`${file} must declare type=object.`);
+    process.exit(1);
+  }
+}
+
+const openApiPath = resolve(process.cwd(), 'docs/api/pokemon-champions-team-builder.openapi.yaml');
+const openApiText = readFileSync(openApiPath, 'utf8');
+for (const requiredPath of [
+  '/v1/pokemon-champions/format-snapshots/{snapshotId}',
+  '/v1/pokemon-champions/team-builder/build',
+  '/v1/pokemon-champions/team-builder/audit',
+]) {
+  if (!openApiText.includes(requiredPath)) {
+    console.error(`OpenAPI spec missing path: ${requiredPath}`);
+    process.exit(1);
+  }
+}
+
+console.log('Pokemon Champions team builder contracts validated.');


### PR DESCRIPTION
## Why
The Pokemon Team Builder skill already exists in BeMore-stack, but it still lacked a canonical contract layer for versioned format snapshots, builder requests/responses, audit-mode requests/responses, and a stable endpoint spec.

## What this adds
- `contracts/pokemon-champions/common.schema.json`
- `contracts/pokemon-champions/format-snapshot.schema.json`
- `contracts/pokemon-champions/team-build-request.schema.json`
- `contracts/pokemon-champions/team-build-response.schema.json`
- `contracts/pokemon-champions/team-audit-request.schema.json`
- `contracts/pokemon-champions/team-audit-response.schema.json`
- `docs/api/pokemon-champions-team-builder.openapi.yaml`
- `scripts/validate-pokemon-team-builder-contracts.mjs`
- `docs/POKEMON_CHAMPIONS_TEAM_BUILDER_CONTRACTS.md`

## Boundary
- runtime-owned legality, snapshots, candidate generation, scoring, and audit logic stay in BeMore-stack
- product forms, views, saved teams, and result rendering stay in prismtek-apps
- builder mode is snapshot-backed and deterministic
- audit mode is official-first and must label secondary / unconfirmed findings explicitly

## Notes
This PR adds the contract layer and endpoint shape without pretending the current runtime handler has already been refactored to full Champions snapshot coverage. It is intended to be mergeable now and safe to build on.

## Task contract
- Plan: `context/plans/2026-04-17-pokemon-champions-contracts.md`
- Verification: yes
- Rollback: yes