### PR TITLE
sync: reconcile main back into master

### DIFF
--- a/docs/remaining-work/stack-remaining-work-checklist.md
+++ b/docs/remaining-work/stack-remaining-work-checklist.md
@@ -1,0 +1,29 @@
+# BeMore stack remaining work checklist
+
+This document tracks the remaining canonical runtime / capability / identity work still needed in `bmo-stack`.
+
+## P0
+
+- Keep the Hermes / BeMore capability contract as the canonical source of truth and verify downstream consumers match it.
+- Validate that the merged capability parity map still matches current runtime/operator expectations.
+
+## P1 — Canonical runtime gaps
+
+- Continue removing legacy OpenClaw naming and compatibility types where they are no longer necessary.
+- Move remaining runtime identity, path, and compatibility surfaces from OpenClaw-centric names to BeMore/Hermes-native names.
+- Ensure posture, council behavior, operator rules, skills/manifests, Codex execution, and runtime discipline docs all reflect the BeMore/Hermes system consistently.
+
+## P1 — Capability parity gaps
+
+- Expand the canonical capability registry and contracts where the app/site now expose linked-account and linked-runtime behavior.
+- Document the trust boundaries clearly for:
+  - native app
+  - linked account
+  - linked runtime
+  - web shell
+- Tighten the separation between innate capabilities, learned skills, and deeper runtime/operator actions.
+
+## P2 — Validation
+
+- Add or strengthen validation/docs around user-taught skill packages and capability compatibility.
+- Add explicit migration notes for repos still consuming OpenClaw-named runtime artifacts or paths.


### PR DESCRIPTION
## Summary
- reconcile the current `main` branch drift back into `master`
- bring the recently merged remaining-work/runtime cleanup docs over to the default branch

## Why
`bmo-stack` currently has both `main` and `master`, while the repo default branch is still `master`. `main` is ahead, which creates avoidable ambiguity for workflows, docs, and operators reading the repo state.

This PR takes the smallest safe step: make `master` match the newer `main` content before any deeper branch-policy decision is made.

## Validation
- branch reconciliation PR only
- content reviewed against current `main...master` drift before opening

## Follow-up still needed
- decide whether the repo should stay on `master` or formally switch its default branch to `main`
- refresh any remaining docs/settings that assume both branches are active lead branches