### PR TITLE
chore(donors): refresh fork inventory

### DIFF
--- a/DONORS.yaml
+++ b/DONORS.yaml
@@ -1,7 +1,7 @@
 version: 1
 owner: 'codysumpter-cloud'
 generated_by: 'scripts/fork-governor.mjs'
-generated_at: '2026-04-24T17:56:36.124Z'
+generated_at: '2026-04-24T19:29:06.109Z'
 total_forks: 44
 forks:
   - name: 'agentic-stack'
@@ -38,7 +38,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/aseprite-windows-docker-build'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'autoresearch'
     full_name: 'codysumpter-cloud/autoresearch'
@@ -83,7 +83,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/chumpy'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'claw-code'
     full_name: 'codysumpter-cloud/claw-code'
@@ -110,7 +110,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/docker-aseprite-linux'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'gbrain'
     full_name: 'codysumpter-cloud/gbrain'
@@ -290,7 +290,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/mlc-llm'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'mlx-swift'
     full_name: 'codysumpter-cloud/mlx-swift'
@@ -299,7 +299,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/mlx-swift'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'mlx-swift-examples'
     full_name: 'codysumpter-cloud/mlx-swift-examples'
@@ -308,7 +308,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/mlx-swift-examples'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'moonlight-docs'
     full_name: 'codysumpter-cloud/moonlight-docs'
@@ -344,7 +344,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/pixellab-js'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'pixellab-mcp'
     full_name: 'codysumpter-cloud/pixellab-mcp'
@@ -353,7 +353,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/pixellab-mcp'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'pixellab-python'
     full_name: 'codysumpter-cloud/pixellab-python'
@@ -362,7 +362,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/pixellab-python'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'sideband'
     full_name: 'codysumpter-cloud/sideband'
@@ -389,7 +389,7 @@ forks:
     html_url: 'https://github.com/codysumpter-cloud/tamagoscii'
     upstream_full_name: null
     archived: false
-    sync_workflow_status: 'created'
+    sync_workflow_status: 'unchanged'
     sync_workflow_path: '.github/workflows/sync-fork-upstream.yml'
   - name: 'twenty'
     full_name: 'codysumpter-cloud/twenty'


### PR DESCRIPTION
## Summary
- refresh `DONORS.yaml` from live fork inventory
- bootstrap the upstream sync workflow into newly discovered forks
- surface repo-level blockers through generated donor status fields

## Task contract
- task type: donor inventory refresh
- scope: `DONORS.yaml` and fork sync metadata only
- out of scope: product code, runtime behavior, and release changes
- validation: existing `task-readiness`, `ci`, and smoke workflows on this PR
- Verification: yes
- Rollback: yes

Plan: `PR_BODY`

## Problem
The generated donor inventory PR must describe its scope and rollback path well enough for the readiness gate to allow automation-managed assimilation work to proceed.

## Smallest useful wedge
Keep this PR limited to `DONORS.yaml` and fork-governor metadata refresh output, with no product or release changes mixed in.

## Verification plan
Re-run the existing `task-readiness`, `ci`, and smoke workflows on this PR and require them to pass against the updated body contract.

## Rollback plan
If the inventory refresh is incorrect, revert this PR or regenerate the donor inventory from the previous known-good automation inputs.

## Notes
This PR is generated by the fork governor workflow.
If a fork is locked or needs manual resolution, that status will appear in `DONORS.yaml`.
