### PR TITLE
Implement self-evolution core orchestration

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -1,0 +1,8 @@
+# Portable Brain Structure
+
+This directory contains the canonical structure for portable agent state, including brain snapshots, skills, and memory.
+
+## Structure
+- /schema: JSON schemas for brain state
+- /snapshots: Versioned state dumps
+- /skills: Portable skill definitions

--- a/.agent/schema/brain-snapshot.schema.json
+++ b/.agent/schema/brain-snapshot.schema.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "version": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "state": { "type": "object" }
+  },
+  "required": ["version", "timestamp", "state"]
+}

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -1,0 +1,18 @@
+import json
+from typing import List, Dict
+
+class EvalDatasetBuilder:
+    def __init__(self, skill_name: str):
+        self.skill_name = skill_name
+
+    def generate_synthetic_cases(self, count: int = 10) -> List[Dict]:
+        # In a real impl, this would call a strong LLM to generate pairs
+        # For the scaffold, we return structural placeholders
+        return [
+            {"task": f"Synthetic task {i} for {self.skill_name}", "expected": "Rubric-based success criteria"}
+            for i in range(count)
+        ]
+
+    def save_dataset(self, data: List[Dict], path: str):
+        with open(path, 'w') as f:
+            json.dump(data, f, indent=2)

--- a/evolution/core/skill_wrapper.py
+++ b/evolution/core/skill_wrapper.py
@@ -1,0 +1,27 @@
+import dspy
+from typing import List, Tuple
+
+class SkillSignature(dspy.Signature):
+    """
+    Standard signature for evolving a skill.
+    Input: The task and the skill instructions.
+    Output: The agent's response following the skill.
+    """
+    task = dspy.InputField(desc="The specific task to perform")
+    skill_instructions = dspy.InputField(desc="The procedural instructions (SKILL.md)")
+    response = dspy.OutputField(desc="The result of following the skill")
+
+class SkillEvolutionWrapper:
+    def __init__(self, skill_path: str):
+        self.skill_path = skill_path
+        with open(skill_path, 'r') as f:
+            self.instructions = f.read()
+
+    def wrap_as_module(self):
+        # Wraps the skill as a Predictor using the SkillSignature
+        return dspy.Predict(SkillSignature)
+
+    def run_task(self, predictor, task: str) -> str:
+        # Executes the predictor with the current skill instructions
+        result = predictor(task=task, skill_instructions=self.instructions)
+        return result.response

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -1,0 +1,23 @@
+from evolution.core.skill_wrapper import SkillEvolutionWrapper
+from evolution.core.dataset_builder import EvalDatasetBuilder
+
+def main(skill_name: str):
+    print(f"Initializing evolution for skill: {skill_name}")
+    # Assume skills are in skills/ directory for this demo
+    path = f"skills/{skill_name}/SKILL.md" 
+    
+    try:
+        wrapper = SkillEvolutionWrapper(path)
+        builder = EvalDatasetBuilder(skill_name)
+        dataset = builder.generate_synthetic_cases()
+        print(f"Generated {len(dataset)} synthetic test cases.")
+        print("Ready for GEPA optimization loop.")
+    except FileNotFoundError:
+        print(f"Error: Skill file {path} not found.")
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        main(sys.argv[1])
+    else:
+        print("Usage: python -m evolution.skills.evolve_skill <skill_name>")


### PR DESCRIPTION
## Summary
Implements the foundational orchestration layer for agent self-evolution.

## Task contract
- Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem
Self-evolution orchestration must be an operator-level capability rather than runtime behavior.

## Smallest useful wedge
Land the orchestration skeleton, including the Skill-as-DSPy-module wrapper and synthetic dataset builder.

## Invocation & Eval
**Invocation Command**:
`python3 -m evolution.core.dataset_builder` (via local dev environment)

**Eval Fixture Path**:
`evolution/datasets/synthetic_cases.json`

**Dependency List**:
- dspy-ai
- pandas

**Explicit Statements**:
- This PR implements the **orchestration skeleton only**. It does not execute autonomous mutation of prompts or skills.
- All generated prompt or kernel changes must be submitted as separate, reviewable PRs.

## Verification plan
1. **Static Analysis**: Confirm no production runtime paths are modified.
2. **Module Load**: Verify that `evolution.core.skill_wrapper` and `evolution.core.dataset_builder` can be imported without errors.
3. **Skeleton Execution**: Run the dataset builder to verify synthetic case generation logic.

## Rollback plan
Revert this PR to remove the `evolution/` orchestration files.

## Notes
This PR establishes the pipeline for future DSPy-driven optimization of agent skills.
