### PR TITLE
Add Buddy art validation pipeline

### DIFF
--- a/buddy_art/__init__.py
+++ b/buddy_art/__init__.py
@@ -1,0 +1,19 @@
+"""Buddy art validation pipeline.
+
+This package contains the operator-side validators that make generated or edited
+Buddy assets safe to render in app runtimes.
+"""
+
+from .validation import (
+    BuddyValidationError,
+    make_asset_provenance_receipt,
+    validate_ascii_asset,
+    validate_pixel_asset,
+)
+
+__all__ = [
+    "BuddyValidationError",
+    "make_asset_provenance_receipt",
+    "validate_ascii_asset",
+    "validate_pixel_asset",
+]

--- a/buddy_art/validation.py
+++ b/buddy_art/validation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+class BuddyValidationError(ValueError):
+    pass
+
+
+def _base(asset: Mapping[str, Any], style: str) -> list[str]:
+    issues: list[str] = []
+    spec = asset.get("spec") or {}
+    identity = spec.get("identity") or {}
+    canvas = spec.get("canvas") or {}
+    if asset.get("version") != "1.0":
+        issues.append("asset.version must be 1.0")
+    if spec.get("version") != "1.0":
+        issues.append("spec.version must be 1.0")
+    if spec.get("style") != style:
+        issues.append(f"spec.style must be {style}")
+    if not identity.get("species"):
+        issues.append("identity.species is required")
+    if not identity.get("stage"):
+        issues.append("identity.stage is required")
+    if not identity.get("stylePackId"):
+        issues.append("identity.stylePackId is required")
+    if not isinstance(canvas.get("width"), int) or canvas.get("width", 0) <= 0:
+        issues.append("canvas.width must be positive")
+    if not isinstance(canvas.get("height"), int) or canvas.get("height", 0) <= 0:
+        issues.append("canvas.height must be positive")
+    if (asset.get("metadata") or {}).get("normalized") is not True:
+        issues.append("asset must be normalized")
+    if not asset.get("frames"):
+        issues.append("asset.frames is required")
+    return issues
+
+
+def validate_ascii_asset(asset: Mapping[str, Any]) -> dict[str, Any]:
+    issues = _base(asset, "ascii")
+    canvas = (asset.get("spec") or {}).get("canvas") or {}
+    width = canvas.get("width", 0)
+    height = canvas.get("height", 0)
+    for animation, frames in (asset.get("frames") or {}).items():
+        if not isinstance(frames, list) or not frames:
+            issues.append(f"{animation}: frames must be non-empty")
+            continue
+        for index, frame in enumerate(frames):
+            lines = frame.get("lines") if isinstance(frame, dict) else None
+            if not isinstance(lines, list):
+                issues.append(f"{animation}[{index}]: lines must be a list")
+                continue
+            if len(lines) != height:
+                issues.append(f"{animation}[{index}]: expected {height} lines")
+            for line_number, line in enumerate(lines):
+                if not isinstance(line, str) or len(line) != width:
+                    issues.append(f"{animation}[{index}].line[{line_number}] expected width {width}")
+    return {"valid": not issues, "issues": issues}
+
+
+def validate_pixel_asset(asset: Mapping[str, Any]) -> dict[str, Any]:
+    issues = _base(asset, "pixel")
+    canvas = (asset.get("spec") or {}).get("canvas") or {}
+    width = canvas.get("width", 0)
+    height = canvas.get("height", 0)
+    for animation, frames in (asset.get("frames") or {}).items():
+        if not isinstance(frames, list) or not frames:
+            issues.append(f"{animation}: frames must be non-empty")
+            continue
+        for index, frame in enumerate(frames):
+            if not isinstance(frame, dict):
+                issues.append(f"{animation}[{index}]: frame must be an object")
+                continue
+            if frame.get("width") != width:
+                issues.append(f"{animation}[{index}]: frame width must equal canvas width")
+            if frame.get("height") != height:
+                issues.append(f"{animation}[{index}]: frame height must equal canvas height")
+            if not frame.get("imagePath"):
+                issues.append(f"{animation}[{index}]: imagePath is required")
+    return {"valid": not issues, "issues": issues}
+
+
+def make_asset_provenance_receipt(asset: Mapping[str, Any], source: str, generator: str) -> dict[str, Any]:
+    spec = asset.get("spec") or {}
+    identity = spec.get("identity") or {}
+    return {
+        "kind": "buddy_visual_asset_receipt",
+        "asset": f"{identity.get('species')}:{identity.get('stage')}",
+        "source": source,
+        "generator": generator,
+        "style": spec.get("style"),
+        "stylePackId": identity.get("stylePackId"),
+    }

--- a/tests/test_buddy_art_validation.py
+++ b/tests/test_buddy_art_validation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from buddy_art.validation import (
+    make_asset_provenance_receipt,
+    validate_ascii_asset,
+    validate_pixel_asset,
+)
+
+
+def ascii_asset():
+    lines = ["                "] * 16
+    return {
+        "version": "1.0",
+        "spec": {
+            "version": "1.0",
+            "style": "ascii",
+            "identity": {
+                "species": "trex",
+                "stage": "baby",
+                "stylePackId": "ascii-trex-chibi-v1",
+            },
+            "canvas": {"width": 16, "height": 16, "frameCount": 1, "fps": 4},
+        },
+        "frames": {"idle": [{"lines": lines}]},
+        "metadata": {"normalized": True},
+    }
+
+
+def pixel_asset():
+    return {
+        "version": "1.0",
+        "spec": {
+            "version": "1.0",
+            "style": "pixel",
+            "identity": {
+                "species": "trex",
+                "stage": "baby",
+                "stylePackId": "pixel-tamagotchi-v1",
+            },
+            "canvas": {"width": 32, "height": 32, "frameCount": 1, "fps": 6},
+        },
+        "frames": {
+            "idle": [
+                {
+                    "frameId": "trex-baby-idle-0",
+                    "width": 32,
+                    "height": 32,
+                    "imagePath": "assets/buddies/trex/baby/idle-0.png",
+                }
+            ]
+        },
+        "metadata": {"normalized": True, "colorCount": 2},
+    }
+
+
+def test_valid_ascii_asset_passes():
+    result = validate_ascii_asset(ascii_asset())
+    assert result["valid"] is True
+    assert result["issues"] == []
+
+
+def test_invalid_ascii_width_fails():
+    asset = ascii_asset()
+    asset["frames"]["idle"][0]["lines"][0] = "too short"
+    result = validate_ascii_asset(asset)
+    assert result["valid"] is False
+    assert "expected width" in result["issues"][0]
+
+
+def test_valid_pixel_asset_passes():
+    result = validate_pixel_asset(pixel_asset())
+    assert result["valid"] is True
+    assert result["issues"] == []
+
+
+def test_invalid_pixel_frame_size_fails():
+    asset = pixel_asset()
+    asset["frames"]["idle"][0]["width"] = 16
+    result = validate_pixel_asset(asset)
+    assert result["valid"] is False
+    assert "frame width" in result["issues"][0]
+
+
+def test_provenance_receipt_records_source_and_style_pack():
+    receipt = make_asset_provenance_receipt(
+        pixel_asset(), source="pixellab-candidate", generator="validator-test"
+    )
+    assert receipt["kind"] == "buddy_visual_asset_receipt"
+    assert receipt["source"] == "pixellab-candidate"
+    assert receipt["stylePackId"] == "pixel-tamagotchi-v1"


### PR DESCRIPTION
## Summary
- add the first Buddy art validation package
- add ASCII and pixel asset validators
- add provenance receipt helper for generated/imported visual assets
- add tests for valid and invalid ASCII/pixel assets

## Task contract
- Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem
Buddy visual assets must not render raw model output directly. Generated, imported, or edited ASCII/pixel Buddies need a validation gate before app runtime display.

## Smallest useful wedge
Land a pure-Python validation scaffold that can reject invalid ASCII frame dimensions, invalid pixel frame dimensions, missing metadata, and unnormalized assets.

## Verification plan
- existing bmo-stack CI must pass
- Python test suite must include Buddy art validation cases
- invalid ASCII width must fail validation
- invalid pixel dimensions must fail validation
- provenance receipt helper must record source, generator, style, and style pack

## Rollback plan
Revert this PR to remove the `buddy_art/` package and `tests/test_buddy_art_validation.py`.

## Notes
This PR is the validation/scoring foundation for issue #289. It does not integrate Pixellab, BitsyPet, ASCII Motion, or any third-party generator yet. External references remain inspiration only until license/provenance is cleared.