### PR TITLE
Add Hermes Pokemon Champions skill packs and JSON schema mode

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -73,6 +73,12 @@ It is meant to make a focused workflow easier to execute correctly.
   - read arbitrary user-provided links/files/media with best-effort fallbacks (web fetch, browser relay, yt-dlp, ffmpeg keyframes), then return actionable summaries and blockers
 - `video-review/`
   - review and summarize online videos (especially YouTube) by extracting transcript + keyframes with local tools
+- `pokemon-champions-team-lab/`
+  - Hermes-ready live format team audit and legality-checking pack for Pokémon Champions
+- `pokemon-champions-builder-architect/`
+  - Hermes-ready deterministic builder/product architecture pack for Champions team-builder systems
+- `pokemon-champions-builder-generator/`
+  - Hermes-ready deliverables pack for PRDs, API specs, SwiftUI architecture, and JSON-schema-only contracts
 
 ## Suggested skill format
 

--- a/skills/index.json
+++ b/skills/index.json
@@ -215,6 +215,54 @@
         "turn this into a proper prompt"
       ],
       "default_action": "dispatch"
+    },
+    "pokemon-champions-team-lab": {
+      "actions": [
+        "audit",
+        "build",
+        "spec"
+      ],
+      "triggers": [
+        "pokemon champions team audit",
+        "champions legality check",
+        "legal check this team",
+        "best-fit champions build",
+        "pokemon champions team lab"
+      ],
+      "default_action": "audit"
+    },
+    "pokemon-champions-builder-architect": {
+      "actions": [
+        "prd",
+        "architecture",
+        "api",
+        "ux",
+        "plan"
+      ],
+      "triggers": [
+        "pokemon champions builder architect",
+        "team builder prd",
+        "deterministic legality engine",
+        "snapshot driven builder",
+        "builder architecture"
+      ],
+      "default_action": "architecture"
+    },
+    "pokemon-champions-builder-generator": {
+      "actions": [
+        "prd",
+        "api-spec",
+        "swiftui-arch",
+        "json-schema-only"
+      ],
+      "triggers": [
+        "write the prd",
+        "make the api spec",
+        "design the swiftui architecture",
+        "json schema only",
+        "pokemon champions generator"
+      ],
+      "default_action": "prd"
     }
   }
 }

--- a/skills/pokemon-champions-builder-architect/README.md
+++ b/skills/pokemon-champions-builder-architect/README.md
@@ -1,0 +1,60 @@
+---
+name: pokemon-champions-builder-architect
+description: Repo-native wrapper for the Hermes Pokémon Champions Builder Architect skill pack. Use for deterministic builder architecture, PRDs, scoring models, schemas, UX flows, and snapshot-driven backend design.
+---
+
+# Pokémon Champions Builder Architect
+
+## Purpose
+Provide a repo-local home for the Hermes-ready Pokémon Champions Builder Architect skill pack.
+
+This skill is for:
+- PRDs and product planning
+- deterministic legality/snapshot engine design
+- backend and service boundaries
+- API request/response design
+- UX flows for locking favorites, rebuilding, swapping, and exporting
+
+The actual Hermes asset bundle lives in `skills/pokemon-champions-builder-architect/hermes/`.
+
+## When to Use
+Use this skill when you need to:
+- design a best-fit team-builder product
+- separate deterministic engine work from AI explanation work
+- define snapshot ingestion and versioning
+- outline scoring dimensions and replacement logic
+- plan iOS, web, desktop, or backend architecture
+
+## Actions
+- `prd` — produce product and scope guidance
+- `architecture` — produce system and service design
+- `api` — produce request/response and schema guidance
+- `ux` — produce screen and workflow guidance
+- `plan` — produce implementation sequencing and rollout notes
+
+## Hermes Assets
+- `hermes/SKILL.md`
+- `hermes/references/product-principles.md`
+- `hermes/references/deterministic-engine.md`
+- `hermes/references/ios-architecture.md`
+- `hermes/references/mvp-roadmap.md`
+- `hermes/templates/api-request-response.json`
+- `hermes/templates/builder-response-schema.json`
+- `hermes/templates/prd-outline.md`
+
+## Expected Good State
+- legality and optimization stay deterministic
+- build requests run against versioned snapshots, not live fetches
+- AI is scoped to explanations, coaching, and readable summaries
+- outputs stay implementation-friendly instead of hand-wavy
+
+## Troubleshooting
+- If the task needs current legality checks, use `pokemon-champions-team-lab` instead.
+- If the user wants a ready-to-paste deliverable rather than architectural guidance, use `pokemon-champions-builder-generator`.
+- If the request is drifting into live fetches during end-user build execution, push it back into scheduled ingestion and snapshot publication.
+
+## Related Files
+- `skills/pokemon-champions-team-lab/README.md`
+- `skills/pokemon-champions-builder-generator/README.md`
+- `skills/README.md`
+- `skills/index.json`

--- a/skills/pokemon-champions-builder-architect/hermes/SKILL.md
+++ b/skills/pokemon-champions-builder-architect/hermes/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: pokemon-champions-builder-architect
+description: Deterministic, snapshot-driven Pokémon Champions team-builder product design skill. Produce PRDs, system architecture, scoring models, schemas, UX flows, and implementation plans without treating build-time legality as an LLM problem.
+version: 1.1.0
+author: OpenAI
+license: MIT
+metadata:
+  hermes:
+    category: gaming
+    tags: [pokemon, champions, app-design, architecture, api, ios, team-builder]
+    related_skills: [pokemon-champions-team-lab, pokemon-champions-builder-generator]
+---
+
+# Pokémon Champions Builder Architect
+
+## Purpose
+Use this skill when the user wants product and system design for a Pokémon Champions builder app, backend, or workflow.
+
+This skill is for:
+- PRDs
+- deterministic legality/snapshot design
+- scoring and replacement logic
+- UX flows
+- API and schema planning
+- implementation sequencing
+
+## Positioning
+Call the product a **best-fit team builder**, not a perfect-team machine.
+A real builder optimizes around:
+- current regulation snapshot
+- format
+- locked favorites
+- style preference
+- risk tolerance
+- goal
+
+## Core rules
+1. Legality must be deterministic.
+2. Use versioned format snapshots.
+3. Do not live-fetch during a build request.
+4. AI explains; the engine decides.
+5. Preserve favorites when possible.
+6. Surface uncertainty explicitly.
+7. Keep outputs implementation-friendly.
+
+## Product modes
+### PRD / product brief
+Return:
+- problem
+- user
+- goals
+- non-goals
+- core flows
+- requirements
+- MVP scope
+- launch risks
+
+### System architecture
+Return:
+- domain model
+- service boundaries
+- snapshot ingestion design
+- storage model
+- build pipeline
+- observability and testing notes
+
+### API / schemas
+Return:
+- request/response shapes
+- validation rules
+- uncertainty fields
+- replacement and warning payloads
+
+### UX / feature design
+Return:
+- screen map
+- interaction sequence
+- result card anatomy
+- rebuild controls
+- save/export/share flow
+
+### Implementation plan
+Return:
+- milestone breakdown
+- easiest safe starting point
+- what to postpone until after MVP
+
+## Deterministic engine owns
+- regulation snapshot
+- legal Pokémon/forms/Megas/items/moves/mechanics
+- candidate generation
+- role coverage checks
+- type overlap checks
+- synergy scoring
+- matchup heuristics
+- replacement generation
+
+## AI layer owns
+- readable explanations
+- strategy summaries
+- replacement reasoning
+- naming archetypes
+- simplification for different skill levels
+
+## Output requirements
+Every answer should keep the deterministic/AI split explicit and recommend snapshot publication instead of live-fetch-at-build-time execution.
+
+## Optional references
+- `references/product-principles.md`
+- `references/deterministic-engine.md`
+- `references/ios-architecture.md`
+- `references/mvp-roadmap.md`
+- `templates/api-request-response.json`
+- `templates/builder-response-schema.json`
+- `templates/prd-outline.md`

--- a/skills/pokemon-champions-builder-architect/hermes/references/deterministic-engine.md
+++ b/skills/pokemon-champions-builder-architect/hermes/references/deterministic-engine.md
@@ -1,0 +1,19 @@
+# Deterministic Engine Notes
+
+## Owns
+- regulation snapshot
+- legal Pokémon/forms/Megas/items/moves/mechanics
+- candidate generation
+- role coverage checks
+- synergy scoring
+- matchup heuristics
+- replacement generation
+
+## Does not own
+- narrative explanations
+- coaching tone
+- archetype naming
+
+## Runtime rule
+Ingest and validate format data on a schedule.
+Build requests run against a versioned snapshot, not fresh web fetches.

--- a/skills/pokemon-champions-builder-architect/hermes/references/ios-architecture.md
+++ b/skills/pokemon-champions-builder-architect/hermes/references/ios-architecture.md
@@ -1,0 +1,15 @@
+# iOS Architecture Notes
+
+## Suggested stack
+- SwiftUI for UI
+- SwiftData or local persistence for saved teams and snapshot metadata
+- thin networking layer
+- domain models separated from view state
+
+## Key screens
+- BuildHomeView
+- PokemonLockPickerView
+- TeamResultView
+- ReplacementSheet
+- StrategyView
+- SavedTeamsView

--- a/skills/pokemon-champions-builder-architect/hermes/references/mvp-roadmap.md
+++ b/skills/pokemon-champions-builder-architect/hermes/references/mvp-roadmap.md
@@ -1,0 +1,21 @@
+# MVP Roadmap
+
+## V1
+- one current snapshot
+- 0–6 locked Pokémon
+- one best team
+- replacement suggestions
+- one strategy summary
+- saved teams
+
+## V1.5
+- doubles
+- archetype filters
+- matchup grading
+- alternate builds
+- export/share
+
+## V2
+- usage-informed scoring
+- anti-meta mode
+- revision history between snapshots

--- a/skills/pokemon-champions-builder-architect/hermes/references/product-principles.md
+++ b/skills/pokemon-champions-builder-architect/hermes/references/product-principles.md
@@ -1,0 +1,8 @@
+# Product Principles
+
+1. Best-fit builder, not perfect-team marketing.
+2. Deterministic legality and snapshot rules.
+3. Preserve locked favorites when possible.
+4. Surface uncertainty explicitly.
+5. Return strategy and warnings, not just six slots.
+6. Prefer maintainable systems over clever live-fetch hacks.

--- a/skills/pokemon-champions-builder-architect/hermes/templates/api-request-response.json
+++ b/skills/pokemon-champions-builder-architect/hermes/templates/api-request-response.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "format": "doubles",
+    "regulation_snapshot_id": "champions_reg_ma_2026_04_08",
+    "locked_pokemon": ["palafin", "dragonite"],
+    "style_preference": "balanced_pivot_offense",
+    "risk_tolerance": "stable",
+    "goal": "ladder"
+  },
+  "response": {
+    "team": {
+      "name": "Balanced Pivot Offense",
+      "score": 87.4,
+      "slots": []
+    },
+    "replacements": [],
+    "strategy": {},
+    "warnings": []
+  }
+}

--- a/skills/pokemon-champions-builder-architect/hermes/templates/builder-response-schema.json
+++ b/skills/pokemon-champions-builder-architect/hermes/templates/builder-response-schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "BuilderResponse",
+  "type": "object",
+  "required": ["team", "strategy", "warnings"],
+  "properties": {
+    "team": {
+      "type": "object",
+      "required": ["name", "score", "slots"],
+      "properties": {
+        "name": { "type": "string" },
+        "score": { "type": "number" },
+        "slots": { "type": "array", "items": { "$ref": "#/$defs/TeamSlot" }, "minItems": 6, "maxItems": 6 }
+      }
+    },
+    "replacements": { "type": "array", "items": { "$ref": "#/$defs/ReplacementSuggestion" } },
+    "strategy": { "type": "object" },
+    "warnings": { "type": "array", "items": { "$ref": "#/$defs/Warning" } }
+  },
+  "$defs": {
+    "TeamSlot": {
+      "type": "object",
+      "required": ["species", "role", "moves"],
+      "properties": {
+        "species": { "type": "string" },
+        "role": { "type": "string" },
+        "moves": { "type": "array", "items": { "type": "string" }, "minItems": 4, "maxItems": 4 }
+      }
+    },
+    "ReplacementSuggestion": {
+      "type": "object",
+      "required": ["slot_index", "reason", "options"],
+      "properties": {
+        "slot_index": { "type": "integer" },
+        "reason": { "type": "string" },
+        "options": { "type": "array", "items": { "type": "string" }, "maxItems": 3 }
+      }
+    },
+    "Warning": {
+      "type": "object",
+      "required": ["code", "message", "severity"],
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "severity": { "type": "string", "enum": ["info", "warning", "error"] }
+      }
+    }
+  }
+}

--- a/skills/pokemon-champions-builder-architect/hermes/templates/prd-outline.md
+++ b/skills/pokemon-champions-builder-architect/hermes/templates/prd-outline.md
@@ -1,0 +1,17 @@
+# {{Product Name}} PRD
+
+## Product summary
+## Problem
+## Users
+## Goals
+## Non-goals
+## Core user flows
+## Functional requirements
+## Deterministic engine requirements
+## AI explanation requirements
+## Data and snapshot requirements
+## UX requirements
+## Risks and launch cautions
+## MVP boundary
+## Post-MVP roadmap
+## Open questions

--- a/skills/pokemon-champions-builder-generator/README.md
+++ b/skills/pokemon-champions-builder-generator/README.md
@@ -1,0 +1,62 @@
+---
+name: pokemon-champions-builder-generator
+description: Repo-native wrapper for the Hermes Pokémon Champions Builder Generator skill pack. Use for deliverables such as PRDs, API specs, SwiftUI architecture, and strict JSON-schema-only contracts.
+---
+
+# Pokémon Champions Builder Generator
+
+## Purpose
+Provide a repo-local home for the Hermes-ready Pokémon Champions Builder Generator skill pack.
+
+This skill is for deliverables, not just discussion. It exposes four explicit modes:
+- `PRD`
+- `API_SPEC`
+- `SWIFTUI_ARCH`
+- `JSON_SCHEMA_ONLY`
+
+The actual Hermes asset bundle lives in `skills/pokemon-champions-builder-generator/hermes/`.
+
+## When to Use
+Use this skill when you need to:
+- write the PRD
+- generate backend/API contracts
+- generate SwiftUI app architecture
+- emit strict machine-ready JSON schemas and payload contracts
+- turn rough builder ideas into implementation-ready artifacts
+
+## Actions
+- `prd` — write a product requirements document
+- `api-spec` — write a backend/API contract
+- `swiftui-arch` — write SwiftUI architecture and module guidance
+- `json-schema-only` — emit schema-first, low-prose machine contracts
+
+## Hermes Assets
+- `hermes/SKILL.md`
+- `hermes/references/mode-selection.md`
+- `hermes/references/generator-rules.md`
+- `hermes/references/public-launch-cautions.md`
+- `hermes/templates/prd-template.md`
+- `hermes/templates/api-spec-template.md`
+- `hermes/templates/swiftui-architecture-template.md`
+- `hermes/templates/json-schema-only-template.json`
+- `hermes/examples/prd-example.md`
+- `hermes/examples/api-spec-example.json`
+- `hermes/examples/swiftui-architecture-example.md`
+- `hermes/examples/json-schema-only-example.json`
+
+## Expected Good State
+- the selected mode matches the user’s deliverable
+- deterministic legality/snapshot rules are preserved
+- JSON schema mode emits machine-ready contracts without bloated prose
+- the skill never invents live legality data during end-user build execution
+
+## Troubleshooting
+- If the user wants broad product architecture, prefer `pokemon-champions-builder-architect`.
+- If the user wants live team legality work, prefer `pokemon-champions-team-lab`.
+- If the request names multiple deliverables, return the primary artifact in full and list the next candidates instead of mashing everything together.
+
+## Related Files
+- `skills/pokemon-champions-team-lab/README.md`
+- `skills/pokemon-champions-builder-architect/README.md`
+- `skills/README.md`
+- `skills/index.json`

--- a/skills/pokemon-champions-builder-generator/hermes/SKILL.md
+++ b/skills/pokemon-champions-builder-generator/hermes/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: pokemon-champions-builder-generator
+description: Mode-driven Pokémon Champions builder deliverable skill. Generate PRDs, API specs, SwiftUI architecture, or strict machine-ready JSON schemas from one prompt while preserving deterministic legality-engine boundaries.
+version: 1.1.0
+author: OpenAI
+license: MIT
+metadata:
+  hermes:
+    category: gaming
+    tags: [pokemon, champions, prd, api, swiftui, schema, ios, architecture]
+    related_skills: [pokemon-champions-builder-architect, pokemon-champions-team-lab]
+---
+
+# Pokémon Champions Builder Generator
+
+## Purpose
+Use this skill when the user wants a deliverable they can paste into docs, tickets, or code, not just high-level advice.
+
+## Modes
+### `PRD`
+Use for product requirements documents.
+
+### `API_SPEC`
+Use for backend/API contracts, domain objects, validation rules, and service boundaries.
+
+### `SWIFTUI_ARCH`
+Use for SwiftUI screen layout, state flow, persistence, service layers, and module boundaries.
+
+### `JSON_SCHEMA_ONLY`
+Use for strict machine-ready schemas and structured output contracts with minimal prose.
+This mode is for:
+- JSON Schema packages
+- validator contracts
+- OpenAI structured output payloads
+- tool/function input/output contracts
+- request/response schema bundles
+
+## Core rules
+1. Deterministic engine decides legality and team composition.
+2. AI explains results but does not invent legality or unsupported set data.
+3. Snapshot ingestion is separate from build execution.
+4. Do not live-fetch during an end-user build request.
+5. Preserve locked favorites, replacement logic, and threat notes.
+
+## Mode selection
+- Choose `PRD` for scope, MVP, user stories, and roadmap.
+- Choose `API_SPEC` for backend contracts and service layout.
+- Choose `SWIFTUI_ARCH` for app structure and UI architecture.
+- Choose `JSON_SCHEMA_ONLY` when the user explicitly wants schemas with little or no prose.
+
+## Output contracts
+### `PRD`
+Return:
+- title
+- product summary
+- problem
+- users
+- goals / non-goals
+- flows
+- requirements
+- MVP boundary
+- roadmap
+- open questions
+
+### `API_SPEC`
+Return:
+- scope
+- assumptions
+- domain objects
+- snapshot model
+- request schema
+- response schema
+- validation rules
+- services/modules
+- error handling
+- versioning
+- example payloads
+
+### `SWIFTUI_ARCH`
+Return:
+- app goal
+- architecture summary
+- screens and navigation
+- domain models
+- state management
+- service layer
+- persistence and caching
+- build/result flows
+- testing and performance notes
+- module layout
+
+### `JSON_SCHEMA_ONLY`
+Return:
+- title
+- scope
+- assumptions
+- schema package index
+- canonical enums
+- shared primitives
+- request schemas
+- response schemas
+- warning/error schemas
+- snapshot and uncertainty schemas
+- example payloads
+
+## JSON schema rules
+- Prefer JSON Schema 2020-12 unless the user requests another draft.
+- Use explicit required fields.
+- Use stable enum values.
+- Separate user input payloads from engine output payloads.
+- Include confidence and uncertainty objects where source coverage may be incomplete.
+- Keep prose minimal and field descriptions short.
+
+## Optional references
+- `references/mode-selection.md`
+- `references/generator-rules.md`
+- `references/public-launch-cautions.md`
+- `templates/prd-template.md`
+- `templates/api-spec-template.md`
+- `templates/swiftui-architecture-template.md`
+- `templates/json-schema-only-template.json`
+- `examples/prd-example.md`
+- `examples/api-spec-example.json`
+- `examples/swiftui-architecture-example.md`
+- `examples/json-schema-only-example.json`

--- a/skills/pokemon-champions-builder-generator/hermes/examples/prd-example.md
+++ b/skills/pokemon-champions-builder-generator/hermes/examples/prd-example.md
@@ -1,0 +1,14 @@
+# Example PRD Skeleton
+
+## Product summary
+A best-fit Pokémon Champions team builder that generates one strong team around 0–6 locked picks.
+
+## Problem
+Players want builder help that respects current rules and their favorite Pokémon without making up legality.
+
+## Core flow
+1. Pick format and regulation snapshot
+2. Lock up to 6 Pokémon
+3. Choose style and risk tolerance
+4. Build team
+5. Review replacements, strategy, and threats

--- a/skills/pokemon-champions-builder-generator/hermes/references/generator-rules.md
+++ b/skills/pokemon-champions-builder-generator/hermes/references/generator-rules.md
@@ -1,0 +1,20 @@
+# Generator Rules
+
+## Hard rules
+- Deterministic engine decides legality and team composition.
+- AI explains but does not invent legality.
+- Regulation and roster data should come from versioned snapshots.
+- Build requests should run against stored snapshots, not fresh web fetches.
+
+## Preserve
+- locked favorites
+- team identity
+- simpler fallback path
+- replacements for weak or illegal slots
+- threats and warnings
+
+## JSON schema mode
+- Prefer JSON Schema 2020-12.
+- Use explicit enums and required arrays.
+- Include confidence and uncertainty objects.
+- Keep prose outside the schema body whenever possible.

--- a/skills/pokemon-champions-builder-generator/hermes/references/mode-selection.md
+++ b/skills/pokemon-champions-builder-generator/hermes/references/mode-selection.md
@@ -1,0 +1,18 @@
+# Mode Selection
+
+Use the lightest mode that fully answers the request.
+
+## PRD
+Use for scope, MVP, user stories, roadmap, and release boundaries.
+
+## API_SPEC
+Use for service boundaries, contracts, schemas, validation, and versioning.
+
+## SWIFTUI_ARCH
+Use for SwiftUI views, state flow, persistence, screen hierarchy, and module layout.
+
+## JSON_SCHEMA_ONLY
+Use when the user explicitly wants machine-ready contracts, validator schemas, structured outputs, or minimal-prose payload definitions.
+
+## Combined requests
+Return the primary artifact in full, then list concise next artifact candidates instead of mashing every mode together.

--- a/skills/pokemon-champions-builder-generator/hermes/references/public-launch-cautions.md
+++ b/skills/pokemon-champions-builder-generator/hermes/references/public-launch-cautions.md
@@ -1,0 +1,7 @@
+# Public Launch Cautions
+
+If the user intends to ship publicly:
+- use original app branding
+- avoid implying official Pokémon affiliation
+- do not ship artwork or assets without rights
+- review naming, iconography, screenshots, and store copy for trademark/copyright risk

--- a/skills/pokemon-champions-builder-generator/hermes/templates/api-spec-template.md
+++ b/skills/pokemon-champions-builder-generator/hermes/templates/api-spec-template.md
@@ -1,0 +1,17 @@
+# {{Service Name}} API Spec
+
+## Scope
+## Assumptions
+## Domain objects
+## Snapshot model
+## Request schema
+## Response schema
+## Validation rules
+## Replacement suggestion payloads
+## Warning and uncertainty payloads
+## Services/modules
+## Build pipeline
+## Error handling
+## Versioning strategy
+## Observability/testability notes
+## Example request and response

--- a/skills/pokemon-champions-builder-generator/hermes/templates/json-schema-only-template.json
+++ b/skills/pokemon-champions-builder-generator/hermes/templates/json-schema-only-template.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "{{Schema Package Name}}",
+  "type": "object",
+  "properties": {
+    "snapshot_id": { "type": "string" },
+    "request": { "$ref": "#/$defs/BuildRequest" },
+    "response": { "$ref": "#/$defs/BuildResponse" }
+  },
+  "required": ["snapshot_id", "request", "response"],
+  "$defs": {
+    "BuildRequest": { "type": "object" },
+    "BuildResponse": { "type": "object" },
+    "Warning": { "type": "object" },
+    "ReplacementSuggestion": { "type": "object" }
+  }
+}

--- a/skills/pokemon-champions-builder-generator/hermes/templates/prd-template.md
+++ b/skills/pokemon-champions-builder-generator/hermes/templates/prd-template.md
@@ -1,0 +1,17 @@
+# {{Product Name}} PRD
+
+## Product summary
+## Problem
+## Users
+## Goals
+## Non-goals
+## Core user flows
+## Functional requirements
+## Deterministic engine requirements
+## AI explanation requirements
+## Data and snapshot requirements
+## UX requirements
+## Risks and launch cautions
+## MVP boundary
+## Post-MVP roadmap
+## Open questions

--- a/skills/pokemon-champions-builder-generator/hermes/templates/swiftui-architecture-template.md
+++ b/skills/pokemon-champions-builder-generator/hermes/templates/swiftui-architecture-template.md
@@ -1,0 +1,17 @@
+# {{App or Feature Name}} SwiftUI Architecture
+
+## App goal
+## Architecture summary
+## Screens and navigation
+## Domain models
+## State management
+## Networking/service layer
+## Local persistence and caching
+## Build request flow
+## Result rendering flow
+## Rebuild/swap interactions
+## Error/loading/empty states
+## Testing strategy
+## Performance considerations
+## File/module layout
+## First implementation milestone

--- a/skills/pokemon-champions-team-lab/README.md
+++ b/skills/pokemon-champions-team-lab/README.md
@@ -1,0 +1,55 @@
+---
+name: pokemon-champions-team-lab
+description: Repo-native wrapper for the Hermes Pokémon Champions Team Lab skill pack. Use for live team audits, legality checks, best-fit builds, and current-format Champions analysis.
+---
+
+# Pokémon Champions Team Lab
+
+## Purpose
+Provide a repo-local home for the Hermes-ready Pokémon Champions Team Lab skill pack.
+
+This skill is for:
+- live current-format team audits
+- legality checks
+- best-fit team builds around locked favorites
+- current-format Singles or Doubles rebuilds
+- preserving weird team identity without inventing legality
+
+The actual Hermes asset bundle lives in `skills/pokemon-champions-team-lab/hermes/`.
+
+## When to Use
+Use this skill when you need to:
+- audit pasted Pokémon Champions teams against the current format
+- flag unsupported Megas, forms, moves, items, or mechanics
+- rebuild a team while preserving its intent
+- generate a best-fit team around locked Pokémon and a style/goal
+- separate official confirmation from secondary live meta signal
+
+## Actions
+- `audit` — inspect and rebuild pasted teams
+- `build` — create a best-fit team from locked picks and constraints
+- `spec` — derive builder-oriented structured outputs from the same ruleset
+
+## Hermes Assets
+- `hermes/SKILL.md`
+- `hermes/references/team-audit-template.md`
+- `hermes/references/builder-product-spec.md`
+- `hermes/references/example-teams.md`
+- `hermes/references/structured-output-schema.json`
+
+## Expected Good State
+- official sources are prioritized over secondary sources
+- unsupported or unconfirmed content is labeled plainly
+- replacements preserve team identity where possible
+- outputs include pilot notes, threat notes, and uncertainty where needed
+
+## Troubleshooting
+- If a flashy Mega or form is not verified on current sources, treat it as unconfirmed and replace it.
+- If the task is product design rather than live legality review, switch to `pokemon-champions-builder-architect` or `pokemon-champions-builder-generator`.
+- If you need machine-ready contracts only, prefer `pokemon-champions-builder-generator` in `JSON_SCHEMA_ONLY` mode.
+
+## Related Files
+- `skills/pokemon-champions-builder-architect/README.md`
+- `skills/pokemon-champions-builder-generator/README.md`
+- `skills/README.md`
+- `skills/index.json`

--- a/skills/pokemon-champions-team-lab/hermes/SKILL.md
+++ b/skills/pokemon-champions-team-lab/hermes/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: pokemon-champions-team-lab
+description: Live, format-aware Pokémon Champions team audit and best-fit builder workflow. Check current format legality first, preserve team identity, flag unsupported content, and support deterministic builder/app specs when needed.
+version: 1.1.0
+author: OpenAI
+license: MIT
+metadata:
+  hermes:
+    category: gaming
+    tags: [pokemon, champions, team-building, legality, singles, doubles, anti-meta]
+    requires_toolsets: [web]
+    related_skills: [pokemon-champions-builder-architect, pokemon-champions-builder-generator]
+---
+
+# Pokémon Champions Team Lab
+
+Use this skill to analyze, legal-check, refine, and explain Pokémon Champions teams with current web-verified data.
+
+## Purpose
+- Audit pasted teams against the current live format.
+- Replace illegal, unsupported, or unconfirmed content with the closest faithful option.
+- Preserve weird or flavor-heavy identity when possible.
+- Support best-fit builds around locked favorites, style, and goal.
+
+## Core rules
+1. Never analyze from memory alone.
+2. Check current Champions format data first.
+3. Prioritize official sources:
+   - `champions.pokemon.com`
+   - `pokemon.com` news and rules pages
+   - Play! Pokémon resources
+   - official event pages
+4. Use secondary sources only when official pages are incomplete, and label them clearly.
+5. If something is not verified, say `unconfirmed`.
+6. Treat speculative or custom content as unusable unless verified.
+7. Preserve team identity instead of flattening everything into generic usage sludge.
+
+## Modes
+### Team Audit
+Use when the user pastes one or more teams.
+Return:
+- current format snapshot
+- legality audit
+- structural diagnosis
+- keep/change decisions
+- refined roster
+- pilot notes
+- threat checklist
+
+### Best-Fit Build
+Use when the user gives locked picks or constraints.
+Build around:
+- format
+- regulation snapshot
+- locked Pokémon
+- style
+- risk tolerance
+- goal
+
+### Product Design Handoff
+If the request drifts into builder architecture, recommend snapshot-driven design and hand off to:
+- `pokemon-champions-builder-architect`
+- `pokemon-champions-builder-generator`
+
+## Required snapshot fields
+Always collect and report:
+- date checked
+- sources used
+- active regulation or current public rules wording
+- supported formats relevant to the request
+- legality notes affecting the team
+- key meta notes if available
+- confidence level
+- unresolved uncertainties
+
+## Output contract
+For each team, return:
+- Team name
+- Format
+- Final roster
+- Set details for each Pokémon
+- 3 biggest improvements
+- 3 biggest remaining risks
+- 1 easier or simpler alternative if needed
+
+End with:
+1. What changed from the original
+2. How to rerun this next month
+3. Reusable checklist for future Champions team reviews
+
+## Guardrails
+- Do not invent legality.
+- Do not assign Tera types unless current rules clearly support it.
+- Do not blur official confirmation with secondary live signal.
+- If a Mega, form, move, or mechanic is unsupported, say so plainly and replace it.
+
+## Optional references
+- `references/team-audit-template.md`
+- `references/builder-product-spec.md`
+- `references/example-teams.md`
+- `references/structured-output-schema.json`

--- a/skills/pokemon-champions-team-lab/hermes/references/builder-product-spec.md
+++ b/skills/pokemon-champions-team-lab/hermes/references/builder-product-spec.md
@@ -1,0 +1,33 @@
+# Builder Product Spec Notes
+
+## Product shape
+Describe the product as a **best-fit team builder**.
+
+## Required user inputs
+- format
+- regulation snapshot
+- locked Pokémon: 0–6
+- style preference
+- risk tolerance
+- goal
+
+## Required outputs
+- one best team or top candidates
+- full sets
+- replacements for weak or illegal slots
+- strategy plan
+- matchup warnings
+- export surface
+
+## Deterministic engine owns
+- legality
+- regulation snapshot
+- candidate generation
+- scoring
+- replacement logic
+
+## AI owns
+- explanations
+- strategy summaries
+- naming
+- clearer wording

--- a/skills/pokemon-champions-team-lab/hermes/references/example-teams.md
+++ b/skills/pokemon-champions-team-lab/hermes/references/example-teams.md
@@ -1,0 +1,21 @@
+# Example Team Shapes
+
+## Stable Singles
+- pivot lead
+- progress maker
+- physical breaker
+- special breaker
+- speed control
+- endgame cleaner
+
+## Stable Doubles
+- coherent lead
+- speed control or Trick Room mode
+- support slot
+- spread pressure
+- immediate breaker
+- cleaner or bulky endgame
+
+## Identity rule
+Preserve the team’s weird plan when it can be made legal and coherent.
+Replace only the slots that are illegal, unsupported, or structurally dead.

--- a/skills/pokemon-champions-team-lab/hermes/references/structured-output-schema.json
+++ b/skills/pokemon-champions-team-lab/hermes/references/structured-output-schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PokemonChampionsTeamAuditOutput",
+  "type": "object",
+  "required": ["snapshot", "teams"],
+  "properties": {
+    "snapshot": {
+      "type": "object",
+      "required": ["date_checked", "sources_used", "confidence"],
+      "properties": {
+        "date_checked": { "type": "string" },
+        "sources_used": { "type": "array", "items": { "type": "string" } },
+        "active_regulation": { "type": "string" },
+        "confidence": { "type": "string", "enum": ["high", "medium", "low"] },
+        "uncertainties": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "teams": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["team_name", "format", "final_roster"],
+        "properties": {
+          "team_name": { "type": "string" },
+          "format": { "type": "string" },
+          "final_roster": { "type": "array", "items": { "type": "object" }, "minItems": 1 },
+          "improvements": { "type": "array", "items": { "type": "string" } },
+          "risks": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/skills/pokemon-champions-team-lab/hermes/references/team-audit-template.md
+++ b/skills/pokemon-champions-team-lab/hermes/references/team-audit-template.md
@@ -1,0 +1,33 @@
+# Team Audit Template
+
+## Current format snapshot
+- Date checked
+- Sources used
+- Active regulation or current public rules wording
+- Supported formats
+- Legality notes
+- Meta notes
+- Confidence
+- Unresolved uncertainties
+
+## Per-team audit
+1. Original concept summary
+2. Legality audit
+3. Structural diagnosis
+   - role compression
+   - speed control
+   - defensive backbone
+   - pivoting / positioning
+   - win conditions
+   - matchup weaknesses
+   - redundancy / anti-synergy
+4. Keep / change decisions
+5. Refined team
+6. Why it is better now
+7. Pilot notes
+8. Threat checklist
+
+## End block
+- What changed from the original
+- How to rerun this next month
+- Reusable checklist


### PR DESCRIPTION
## Summary
- add three repo-native skill wrappers in `skills/` for Pokémon Champions workflows
- register the new skills in `skills/index.json` and document them in `skills/README.md`
- land Hermes-ready payloads for Team Lab, Builder Architect, and Builder Generator
- complete the fourth generator mode: `JSON_SCHEMA_ONLY`
- include supporting references, templates, and examples so the packs are usable immediately

## Why
These skills already existed as local artifacts, but they were not committed into the repo-native skill system that `bmo-stack` already uses. This PR makes them discoverable and keeps the Hermes packs alongside the repo wrappers.

## Notes
- no runtime code paths changed
- no iOS/TestFlight workflow paths changed
- this is skill-pack and docs/registry work only

## Validation
- structure follows the existing `skills/` registry + README pattern
- each registered skill has a corresponding `skills/<name>/README.md`
- generator pack now includes explicit `JSON_SCHEMA_ONLY` mode and matching template/example
