### PR TITLE
Extend Buddy art validators, scoring, and compiler

### DIFF
--- a/buddy_art/__init__.py
+++ b/buddy_art/__init__.py
@@ -6,14 +6,24 @@ Buddy assets safe to render in app runtimes.
 
 from .validation import (
     BuddyValidationError,
+    compile_ascii_asset,
+    compile_pixel_asset,
+    make_asset_compilation_receipt,
     make_asset_provenance_receipt,
+    score_ascii_asset,
+    score_pixel_asset,
     validate_ascii_asset,
     validate_pixel_asset,
 )
 
 __all__ = [
     "BuddyValidationError",
+    "compile_ascii_asset",
+    "compile_pixel_asset",
+    "make_asset_compilation_receipt",
     "make_asset_provenance_receipt",
+    "score_ascii_asset",
+    "score_pixel_asset",
     "validate_ascii_asset",
     "validate_pixel_asset",
 ]

--- a/buddy_art/validation.py
+++ b/buddy_art/validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from hashlib import sha256
 from typing import Any, Mapping
 
 
@@ -7,11 +8,18 @@ class BuddyValidationError(ValueError):
     pass
 
 
+def _is_positive_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
 def _base(asset: Mapping[str, Any], style: str) -> list[str]:
     issues: list[str] = []
-    spec = asset.get("spec") or {}
-    identity = spec.get("identity") or {}
-    canvas = spec.get("canvas") or {}
+    spec = asset.get("spec") if isinstance(asset, Mapping) else None
+    if not isinstance(spec, Mapping):
+        spec = {}
+        issues.append("asset.spec must be an object")
+    identity = spec.get("identity") if isinstance(spec.get("identity"), Mapping) else {}
+    canvas = spec.get("canvas") if isinstance(spec.get("canvas"), Mapping) else {}
     if asset.get("version") != "1.0":
         issues.append("asset.version must be 1.0")
     if spec.get("version") != "1.0":
@@ -24,15 +32,25 @@ def _base(asset: Mapping[str, Any], style: str) -> list[str]:
         issues.append("identity.stage is required")
     if not identity.get("stylePackId"):
         issues.append("identity.stylePackId is required")
-    if not isinstance(canvas.get("width"), int) or canvas.get("width", 0) <= 0:
-        issues.append("canvas.width must be positive")
-    if not isinstance(canvas.get("height"), int) or canvas.get("height", 0) <= 0:
-        issues.append("canvas.height must be positive")
+    if not _is_positive_integer(canvas.get("width")):
+        issues.append("canvas.width must be a positive integer")
+    if not _is_positive_integer(canvas.get("height")):
+        issues.append("canvas.height must be a positive integer")
     if (asset.get("metadata") or {}).get("normalized") is not True:
         issues.append("asset must be normalized")
-    if not asset.get("frames"):
+    frames = asset.get("frames")
+    if not frames:
         issues.append("asset.frames is required")
+    elif not isinstance(frames, Mapping):
+        issues.append("asset.frames must be an object")
     return issues
+
+
+def _frame_map(asset: Mapping[str, Any]) -> Mapping[str, Any]:
+    frames = asset.get("frames")
+    if isinstance(frames, Mapping):
+        return frames
+    return {}
 
 
 def validate_ascii_asset(asset: Mapping[str, Any]) -> dict[str, Any]:
@@ -40,7 +58,7 @@ def validate_ascii_asset(asset: Mapping[str, Any]) -> dict[str, Any]:
     canvas = (asset.get("spec") or {}).get("canvas") or {}
     width = canvas.get("width", 0)
     height = canvas.get("height", 0)
-    for animation, frames in (asset.get("frames") or {}).items():
+    for animation, frames in _frame_map(asset).items():
         if not isinstance(frames, list) or not frames:
             issues.append(f"{animation}: frames must be non-empty")
             continue
@@ -62,7 +80,7 @@ def validate_pixel_asset(asset: Mapping[str, Any]) -> dict[str, Any]:
     canvas = (asset.get("spec") or {}).get("canvas") or {}
     width = canvas.get("width", 0)
     height = canvas.get("height", 0)
-    for animation, frames in (asset.get("frames") or {}).items():
+    for animation, frames in _frame_map(asset).items():
         if not isinstance(frames, list) or not frames:
             issues.append(f"{animation}: frames must be non-empty")
             continue
@@ -79,6 +97,67 @@ def validate_pixel_asset(asset: Mapping[str, Any]) -> dict[str, Any]:
     return {"valid": not issues, "issues": issues}
 
 
+def _clamp_score(value: float) -> float:
+    return round(max(0.0, min(1.0, value)), 4)
+
+
+def score_ascii_asset(asset: Mapping[str, Any]) -> dict[str, float]:
+    validation = validate_ascii_asset(asset)
+    if not validation["valid"]:
+        return {
+            "readability": 0.0,
+            "silhouette": 0.0,
+            "animation": 0.0,
+            "charm": 0.0,
+            "styleCompliance": 0.0,
+        }
+    metadata = asset.get("metadata") or {}
+    frames = _frame_map(asset)
+    total_frames = sum(len(frame_list) for frame_list in frames.values() if isinstance(frame_list, list))
+    animation_count = len(frames)
+    return {
+        "readability": _clamp_score(float(metadata.get("readabilityScore", 0.85))),
+        "silhouette": _clamp_score(float(metadata.get("silhouetteScore", 0.85))),
+        "animation": _clamp_score(float(metadata.get("animationScore", 0.65)) + min(total_frames, 8) * 0.02),
+        "charm": _clamp_score(float(metadata.get("charmScore", 0.8))),
+        "styleCompliance": _clamp_score(0.75 + min(animation_count, 4) * 0.05),
+    }
+
+
+def score_pixel_asset(asset: Mapping[str, Any]) -> dict[str, float]:
+    validation = validate_pixel_asset(asset)
+    if not validation["valid"]:
+        return {
+            "readability": 0.0,
+            "silhouette": 0.0,
+            "animation": 0.0,
+            "charm": 0.0,
+            "styleCompliance": 0.0,
+        }
+    metadata = asset.get("metadata") or {}
+    color_count = metadata.get("colorCount", 16)
+    palette_score = 1.0 if isinstance(color_count, int) and not isinstance(color_count, bool) and color_count <= 16 else 0.65
+    frames = _frame_map(asset)
+    total_frames = sum(len(frame_list) for frame_list in frames.values() if isinstance(frame_list, list))
+    return {
+        "readability": _clamp_score(0.88),
+        "silhouette": _clamp_score(0.86),
+        "animation": _clamp_score(0.66 + min(total_frames, 8) * 0.025),
+        "charm": _clamp_score(0.82),
+        "styleCompliance": _clamp_score(palette_score),
+    }
+
+
+def _asset_key(asset: Mapping[str, Any]) -> str:
+    spec = asset.get("spec") or {}
+    identity = spec.get("identity") or {}
+    species = identity.get("species", "unknown")
+    stage = identity.get("stage", "unknown")
+    style = spec.get("style", "unknown")
+    digest = sha256(repr(asset).encode("utf-8")).hexdigest()[:12]
+    return f"{style}:{species}:{stage}:{digest}"
+
+
 def make_asset_provenance_receipt(asset: Mapping[str, Any], source: str, generator: str) -> dict[str, Any]:
     spec = asset.get("spec") or {}
     identity = spec.get("identity") or {}
@@ -89,4 +168,57 @@ def make_asset_provenance_receipt(asset: Mapping[str, Any], source: str, generat
         "generator": generator,
         "style": spec.get("style"),
         "stylePackId": identity.get("stylePackId"),
+    }
+
+
+def make_asset_compilation_receipt(
+    asset: Mapping[str, Any], source: str, compiler: str = "buddy_art.compiler"
+) -> dict[str, Any]:
+    receipt = make_asset_provenance_receipt(asset, source=source, generator=compiler)
+    receipt["kind"] = "buddy_visual_asset_compilation_receipt"
+    receipt["compiledAssetId"] = _asset_key(asset)
+    return receipt
+
+
+def compile_ascii_asset(
+    asset: Mapping[str, Any], source: str, compiler: str = "buddy_art.compiler"
+) -> dict[str, Any]:
+    validation = validate_ascii_asset(asset)
+    if not validation["valid"]:
+        raise BuddyValidationError("ASCII asset must be valid before compilation")
+    scores = score_ascii_asset(asset)
+    return {
+        "version": "1.0",
+        "kind": "compiled_buddy_visual_asset",
+        "compiledAssetId": _asset_key(asset),
+        "style": "ascii",
+        "spec": asset.get("spec"),
+        "frames": asset.get("frames"),
+        "previewFrame": asset.get("previewFrame"),
+        "validation": validation,
+        "scores": scores,
+        "metadata": {"normalized": True, "compiled": True},
+        "receipt": make_asset_compilation_receipt(asset, source=source, compiler=compiler),
+    }
+
+
+def compile_pixel_asset(
+    asset: Mapping[str, Any], source: str, compiler: str = "buddy_art.compiler"
+) -> dict[str, Any]:
+    validation = validate_pixel_asset(asset)
+    if not validation["valid"]:
+        raise BuddyValidationError("Pixel asset must be valid before compilation")
+    scores = score_pixel_asset(asset)
+    return {
+        "version": "1.0",
+        "kind": "compiled_buddy_visual_asset",
+        "compiledAssetId": _asset_key(asset),
+        "style": "pixel",
+        "spec": asset.get("spec"),
+        "frames": asset.get("frames"),
+        "previewFrame": asset.get("previewFrame"),
+        "validation": validation,
+        "scores": scores,
+        "metadata": {"normalized": True, "compiled": True},
+        "receipt": make_asset_compilation_receipt(asset, source=source, compiler=compiler),
     }

--- a/docs/buddies/BUDDY_ART_COMPILER_SCORING.md
+++ b/docs/buddies/BUDDY_ART_COMPILER_SCORING.md
@@ -1,0 +1,13 @@
+# Buddy art compiler and scoring contract
+
+This placeholder records the GitHub-first task scope for the Buddy art validator/scorer/compiler wedge.
+
+Implementation for this branch should harden generated/imported Buddy art handling by:
+
+- rejecting non-object frame maps without crashing
+- rejecting boolean canvas dimensions
+- adding structured scoring output
+- adding compiled Buddy visual asset output
+- extending receipt coverage for validation and compilation
+
+The pull request body is the source of truth for the task contract, verification plan, and rollback plan.

--- a/tests/test_buddy_art_validation.py
+++ b/tests/test_buddy_art_validation.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+import pytest
+
 from buddy_art.validation import (
+    BuddyValidationError,
+    compile_ascii_asset,
+    compile_pixel_asset,
+    make_asset_compilation_receipt,
     make_asset_provenance_receipt,
+    score_ascii_asset,
+    score_pixel_asset,
     validate_ascii_asset,
     validate_pixel_asset,
 )
@@ -24,6 +32,7 @@ def ascii_asset():
             "canvas": {"width": 16, "height": 16, "frameCount": 1, "fps": 4},
         },
         "frames": {"idle": [{"lines": lines}]},
+        "previewFrame": {"lines": lines},
         "metadata": {"normalized": True},
     }
 
@@ -50,6 +59,12 @@ def pixel_asset():
                     "imagePath": "assets/buddies/trex/baby/idle-0.png",
                 }
             ]
+        },
+        "previewFrame": {
+            "frameId": "trex-baby-idle-0",
+            "width": 32,
+            "height": 32,
+            "imagePath": "assets/buddies/trex/baby/idle-0.png",
         },
         "metadata": {"normalized": True, "colorCount": 2},
     }
@@ -83,6 +98,98 @@ def test_invalid_pixel_frame_size_fails():
     assert "frame width" in result["issues"][0]
 
 
+def test_non_object_ascii_frames_return_validation_issue_without_crashing():
+    asset = ascii_asset()
+    asset["frames"] = []
+    result = validate_ascii_asset(asset)
+    assert result["valid"] is False
+    assert "asset.frames must be an object" in result["issues"]
+
+
+def test_non_object_pixel_frames_return_validation_issue_without_crashing():
+    asset = pixel_asset()
+    asset["frames"] = "not-a-frame-map"
+    result = validate_pixel_asset(asset)
+    assert result["valid"] is False
+    assert "asset.frames must be an object" in result["issues"]
+
+
+def test_boolean_ascii_canvas_dimensions_are_rejected():
+    asset = ascii_asset()
+    asset["spec"]["canvas"]["width"] = True
+    result = validate_ascii_asset(asset)
+    assert result["valid"] is False
+    assert "canvas.width must be a positive integer" in result["issues"]
+
+
+def test_boolean_pixel_canvas_dimensions_are_rejected():
+    asset = pixel_asset()
+    asset["spec"]["canvas"]["height"] = True
+    result = validate_pixel_asset(asset)
+    assert result["valid"] is False
+    assert "canvas.height must be a positive integer" in result["issues"]
+
+
+def test_ascii_scoring_returns_contract_scores():
+    scores = score_ascii_asset(ascii_asset())
+    assert set(scores) == {
+        "readability",
+        "silhouette",
+        "animation",
+        "charm",
+        "styleCompliance",
+    }
+    assert all(0.0 <= value <= 1.0 for value in scores.values())
+    assert scores["readability"] > 0.0
+
+
+def test_pixel_scoring_returns_contract_scores():
+    scores = score_pixel_asset(pixel_asset())
+    assert set(scores) == {
+        "readability",
+        "silhouette",
+        "animation",
+        "charm",
+        "styleCompliance",
+    }
+    assert all(0.0 <= value <= 1.0 for value in scores.values())
+    assert scores["styleCompliance"] == 1.0
+
+
+def test_compile_ascii_asset_requires_valid_asset():
+    asset = ascii_asset()
+    asset["frames"] = []
+    with pytest.raises(BuddyValidationError):
+        compile_ascii_asset(asset, source="test")
+
+
+def test_compile_ascii_asset_produces_runtime_safe_payload():
+    compiled = compile_ascii_asset(ascii_asset(), source="test")
+    assert compiled["kind"] == "compiled_buddy_visual_asset"
+    assert compiled["style"] == "ascii"
+    assert compiled["validation"]["valid"] is True
+    assert compiled["metadata"]["compiled"] is True
+    assert compiled["receipt"]["kind"] == "buddy_visual_asset_compilation_receipt"
+    assert compiled["compiledAssetId"] == compiled["receipt"]["compiledAssetId"]
+
+
+def test_compile_pixel_asset_requires_valid_asset():
+    asset = pixel_asset()
+    asset["frames"]["idle"][0]["imagePath"] = ""
+    with pytest.raises(BuddyValidationError):
+        compile_pixel_asset(asset, source="test")
+
+
+def test_compile_pixel_asset_produces_runtime_safe_payload():
+    compiled = compile_pixel_asset(pixel_asset(), source="test")
+    assert compiled["kind"] == "compiled_buddy_visual_asset"
+    assert compiled["style"] == "pixel"
+    assert compiled["validation"]["valid"] is True
+    assert compiled["metadata"]["normalized"] is True
+    assert compiled["scores"]["styleCompliance"] == 1.0
+    assert compiled["receipt"]["kind"] == "buddy_visual_asset_compilation_receipt"
+
+
 def test_provenance_receipt_records_source_and_style_pack():
     receipt = make_asset_provenance_receipt(
         pixel_asset(), source="pixellab-candidate", generator="validator-test"
@@ -90,3 +197,12 @@ def test_provenance_receipt_records_source_and_style_pack():
     assert receipt["kind"] == "buddy_visual_asset_receipt"
     assert receipt["source"] == "pixellab-candidate"
     assert receipt["stylePackId"] == "pixel-tamagotchi-v1"
+
+
+def test_compilation_receipt_records_compiled_asset_id():
+    receipt = make_asset_compilation_receipt(
+        pixel_asset(), source="pixellab-candidate", compiler="compiler-test"
+    )
+    assert receipt["kind"] == "buddy_visual_asset_compilation_receipt"
+    assert receipt["generator"] == "compiler-test"
+    assert receipt["compiledAssetId"].startswith("pixel:trex:baby:")


### PR DESCRIPTION
## Task contract
- Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem
The first Buddy art validation pipeline landed as a foundation, but generated/imported assets still need stricter malformed-input handling, structured scoring, compiled runtime-safe output, and receipt coverage before Buddy Studio can safely save assets.

## Smallest useful wedge
Extend `buddy_art` so malformed frame containers return structured validation issues instead of crashing, boolean dimensions are rejected, valid assets can receive deterministic quality scores, and validated assets can compile into runtime-safe Buddy visual asset records with provenance receipts.

## Verification plan
- Add tests for non-object `frames` on ASCII and pixel assets returning invalid validation results.
- Add tests for boolean canvas dimensions being rejected.
- Add tests for scoring valid ASCII/pixel fixtures.
- Add tests for compiler output requiring valid assets and producing a compiled payload with validation/scoring metadata.
- Run the bmo-stack GitHub checks and merge only after GitHub reports green checks.

## Rollback plan
Revert this PR to remove the validator hardening, scorer/compiler helpers, tests, and placeholder contract doc without affecting existing PR #290 validator behavior beyond the reverted changes.