### PR TITLE
Align Buddy intro posture companion-first

### DIFF
--- a/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/AppModels.swift
@@ -353,11 +353,11 @@ enum BuddyPowerMode: String, Codable, CaseIterable, Hashable, Identifiable {
     var subtitle: String {
         switch self {
         case .gentle:
-            return "Keep the shell simple and put Buddy guidance first."
+            return "Keep the experience calm: planning, reminders, notes, and teaching Buddy what helps."
         case .balanced:
-            return "Show the normal Buddy, workspace, and results flow."
+            return "Keep Buddy, chat, skills, and results visible without making setup feel heavy."
         case .turbo:
-            return "Keep advanced runtime setup and Mac power surfaces close."
+            return "Keep deeper operator tools close for repo, runtime, debugging, and skill work."
         }
     }
 

--- a/apps/openclaw-shell-ios/OpenClawShell/Features/Chat/ChatTabView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Features/Chat/ChatTabView.swift
@@ -93,7 +93,7 @@ struct ChatTabView: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(appState.chatStore.isGenerating || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || (!appState.usesStubRuntime && appState.selectedInstalledModel == nil))
+                .disabled(!canSend)
             }
 
             HStack {
@@ -138,6 +138,15 @@ struct ChatTabView: View {
     }
 
     private var fallbackPlaceholder: String {
-        appState.usesStubRuntime ? "Try the shell UI (stub runtime active)" : "Ask your local model"
+        appState.usesStubRuntime ? "Ask what Buddy can do, or link chat for more" : "Ask your Buddy"
+    }
+
+    private var canSend: Bool {
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !appState.chatStore.isGenerating, !trimmedPrompt.isEmpty else { return false }
+        if BuddyIntroCopy.response(for: trimmedPrompt, buddyName: appState.buddyStore.activeBuddy?.displayName ?? "Buddy") != nil {
+            return true
+        }
+        return appState.usesStubRuntime || appState.selectedInstalledModel != nil || appState.selectedProviderAccount != nil
     }
 }

--- a/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/OnboardingFlow.swift
@@ -97,16 +97,16 @@ struct OnboardingFlow: View {
                 .foregroundColor(BMOTheme.textPrimary)
                 .multilineTextAlignment(.center)
 
-            Text("Start with a Buddy. Runtime pairing, models, and power mode come after your companion has an identity.")
+            Text("Start with a Buddy you can name, teach, and use for real daily help. Deeper setup can wait until you need it.")
                 .font(.body)
                 .foregroundColor(BMOTheme.textSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, BMOTheme.spacingXL)
 
             VStack(alignment: .leading, spacing: 10) {
-                featureRow("Choose the Buddy who will be with you on Home, Chat, Skills, and Results")
-                featureRow("Name them and set their first focus")
-                featureRow("Add Mac power mode later when you want a stronger runtime")
+                featureRow("Choose the Buddy who will help with your day, work, notes, and follow-through")
+                featureRow("Name them and teach the first thing you want help with")
+                featureRow("Add operator power later when you want repo, runtime, or skill execution help")
             }
             .padding(.horizontal, BMOTheme.spacingXL)
 
@@ -155,7 +155,7 @@ struct OnboardingFlow: View {
         ScrollView {
             VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
                 Spacer().frame(height: BMOTheme.spacingXL)
-                onboardingTitle("Name your Buddy", subtitle: "Give your companion the name you want to see on Home, Chat, tasks, training, and receipts.")
+                onboardingTitle("Name your Buddy", subtitle: "Give your companion the name you want to see in plans, chats, tasks, and training.")
                 labeledField(title: "Buddy name", text: $buddyName, placeholder: selectedTemplate?.name ?? "Buddy")
                 selectedBuddyPreview
                 navButtons(back: .chooseBuddy, next: .focusBuddy, canProceed: !trimmed(buddyName).isEmpty)
@@ -168,13 +168,13 @@ struct OnboardingFlow: View {
         ScrollView {
             VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
                 Spacer().frame(height: BMOTheme.spacingXL)
-                onboardingTitle("Pick your Buddy's first focus", subtitle: "This sets the first use-case BeMore reinforces after onboarding. You can change it later.")
+                onboardingTitle("Pick your Buddy's first focus", subtitle: "Choose the first kind of help you want Buddy to practice. You can change it later.")
                 labeledField(title: "First focus", text: $buddyFocus, placeholder: selectedTemplate?.canonicalRole ?? "Help me finish the next useful step")
                 VStack(alignment: .leading, spacing: 10) {
                     Text("How this will show up")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("\(fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")) will open on Home with this focus, carry it into Chat, and use it as the default for the first check-ins and receipts.")
+                    Text("\(fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")) will use this focus on Home, in Chat, and in the first check-ins so the experience starts personal.")
                         .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
@@ -190,7 +190,7 @@ struct OnboardingFlow: View {
         ScrollView {
             VStack(alignment: .leading, spacing: BMOTheme.spacingLG) {
                 Spacer().frame(height: BMOTheme.spacingXL)
-                onboardingTitle("Power mode is optional", subtitle: "BeMore can start as your Buddy on iPhone. Pairing Mac and route setup are stronger-mode choices, not the first thing you have to understand.")
+                onboardingTitle("Mode choice is optional", subtitle: "Begin in companion mode on iPhone. Operator setup is there when you want deeper technical work, not something you need to learn first.")
 
                 VStack(spacing: 12) {
                     ForEach(BuddyPowerMode.allCases) { mode in
@@ -221,7 +221,7 @@ struct OnboardingFlow: View {
                 }
                 .padding(.horizontal, BMOTheme.spacingLG)
 
-                toggleCard(icon: "macbook.and.iphone", title: "Pair with Mac later", subtitle: "Keep Mac runtime pairing available after you land on Buddy Home.", isOn: $config.installDesktopNode)
+                toggleCard(icon: "macbook.and.iphone", title: "Pair with Mac later", subtitle: "Keep deeper operator tools available after you land on Buddy Home.", isOn: $config.installDesktopNode)
                     .padding(.horizontal, BMOTheme.spacingLG)
                 toggleCard(icon: "bell.badge", title: "Buddy notifications", subtitle: "Allow BeMore to remind you about Buddy tasks, results, and check-ins when enabled.", isOn: $config.enableNotifications)
                     .padding(.horizontal, BMOTheme.spacingLG)
@@ -234,12 +234,12 @@ struct OnboardingFlow: View {
                         labeledField(title: "Public domain", text: $config.adminDomain, placeholder: "example.com")
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
-                        toggleCard(icon: "wrench.and.screwdriver", title: "Tools", subtitle: "Allow tool and API actions when the connected runtime supports them.", isOn: $config.toolsEnabled)
-                        toggleCard(icon: "brain", title: "Memory", subtitle: "Persist Buddy and operator context locally on device.", isOn: $config.memoryEnabled)
+                        toggleCard(icon: "wrench.and.screwdriver", title: "Operator tools", subtitle: "Allow technical actions when the connected runtime supports and confirms them.", isOn: $config.toolsEnabled)
+                        toggleCard(icon: "brain", title: "Memory", subtitle: "Let Buddy keep local preferences, routines, and useful context on this device.", isOn: $config.memoryEnabled)
                     }
                     .padding(.top, BMOTheme.spacingMD)
                 } label: {
-                    Text("Advanced runtime setup")
+                    Text("Advanced operator setup")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
                 }
@@ -309,7 +309,7 @@ struct OnboardingFlow: View {
                     .font(.system(size: 28, weight: .bold))
                     .foregroundColor(BMOTheme.textPrimary)
 
-                Text("You’ll land on Buddy Home. Chat, Skills, Results, and Mac power mode all point back to this active Buddy.")
+                Text("You’ll land on Buddy Home. Chat, skills, results, and optional operator power all point back to this active Buddy.")
                     .font(.subheadline)
                     .foregroundColor(BMOTheme.textSecondary)
                     .multilineTextAlignment(.center)
@@ -344,7 +344,7 @@ struct OnboardingFlow: View {
         let steps = [
             (0.25, "Creating \(name) as your active Buddy"),
             (0.50, "Linking Buddy to Home, Chat, Skills, and Results"),
-            (0.75, config.installDesktopNode ? "Keeping Mac power mode available as an optional upgrade" : "Starting in phone-first mode"),
+            (0.75, config.installDesktopNode ? "Keeping deeper Mac operator tools available for later" : "Starting in phone-first companion mode"),
             (1.0, "Preparing your Buddy-first BeMore shell")
         ]
         for (index, (progress, message)) in steps.enumerated() {
@@ -552,12 +552,12 @@ struct OnboardingFlow: View {
         var items = ["Keep \(fallback(buddyName, defaultValue: selectedTemplate?.name ?? "Buddy")) active on Home, Chat, Skills, and Results."]
         items.append("Start in \(selectedPowerMode.title.lowercased()) so the first-run shell matches your comfort level.")
         if config.installDesktopNode {
-            items.append("Pair a BeMore Mac runtime when you want workspace execution, diffs, artifacts, and receipts from your desktop.")
+            items.append("Pair BeMore Mac when you want repo work, debugging, workspace actions, and deeper verification from your desktop.")
         }
         if config.toolsEnabled {
-            items.append("Enable only the tools you want this Buddy to use through the connected runtime.")
+            items.append("Enable only the operator tools you want Buddy to use after the connected runtime confirms support.")
         }
-        items.append("Use Pricing to compare free Buddy slots, Plus runtime capacity, and Council/marketplace access before upgrading.")
+        items.append("Use Pricing to compare free Buddy slots, Plus capacity, and Council/marketplace access before upgrading.")
         return items
     }
 

--- a/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift
@@ -784,13 +784,18 @@ enum CloudPromptBuilder {
         let name = operatorName.trimmingCharacters(in: .whitespacesAndNewlines)
         let displayName = name.isEmpty ? "the operator" : name
         let toolPosture = config.toolsEnabled
-            ? "The operator intends to use tool-capable BeMore routes through the built-in Workspace Runtime as capabilities become available."
-            : "The operator has not enabled tool-capable behavior for this stack profile."
+            ? "Operator mode can use tool-capable BeMore routes when the Workspace Runtime has confirmed support."
+            : "Tool-capable operator actions are not enabled for this stack profile."
 
         return """
-        You are BeMoreAgent, the BMO-style operator agent for \(displayName)'s BeMore stack.
+        You are BeMoreAgent, \(displayName)'s Buddy-first companion for the BeMore stack.
 
-        You are not confined to the iOS app. Do not frame yourself as app-only. Help with the full BeMore operator context: planning, repo work, runtime diagnosis, provider setup, deployment reasoning, and stack operations.
+        Front-door behavior:
+        1. Start with everyday help: planning the day, breaking down work, staying on track, drafting reminders, notes, follow-ups, and messages.
+        2. Explain how you can learn: preferences, routines, communication style, corrections, and what good help looks like.
+        3. Explain growth through trained skills, repeated use, visible memory, and useful routines.
+        4. Mention deeper operator powers only after the user value is clear: repo work, runtime diagnosis, debugging, provider setup, deployment reasoning, skill execution, and stack operations.
+        5. Invite one concrete next action: a task to help with today or one thing to learn about how \(displayName) works.
 
         Current route: \(routeLabel).
         Stack name: \(config.stackName).
@@ -798,10 +803,67 @@ enum CloudPromptBuilder {
         Admin/public domain: \(config.adminDomain).
         \(toolPosture)
 
-        Be honest about capabilities. This direct cloud chat route can reason and use attached file context. Real filesystem, memory, skill, and sandbox changes must go through BeMore Workspace Runtime receipts. If a capability is unavailable in this iOS runtime, say unavailable or failed instead of claiming completion.
+        Mode framing:
+        - Companion mode helps decide what matters, plan, reflect, teach, remember preferences, and stay aligned.
+        - Operator mode handles technical execution, repo/runtime reasoning, debugging, structured work, and confirmed skill or workspace actions.
+
+        Be honest about capabilities. This direct cloud chat route can reason and use attached file context. Real filesystem, durable memory, skill, and sandbox changes require confirmed BeMore Workspace Runtime action. If a capability is unavailable in this iOS runtime, say unavailable or failed instead of claiming completion.
 
         Reply with the answer only. Do not reveal hidden reasoning, chain-of-thought, scratchpad notes, analysis sections, or internal deliberation unless the operator explicitly asks for an explanation. If asked to explain, give a concise rationale, not private step-by-step thoughts.
         """
+    }
+}
+
+enum BuddyIntroCopy {
+    static func response(for prompt: String, buddyName: String) -> String? {
+        let text = prompt.lowercased()
+        let asksCapability = containsAny(text, ["what can you do", "what are you good at", "what should i use you for", "how should i use you", "how do you work"])
+        let asksTraining = containsAny(text, ["make you better", "train you", "how do i train", "teach you", "improve you"])
+        let asksModes = containsAny(text, ["companion mode", "operator mode", "difference between", "power mode"])
+
+        guard asksCapability || asksTraining || asksModes else { return nil }
+
+        if asksModes {
+            return """
+            I have two useful gears.
+
+            Companion mode is for deciding what matters, planning your day, reflecting, remembering preferences, drafting notes or follow-ups, and helping you stay aligned without turning everything into a project.
+
+            Operator mode is for structured technical work: repo changes, debugging, runtime checks, provider setup, skill execution, and careful verification. You do not need to know the internals to use it; just ask for the outcome and I will surface the mechanics only when they matter.
+
+            A good next step: tell \(buddyName) what you want help with today, or teach one preference about how you like plans, reminders, or follow-ups handled.
+            """
+        }
+
+        if asksTraining && !asksCapability {
+            return """
+            You make \(buddyName) better by teaching me how good help should feel in your life.
+
+            Start with preferences: how you like your day planned, how direct I should be, what reminders are useful, what tone helps, and what I should avoid. Correct me when I miss. Show me your routines. Tell me which drafts, notes, plans, or follow-ups were actually useful.
+
+            Over time, that teaching becomes visible memory, stronger routines, and trained skills like planning, journaling, reminders, message drafting, research, or project support. Deeper operator tools still exist for repo and runtime work, but the first upgrade path is simple: teach, correct, repeat.
+
+            Give me one thing to learn about how you work, and I will use it on the next plan or draft.
+            """
+        }
+
+        return """
+        I can help with your day, your work, your plans, your follow-through, and your thinking.
+
+        Use \(buddyName) for planning the day, breaking down messy work, staying on track, capturing notes, drafting reminders, journaling, preparing follow-ups, and shaping messages before you send them. I can also help with product thinking, implementation thinking, and system work when you ask for that depth.
+
+        You can make me better by teaching preferences, routines, communication style, and corrections. Tell me what good help looks like, what to avoid, and which reminders or drafts were useful. I should become more aligned because you taught me, not because I pretend to know you.
+
+        Skills and memory are how I grow: planning, reminders, journaling, message drafting, research, project support, and careful review can become stronger through repeated use and visible training.
+
+        When you want operator mode, I can go deeper into repo work, runtime reasoning, debugging, skill execution, and verification. I will keep those mechanics behind the front door until they are useful.
+
+        Start with one thing you want help with today, or one thing you want \(buddyName) to learn about how you work.
+        """
+    }
+
+    private static func containsAny(_ text: String, _ needles: [String]) -> Bool {
+        needles.contains { text.contains($0) }
     }
 }
 
@@ -1686,6 +1748,13 @@ final class AppState: ObservableObject {
         let cleaned = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return }
 
+        if let intro = BuddyIntroCopy.response(for: cleaned, buddyName: buddyStore.activeBuddy?.displayName ?? "Buddy") {
+            chatStore.messages.append(ChatMessage(role: .user, content: cleaned))
+            chatStore.messages.append(ChatMessage(role: .assistant, content: intro))
+            chatStore.persist()
+            return
+        }
+
         if selectedProviderAccount == nil && engine.requiresModelSelection && selectedInstalledModel == nil {
             chatStore.errorMessage = "Link a provider in Settings or select an installed model in Models before sending."
             runtimeStatus = "Model or provider required"
@@ -1821,7 +1890,7 @@ final class AppState: ObservableObject {
                     config: stackConfig,
                     operatorName: operatorDisplayName,
                     routeLabel: routeLabel
-                ) + "\n\n\(activeBuddyChatContext)\n\nWorkspace Runtime: Available inside BeMore. Ask for actions through the runtime contract; do not claim files, memory, skills, or sandbox commands changed unless a BeMore receipt confirms it. Registered skills: \(workspaceRuntime.skills.map(\.name).joined(separator: ", ")). Canonical artifacts: soul.md, user.md, memory.md, session.md, skills.md.\n\nMac Power Mode: \(macPowerModeSummary)"
+                ) + "\n\n\(activeBuddyChatContext)\n\nOperator depth, when requested: BeMore can coordinate workspace actions, memory updates, skill runs, sandbox commands, and repo/runtime work only when confirmed by the Workspace Runtime. Registered skills: \(workspaceRuntime.skills.map(\.name).joined(separator: ", ")). Deeper artifacts exist for verification, but do not lead with artifact names unless the user asks for technical detail.\n\nMac power: \(macPowerModeSummary)"
             )
         ]
 
@@ -1850,7 +1919,7 @@ final class AppState: ObservableObject {
             return "Active Buddy: none yet. Encourage the user to create or install a Buddy before treating chat as personalized."
         }
         let focus = buddy.state.currentFocus ?? "no active focus"
-        return "Active Buddy: \(buddy.displayName). Role: \(buddy.identity.role). Class: \(buddy.identity.class). Mood: \(buddy.state.mood). Focus: \(focus). Reply as the BeMore companion connected to this Buddy identity, and keep visible work tied to Buddy tasks, skills, receipts, and results."
+        return "Active Buddy: \(buddy.displayName). Role: \(buddy.identity.role). Class: \(buddy.identity.class). Mood: \(buddy.state.mood). Focus: \(focus). Reply as a practical companion first: help with the user's day, work, plans, follow-through, memory, and training. Technical work can still use Buddy tasks, skills, results, and verified operator actions when requested."
     }
 
     private func generatedSetupChecklist(for config: StackConfig) -> [String] {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyView.swift
@@ -68,7 +68,7 @@ struct BuddyView: View {
                     Text(buddy.displayName)
                         .font(.system(size: 30, weight: .bold))
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text(template?.onboardingCopy ?? "\(buddy.displayName) is the active companion for chat, skills, tasks, receipts, and results.")
+                    Text(template?.onboardingCopy ?? "\(buddy.displayName) helps with your day, your work, your follow-through, and the routines you teach over time.")
                         .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
@@ -117,7 +117,7 @@ struct BuddyView: View {
 
             BuddyAsciiView(buddy: buddy, template: template, mood: buddyMood(for: buddy))
 
-            Text(template?.onboardingCopy ?? "Buddy profile is ready for the BeMore runtime.")
+            Text(template?.onboardingCopy ?? "Buddy is ready to help with planning, notes, follow-through, and skills you train over time.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
 
@@ -212,7 +212,7 @@ struct BuddyView: View {
                 .foregroundColor(BMOTheme.textPrimary)
 
             if events.isEmpty {
-                Text("No runtime events recorded yet. Install, personalize, check in, or train to start the event stream.")
+                Text("No activity yet. Install, personalize, check in, or train Buddy to start building useful history.")
                     .font(.subheadline)
                     .foregroundColor(BMOTheme.textSecondary)
             } else {
@@ -249,7 +249,7 @@ struct BuddyView: View {
                     Text("Discover Buddies")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("A curated Buddy marketplace beta. Install starter Buddies now; premium creator Buddies can live here when billing is ready.")
+                    Text("Try starter Buddies with different strengths. Pick the one that feels useful for how you plan, work, remember, or create.")
                         .font(.subheadline)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
@@ -311,7 +311,7 @@ struct BuddyView: View {
                     Text("My Buddy Roster")
                         .font(.headline)
                         .foregroundColor(BMOTheme.textPrimary)
-                    Text("Owned Buddies stay separate from marketplace templates. Equip one active Buddy at a time.")
+                    Text("Keep a small roster of Buddies with different strengths. Equip the one you want helping right now.")
                         .font(.caption)
                         .foregroundColor(BMOTheme.textSecondary)
                 }
@@ -372,7 +372,7 @@ struct BuddyView: View {
             Text("Training and Plans")
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-            Text("Training grows your active Buddy. Pricing controls future Buddy slots, premium marketplace access, and higher runtime capacity.")
+            Text("Training teaches Buddy what better help looks like. Use Chat for a real task, or Pricing when you want more Buddy slots and higher capacity.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
             HStack {
@@ -394,7 +394,7 @@ struct BuddyView: View {
             Text("No Buddy Installed Yet")
                 .font(.headline)
                 .foregroundColor(BMOTheme.textPrimary)
-            Text("Install a starter Buddy to create a local companion, start the Buddy event stream, and keep receipt-backed continuity.")
+            Text("Install a starter Buddy to begin with a companion you can name, teach, train, and rely on for everyday follow-through.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
         }

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/ChatView.swift
@@ -201,9 +201,14 @@ struct ChatView: View {
     }
 
     private var canSend: Bool {
-        !appState.chatStore.isGenerating &&
-        !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        (appState.selectedProviderAccount != nil || (appState.selectedInstalledModel != nil && !appState.usesStubRuntime))
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !appState.chatStore.isGenerating &&
+        !trimmedPrompt.isEmpty &&
+        (
+            BuddyIntroCopy.response(for: trimmedPrompt, buddyName: store.activeBuddy?.displayName ?? "Buddy") != nil ||
+            appState.selectedProviderAccount != nil ||
+            (appState.selectedInstalledModel != nil && !appState.usesStubRuntime)
+        )
     }
 
     private var chatScopedActions: [OpenClawActionRecord] {
@@ -220,7 +225,7 @@ struct ChatView: View {
         if let model = appState.selectedInstalledModel {
             return appState.usesStubRuntime ? "Local model selected, runtime not included in this build" : "\(store.activeBuddy?.displayName ?? "Buddy") on-device • \(model.displayName)"
         }
-        return "Route not configured. Link a cloud provider to chat in this build."
+        return "Ask what Buddy can do, or link a cloud provider for open-ended live chat."
     }
 
     private var buddyChatSubtitle: String {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/MissionControlView.swift
@@ -144,7 +144,7 @@ struct MissionControlView: View {
             }
 
             if status.recentChanges.isEmpty {
-                Text("Run a Buddy action, skill, or Mac inspection to create the next receipt-backed result.")
+                Text("Run a Buddy action, skill, or Mac inspection to create the next visible result.")
                     .font(.caption)
                     .foregroundColor(BMOTheme.textTertiary)
             } else {

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/SkillsView.swift
@@ -47,7 +47,7 @@ struct SkillsView: View {
                 Spacer()
                 StatusBadge(label: "\(appState.workspaceRuntime.skills.count) registered", color: BMOTheme.accent)
             }
-            Text("Skills run through the same receipt-backed BeMore workspace runtime used by Buddy, mobile actions, and Mac pairing.")
+            Text("Skills are practical abilities Buddy can learn, equip, and use for planning, review, building, and deeper operator work when you ask for it.")
                 .font(.subheadline)
                 .foregroundColor(BMOTheme.textSecondary)
         }

--- a/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
+++ b/apps/openclaw-shell-ios/OpenClawShellTests/AppStateRuntimeTests.swift
@@ -123,7 +123,7 @@ final class AppStateRuntimeTests: XCTestCase {
         XCTAssertNil(appState.chatReturnTab)
     }
 
-    func testCloudSystemPromptDoesNotConfineAgentToAppOnly() {
+    func testCloudSystemPromptLeadsWithCompanionValueBeforeOperatorDepth() {
         var config = StackConfig.default
         config.stackName = "BeMoreAgent"
         config.gatewayURL = "https://gateway.example.test"
@@ -136,11 +136,31 @@ final class AppStateRuntimeTests: XCTestCase {
             routeLabel: "OpenAI using gpt-4.1"
         )
 
-        XCTAssertTrue(prompt.contains("not confined to the iOS app"))
-        XCTAssertTrue(prompt.contains("full BeMore operator context"))
-        XCTAssertTrue(prompt.contains("Workspace Runtime receipts"))
+        XCTAssertTrue(prompt.contains("Buddy-first companion"))
+        XCTAssertTrue(prompt.contains("Start with everyday help"))
+        XCTAssertTrue(prompt.contains("Companion mode helps decide what matters"))
+        XCTAssertTrue(prompt.contains("Operator mode handles technical execution"))
+        XCTAssertTrue(prompt.contains("repo work"))
+        XCTAssertTrue(prompt.contains("confirmed BeMore Workspace Runtime action"))
         XCTAssertTrue(prompt.contains("Do not reveal hidden reasoning"))
         XCTAssertFalse(prompt.contains("only perform functions inside the app"))
+        XCTAssertFalse(prompt.contains("Canonical artifacts"))
+    }
+
+    func testBuddyIntroCopyAnswersCapabilitiesWithTrainingBeforeRuntimeMechanics() {
+        let reply = BuddyIntroCopy.response(
+            for: "What can you do for me and how can I make you better?",
+            buddyName: "Prism"
+        )
+
+        XCTAssertNotNil(reply)
+        XCTAssertTrue(reply!.contains("planning the day"))
+        XCTAssertTrue(reply!.contains("teaching preferences"))
+        XCTAssertTrue(reply!.contains("Skills and memory are how I grow"))
+        XCTAssertTrue(reply!.contains("operator mode"))
+        XCTAssertTrue(reply!.contains("Start with one thing"))
+        XCTAssertFalse(reply!.localizedCaseInsensitiveContains("canonical artifacts"))
+        XCTAssertFalse(reply!.localizedCaseInsensitiveContains("receipts"))
     }
 
     func testAgentReplySanitizerRemovesThoughtBlocks() {
@@ -274,7 +294,12 @@ private final class FakeLocalLLMEngine: LocalLLMEngine {
         isRuntimeReady = config != nil && supportsLocalModels
     }
 
-    func generate(prompt: String, fileContexts: [WorkspaceFile], chatHistory: [ChatMessage]) async throws -> String {
+    func generate(
+        prompt: String,
+        fileContexts: [WorkspaceFile],
+        chatHistory: [ChatMessage],
+        activeStack: CompiledStack?
+    ) async throws -> String {
         "ok"
     }
 }

--- a/context/plans/2026-04-17-buddy-companion-first-intro-copy.md
+++ b/context/plans/2026-04-17-buddy-companion-first-intro-copy.md
@@ -1,0 +1,20 @@
+# Buddy Companion-First Intro Copy
+
+## Problem
+
+Buddy's intro and help surfaces were leading with operator/runtime mechanics before the user-facing value. That made the product feel more like an internal stack manual than a useful, teachable companion.
+
+## Smallest useful wedge
+
+Rewrite the OpenClaw iOS prompt, local help answers, onboarding copy, mode explanations, and obvious help/empty states so Buddy leads with everyday help, learning, memory, skills, and growth before deeper repo/runtime powers.
+
+## Verification plan
+
+- Run the OpenClaw iOS simulator test suite.
+- Run the bmo operating-system validator.
+- Run a targeted grep for removed front-door technical phrases in edited entry points.
+- Run `git diff --check`.
+
+## Rollback plan
+
+Revert the PR to restore the previous prompt and UI copy.


### PR DESCRIPTION
## Summary
- mirrors the Buddy intro/help posture rewrite in the bmo-stack OpenClaw iOS surface
- adds local companion-first answers for capability, training, and companion/operator mode questions
- keeps operator/runtime powers available, but moves repo/runtime/artifact details behind user-value framing
- updates the local test fake to match the current `LocalLLMEngine` protocol shape

## Task contract
- Plan: `context/plans/2026-04-17-buddy-companion-first-intro-copy.md`
- Verification: yes
- Rollback: yes

## Validation
- `node scripts/validate-bmo-operating-system.mjs`
- `git diff --check`
- `cd apps/openclaw-shell-ios && xcodegen generate && xcodebuild test -project BeMoreAgent.xcodeproj -scheme BeMoreAgent -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath .build/DerivedData`
- copy consistency grep for removed intro/front-door technical phrases returned no matches in the edited entry points
