### PR TITLE
fix: resolve redeclaration of BuddyAnimationMood

### DIFF
--- a/PLAN-001
+++ b/PLAN-001
@@ -8,6 +8,6 @@ Remove the duplicate declaration from BuddyAsciiView.swift.
 1. Remove the duplicate declaration from BuddyAsciiView.swift.
 2. Verify that the project builds successfully.
 
-## Verification
+## Verification plan
 - Run local build.
 - Ensure CI 'Generate and build BeMoreAgent' passes.

--- a/PLAN-001
+++ b/PLAN-001
@@ -1,4 +1,10 @@
-Plan to resolve BuddyAnimationMood redeclaration:
-1. Identify duplicate declarations of BuddyAnimationMood.
-2. Remove declaration from BuddyAsciiView.swift.
-3. Verify build passes locally and in CI.
+## Problem
+BuddyAnimationMood is declared in both BuddyAsciiView.swift and BuddyVisualModels.swift, causing a compiler error for redeclaration.
+
+## Plan
+1. Remove the duplicate declaration from BuddyAsciiView.swift.
+2. Verify that the project builds successfully.
+
+## Verification
+- Run local build.
+- Ensure CI 'Generate and build BeMoreAgent' passes.

--- a/PLAN-001
+++ b/PLAN-001
@@ -1,0 +1,4 @@
+Plan to resolve BuddyAnimationMood redeclaration:
+1. Identify duplicate declarations of BuddyAnimationMood.
+2. Remove declaration from BuddyAsciiView.swift.
+3. Verify build passes locally and in CI.

--- a/PLAN-001
+++ b/PLAN-001
@@ -1,6 +1,9 @@
 ## Problem
 BuddyAnimationMood is declared in both BuddyAsciiView.swift and BuddyVisualModels.swift, causing a compiler error for redeclaration.
 
+## Smallest useful wedge
+Remove the duplicate declaration from BuddyAsciiView.swift.
+
 ## Plan
 1. Remove the duplicate declaration from BuddyAsciiView.swift.
 2. Verify that the project builds successfully.

--- a/PLAN-001
+++ b/PLAN-001
@@ -11,3 +11,6 @@ Remove the duplicate declaration from BuddyAsciiView.swift.
 ## Verification plan
 - Run local build.
 - Ensure CI 'Generate and build BeMoreAgent' passes.
+
+## Rollback plan
+Revert the commit that removed the declaration from BuddyAsciiView.swift if it causes regressions in ASCII view rendering.

--- a/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyAsciiView.swift
+++ b/apps/openclaw-shell-ios/OpenClawShell/Views/BuddyAsciiView.swift
@@ -1,15 +1,5 @@
 import SwiftUI
 
-enum BuddyAnimationMood {
-    case idle
-    case happy
-    case thinking
-    case working
-    case sleepy
-    case levelUp
-    case needsAttention
-}
-
 struct BuddyAsciiView: View {
     var buddy: BuddyInstance?
     var template: CouncilStarterBuddyTemplate?


### PR DESCRIPTION
Removed duplicate declaration of BuddyAnimationMood in BuddyAsciiView.swift to resolve compiler error.

- Verification: yes

## Task contract
- Plan: `PLAN-001`
- Verification: yes
- Rollback: yes
