### PR TITLE
fix: resolve pokemon champions contract validation failures

### DIFF
--- a/context/plans/2026-04-18-fix-pokemon-champions-contracts.md
+++ b/context/plans/2026-04-18-fix-pokemon-champions-contracts.md
@@ -1,0 +1,16 @@
+## Problem
+
+The previously merged PR #256 was missing the `contracts/pokemon-champions/team-build-request.schema.json` file and `contracts/pokemon-champions/common.schema.json` lacked a top-level `type: object` declaration. This caused the `scripts/validate-pokemon-team-builder-contracts.mjs` script to fail, leaving the repository in a "red" state.
+
+## Smallest useful wedge
+
+Restore the missing request schema and add the required type declaration to the common schema to ensure full contract validation passes.
+
+## Verification plan
+
+- Run `node scripts/validate-pokemon-team-builder-contracts.mjs` locally to confirm "Pokemon Champions team builder contracts validated."
+- Verify that the `readiness` and `validate` checks pass in GitHub Actions.
+
+## Rollback plan
+
+- Revert the commit adding the missing schema and patching the common schema.

--- a/contracts/pokemon-champions/common.schema.json
+++ b/contracts/pokemon-champions/common.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://bemore.dev/contracts/pokemon-champions/common.schema.json",
   "title": "Pokemon Champions Common Contracts",
+  "type": "object",
   "$defs": {
     "sourceRef": {
       "type": "object",

--- a/contracts/pokemon-champions/team-build-request.schema.json
+++ b/contracts/pokemon-champions/team-build-request.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bemore.dev/contracts/pokemon-champions/team-build-request.schema.json",
+  "title": "Pokemon Champions Team Build Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "regulationId",
+    "snapshotId"
+  ],
+  "properties": {
+    "format": {
+      "type": "string",
+      "enum": [
+        "singles",
+        "doubles"
+      ]
+    },
+    "regulationId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "snapshotId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lockedPokemon": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "stylePreference": {
+      "type": "string",
+      "minLength": 1
+    },
+    "riskTolerance": {
+      "type": "string"
+    },
+    "goal": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dislikedPokemon": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Restores missing team-build-request.schema.json and adds top-level type to common.schema.json to satisfy the project's contract validator.

## Task contract
- Plan: context/plans/2026-04-18-fix-pokemon-champions-contracts.md
- Verification: yes
- Rollback: yes