### PR TITLE
Clarify Buddy app ownership boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ It is the canonical source for BMO startup context, council contracts, operator 
 runbooks, workspace sync, and cross-repo integration glue. It does not pretend to own every live
 surface in the broader system.
 
+It does not own the iPhone app's core lovable Buddy loop. `prismtek-apps` now owns the standalone
+phone-first Buddy product surface: care, training, customization, collection, sparring, and
+trade-ready Buddy packages. `BeMore-stack` remains the deeper operator/runtime truth behind that
+product when the app needs posture, contracts, or integration depth.
+
 ## System boundaries
 
 - `BeMore-stack`: operator workflows, startup context, council policy, GitHub automation, and local
   integration glue
+- `prismtek-apps`: shipped product UX, including the standalone iPhone Buddy companion experience
 - `openclaw`: live Telegram/runtime delivery behavior
 - `prismtek-site`: public-web `prismtek.dev` surface and site-backed APIs
 


### PR DESCRIPTION
## Summary
- clarify that prismtek-apps owns the standalone iPhone Buddy product loop
- keep bmo-stack positioned as the deeper operator/runtime source of truth behind the app

## Task contract
- Verification: yes
- Rollback: yes
- Plan: PR_BODY

## Problem
The repo boundary docs were underspecified after the iPhone Buddy work moved product value into prismtek-apps.

## Smallest useful wedge
Update the bmo-stack front-door README so it explicitly positions bmo-stack as operator/runtime truth and prismtek-apps as the standalone Buddy product owner.

## Verification plan
- review the wording against the current repo split
- let the existing repository workflows validate the docs-only PR contract and repo hygiene

## Rollback plan
Revert the README wording change if it creates boundary confusion or conflicts with the canonical repo map.

## Validation
- docs-only change
- boundary wording reviewed against current repo split