### PR TITLE
Mirror Omni-BMO runtime contracts into bmo-stack

### DIFF
--- a/context/plans/2026-04-23-omni-bmo-runtime-contract.md
+++ b/context/plans/2026-04-23-omni-bmo-runtime-contract.md
@@ -1,0 +1,13 @@
+## Problem
+The bmo-stack repository needs to adopt the canonical Omni-BMO runtime contract and related schemas to ensure compatibility with the omni-bmo runtime implementation and downstream products.
+
+## Smallest useful wedge
+Add the Omni-BMO runtime contract mirror, transport and runtime profile schemas, and the remote operator mode runbook to bmo-stack.
+
+## Verification plan
+- Verify that the files `docs/runtime/OMNI_BMO_RUNTIME_CONTRACT.md`, `schemas/transport-state.schema.json`, `schemas/runtime-profile.schema.json`, and `docs/runbooks/OMNI_BMO_REMOTE_OPERATOR_MODE.md` exist and have been added.
+- Check that the content matches the expected mirrors from the omni-bmo repository.
+- Ensure that any existing tests or validation scripts pass.
+
+## Rollback plan
+If any issues arise, remove the added files and revert any changes to the repository. The PR can be closed or reverted.

--- a/docs/runbooks/OMNI_BMO_REMOTE_OPERATOR_MODE.md
+++ b/docs/runbooks/OMNI_BMO_REMOTE_OPERATOR_MODE.md
@@ -1,0 +1,75 @@
+# Omni-BMO Remote Operator Mode
+
+This runbook mirrors the remote-operator split used by Omni-BMO so operator workflows stay consistent across repos.
+
+## Goal
+
+Support two kinds of operator access without conflating them:
+
+- **resilient control path** for text, status, and compact command traffic
+- **rich remote session path** for full UI and desktop control
+
+## Path split
+
+### Resilient control path
+
+Use this for degraded-network or sovereignty-first operation:
+
+- transport mode: `reticulum_fallback`
+- intended payloads: compact command + text status exchange
+- expected tooling family: Reticulum ecosystem bridge / Sideband-style control surface
+
+This path should remain available even when richer streaming access is not.
+
+### Rich remote session path
+
+Use this when the host has enough connectivity for full remote access:
+
+- expected tooling family: Sunshine host + Moonlight client workflows
+- intended payloads: GUI access, troubleshooting, rich operator interaction
+
+This path is helpful, but it must not be treated as a prerequisite for basic control.
+
+## Operator-visible states
+
+### Normal
+
+- `online` is healthy
+- runtime reachable
+- rich remote session optional
+
+### Degraded
+
+- `online` unhealthy
+- `mesh` or `reticulum_fallback` active
+- operator warned that the runtime is in fallback posture
+
+### Control-only
+
+- compact control path available
+- rich remote session unavailable
+- commands and diagnostics should still work
+
+## Required summary fields
+
+Operator surfaces should be able to report:
+
+- selected transport mode
+- last transport reason
+- whether the bridge is reachable
+- whether the remote session path is reachable
+- last heartbeat timestamp
+- whether the runtime is in control-only posture
+
+## Escalation rules
+
+1. Prefer restoring `online` when possible.
+2. If online is down but mesh is healthy, use `mesh`.
+3. If no useful IP route is healthy, keep the runtime reachable via `reticulum_fallback`.
+4. Do not claim the runtime is fully reachable if only a control path is available.
+
+## Downstream boundary
+
+- `omni-bmo` owns the implementation and field behavior
+- `bmo-stack` owns the mirrored operator contract and runbook
+- `prismtek-apps` should only present product-safe pairing and reachability cues

--- a/docs/runtime/OMNI_BMO_RUNTIME_CONTRACT.md
+++ b/docs/runtime/OMNI_BMO_RUNTIME_CONTRACT.md
@@ -1,0 +1,98 @@
+# Omni-BMO Runtime Contract
+
+This document mirrors the Omni-BMO runtime contract at the operator and integration layer.
+
+## Purpose
+
+`omni-bmo` remains the executable runtime reference. `bmo-stack` mirrors the contract here so operators, downstream repos, and runbooks have a canonical source of truth for:
+
+- runtime modes
+- transport state
+- failover expectations
+- profile semantics
+- product-safe adapter boundaries
+
+## Ownership split
+
+- `omni-bmo` — executable runtime implementation, health checks, bridge adapters, operator controls
+- `bmo-stack` — contract mirror, operator runbooks, validation posture, cross-repo boundary documentation
+- `prismtek-apps` — product-safe pairing and reachability surfaces only
+
+## Canonical transport modes
+
+The runtime contract recognizes exactly these modes:
+
+- `online`
+- `mesh`
+- `reticulum_fallback`
+- `auto`
+
+The meanings of those modes must stay aligned with the executable runtime implementation.
+
+## Resolution rules
+
+1. Explicit operator override wins over automatic selection.
+2. `online` is preferred when healthy.
+3. `mesh` is preferred when the online path is unhealthy but mesh access is healthy.
+4. `reticulum_fallback` is the compact resilient control path.
+5. The runtime must always expose the selected mode and the reason for the last transition.
+
+## Required transport state
+
+The mirrored state shape is captured in `schemas/transport-state.schema.json`.
+
+At minimum, downstream integrations should expect:
+
+- `selected_mode`
+- `requested_mode`
+- `last_reason`
+- `online_healthy`
+- `mesh_healthy`
+- `reticulum_available`
+- `last_transition_at`
+- `override_source`
+
+## Runtime profile posture
+
+The mirrored profile shape is captured in `schemas/runtime-profile.schema.json`.
+
+Profiles should remain composable and readable instead of becoming ad hoc shell-only presets.
+
+Current profile families:
+
+- environment profile — `desktop-dev | pi-live | demo-mode | field`
+- latency profile — `snappy | balanced | robust`
+
+Profile material may eventually live in executable files elsewhere, but the shape should stay stable here.
+
+## Downstream adapter rules
+
+### For `prismtek-apps`
+
+Allowed to consume:
+
+- pairing / unpaired state
+- selected transport mode
+- degraded / reachable / control-only status
+- last successful heartbeat
+- remote-session-available indicator
+
+Not allowed to inherit wholesale:
+
+- field operator hotkeys
+- shell-centric diagnostics
+- raw bridge secrets
+- full council / operator workflow semantics
+
+### For operator surfaces
+
+Runbooks should always describe:
+
+- how a mode is selected
+- what degraded means
+- what control-only means
+- how to recover to normal operation
+
+## Source-of-truth rule
+
+When the executable `omni-bmo` implementation evolves, this mirrored contract in `bmo-stack` must be updated in the same change window so downstream repos do not drift.

--- a/schemas/runtime-profile.schema.json
+++ b/schemas/runtime-profile.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "runtime-profile.schema.json",
+  "title": "Omni-BMO Runtime Profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "environment_profile",
+    "latency_profile",
+    "transport_mode",
+    "omni_tool_route_mode",
+    "omni_fallback_to_ollama"
+  ],
+  "properties": {
+    "environment_profile": {
+      "type": "string",
+      "enum": ["desktop-dev", "pi-live", "demo-mode", "field"]
+    },
+    "latency_profile": {
+      "type": "string",
+      "enum": ["snappy", "balanced", "robust"]
+    },
+    "transport_mode": {
+      "type": "string",
+      "enum": ["online", "mesh", "reticulum_fallback", "auto"]
+    },
+    "omni_tool_route_mode": {
+      "type": "string",
+      "enum": ["off", "hybrid", "direct"]
+    },
+    "omni_fallback_to_ollama": {
+      "type": "boolean"
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/transport-state.schema.json
+++ b/schemas/transport-state.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "transport-state.schema.json",
+  "title": "Omni-BMO Transport State",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "selected_mode",
+    "requested_mode",
+    "last_reason",
+    "online_healthy",
+    "mesh_healthy",
+    "reticulum_available",
+    "last_transition_at",
+    "override_source"
+  ],
+  "properties": {
+    "selected_mode": {
+      "type": "string",
+      "enum": ["online", "mesh", "reticulum_fallback", "auto"]
+    },
+    "requested_mode": {
+      "type": "string",
+      "enum": ["online", "mesh", "reticulum_fallback", "auto"]
+    },
+    "last_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "online_healthy": {
+      "type": "boolean"
+    },
+    "mesh_healthy": {
+      "type": "boolean"
+    },
+    "reticulum_available": {
+      "type": "boolean"
+    },
+    "last_transition_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "override_source": {
+      "type": "string",
+      "enum": ["none", "operator_hotkey", "operator_command", "config"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a canonical Omni-BMO runtime contract mirror
- add mirrored transport and runtime profile schemas
- add a remote operator mode runbook for the operator repo

## Why
`bmo-stack` is the right home for the canonical operator-facing contract and runbooks that downstream repos consume. This mirrors the current `omni-bmo` direction without pretending this repo owns the executable runtime.

## Files
- `docs/runtime/OMNI_BMO_RUNTIME_CONTRACT.md`
- `schemas/transport-state.schema.json`
- `schemas/runtime-profile.schema.json`
- `docs/runbooks/OMNI_BMO_REMOTE_OPERATOR_MODE.md`

## Notes
This keeps repo boundaries explicit:
- `omni-bmo` = runtime implementation
- `bmo-stack` = operator contract + runbooks
- `prismtek-apps` = product-safe pairing surfaces

## Task contract
- Plan: `context/plans/2026-04-23-omni-bmo-runtime-contract.md`
- Verification: yes
- Rollback: yes