### PR TITLE
docs: record post-sync branch truth

### DIFF
--- a/docs/remaining-work/stack-remaining-work-checklist.md
+++ b/docs/remaining-work/stack-remaining-work-checklist.md
@@ -6,6 +6,7 @@ This document tracks the remaining canonical runtime / capability / identity wor
 
 - Keep the Hermes / BeMore capability contract as the canonical source of truth and verify downstream consumers match it.
 - Validate that the merged capability parity map still matches current runtime/operator expectations.
+- `master` is the active default branch and the earlier `main -> master` reconciliation removed the practical lead-branch drift. Only keep both names where compatibility or migration notes still require it.
 
 ## P1 — Canonical runtime gaps
 


### PR DESCRIPTION
## Summary
- record that master remains the active default branch
- note that the earlier main-to-master reconciliation removed practical lead-branch drift

## Task contract
- Verification: yes
- Rollback: yes
- Plan: PR_BODY

## Problem
The remaining-work checklist still read like branch drift might still be unresolved even after the merged main-to-master sync follow-up.

## Smallest useful wedge
Add one explicit line to the checklist that documents master as the active default branch and treats dual branch naming as compatibility-only.

## Verification plan
Use the repo-owned automation already triggered on the PR and confirm the docs-only change leaves the existing validation workflows green.

## Rollback plan
Revert this single docs commit to restore the prior checklist wording if the branch-state statement is inaccurate.

## Validation
- docs-only change
- repo automation on PR