### PR TITLE
fix: repair corrupted Info.plist to resolve CI failure

### DIFF
--- a/apps/openclaw-shell-ios/OpenClawShell/Info.plist
+++ b/apps/openclaw-shell-ios/OpenClawShell/Info.plist
@@ -14,7 +14,8 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.2</string>
-	<key>CFBundleVersion</key>\n	<string>24</string>
+	<key>CFBundleVersion</key>
+	<string>24</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
Fixed a corrupted Info.plist file in the iOS validation shell that was causing PlistBuddy to fail.