### PR TITLE
docs(ios): clarify MLCSwift rollback boundary

### DIFF
--- a/apps/openclaw-shell-ios/LOCAL_RUNTIME_BLOCKERS.md
+++ b/apps/openclaw-shell-ios/LOCAL_RUNTIME_BLOCKERS.md
@@ -16,6 +16,16 @@ This file records the exact blockers for honest on-device runtime completion on 
 3. There is no device-level proof on current `master` showing a selected local model generating a real response on-device.
 4. Because those pieces are missing, any PR that claims the local runtime is complete would be dishonest.
 
+## MLCSwift linking guardrail
+
+Do not fix local-runtime instability by reverting unrelated documentation, response guidance, plist cleanup, or Buddy UI model changes. The safe rollback boundary is the runtime dependency/linking surface itself:
+
+- `apps/openclaw-shell-ios/project.yml`
+- `apps/openclaw-shell-ios/OpenClawShell/RuntimeServices.swift`
+- any future vendored runtime framework or Swift package wiring
+
+If a future MLCSwift integration breaks the lead branch, revert or isolate that runtime wiring directly and leave unrelated docs, Info.plist formatting, and `BuddyAnimationMood` ownership intact.
+
 ## Honest definition of done
 
 A local-runtime PR is only complete when all of the following are true:


### PR DESCRIPTION
## Summary
- replace the unsafe broad revert with a narrow local-runtime rollback guardrail
- document that MLCSwift instability should be isolated to runtime wiring, not unrelated docs, plist formatting, or Buddy UI model ownership

## Task contract
Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem
The original branch attempted to revert a broad historical merge and would have reintroduced unrelated regressions, including a broken `Info.plist` newline, duplicate `BuddyAnimationMood` ownership, and removal of useful docs/guidance.

## Smallest useful wedge
Reset the branch to current `master` and add a focused guardrail to `apps/openclaw-shell-ios/LOCAL_RUNTIME_BLOCKERS.md` that defines the safe MLCSwift rollback boundary.

## Verification plan
Use the pull request checks for this PR, including `ci`, `lint`, `task-readiness`, CodeQL, and the iOS validation workflow.

## Rollback plan
Revert this PR to remove only the added guardrail section from `LOCAL_RUNTIME_BLOCKERS.md`.