### PR TITLE
Add optional AgentCraft local observability bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host context-reseed worker-create worker-upload-config worker-connect worker-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync openclaw-boundary-doctor openclaw-host-policy project-snapshot continuity-report continuity-publish site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-donor-extract site-page-checklist site-parity-matrix site-parity-report site-parity-update site-react-template launchd-install durable-init durable-run-next durable-status durable-resume durable-cancel
+.PHONY: up down status logs doctor sync-context sync-context-host-to-repo sync-context-repo-to-host context-reseed worker-create worker-upload-config worker-connect worker-status recover-session worker-ready health-check doctor-plus checkpoint omni-sync omni-doctor omni-launch recover-bmo update-all runtime-doctor runtime-profile-dev runtime-profile-snappy runtime-profile-robust runtime-face-idle runtime-loop runtime-router runtime-profile2-dev runtime-profile2-snappy runtime-profile2-robust runtime-stt-once runtime-face-rich-idle runtime-launch runtime-launch-dry runtime-cloud-once runtime-cloud-dry workspace-sync openclaw-boundary-doctor openclaw-host-policy project-snapshot continuity-report continuity-publish site-caretaker site-route-report site-work-report site-route-scaffold site-route-update site-donor-extract site-page-checklist site-parity-matrix site-parity-report site-parity-update site-react-template launchd-install durable-init durable-run-next durable-status durable-resume durable-cancel agentcraft-start agentcraft-stop agentcraft-doctor agentcraft-health agentcraft-smoke
 
 # Docker Compose file
 COMPOSE_FILE=compose.yaml
+AGENTCRAFT_PORT ?= 2468
+AGENTCRAFT_EVENT_URL ?= http://localhost:$(AGENTCRAFT_PORT)/event
 
 up:
 	docker compose -f $(COMPOSE_FILE) up -d
@@ -234,3 +236,21 @@ durable-resume:
 
 durable-cancel:
 	@python3 ./scripts/durable_task_runtime.py cancel $(if $(ARGS),$(ARGS))
+
+agentcraft-start:
+	@npx @idosal/agentcraft start --all-projects --port $(AGENTCRAFT_PORT) -d
+
+agentcraft-stop:
+	@npx @idosal/agentcraft stop
+
+agentcraft-doctor:
+	@npx @idosal/agentcraft doctor
+
+agentcraft-health:
+	@curl -sf http://localhost:$(AGENTCRAFT_PORT)/health
+
+agentcraft-smoke:
+	@node ./scripts/agentcraft-report.mjs hero_active
+	@AGENTCRAFT_ENABLED=1 AGENTCRAFT_EVENT_URL=$(AGENTCRAFT_EVENT_URL) node ./scripts/agentcraft-report.mjs hero_active
+	@AGENTCRAFT_ENABLED=1 AGENTCRAFT_EVENT_URL=$(AGENTCRAFT_EVENT_URL) node ./scripts/agentcraft-report.mjs mission_start '{"name":"BMO smoke test","prompt":"redacted smoke test"}'
+	@AGENTCRAFT_ENABLED=1 AGENTCRAFT_EVENT_URL=$(AGENTCRAFT_EVENT_URL) node ./scripts/agentcraft-report.mjs hero_idle

--- a/config/agentcraft.safe.json
+++ b/config/agentcraft.safe.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "enabledByDefault": false,
+  "eventUrl": "http://localhost:2468/event",
+  "client": "bmo-stack",
+  "redactPrompts": true,
+  "maxCommandChars": 120,
+  "reportingMode": "optional-observability",
+  "failureMode": "do-not-fail-runtime",
+  "sourceOfTruth": [
+    "contracts/buddy_runtime.md",
+    "BUDDY_RUNTIME_EVENTS_FILES.md",
+    "docs/AGENTCRAFT_INTEGRATION.md"
+  ],
+  "allowedEventTypes": [
+    "hero_active",
+    "mission_start",
+    "file_access",
+    "bash_command",
+    "hero_idle"
+  ],
+  "nonGoals": [
+    "runtime authority",
+    "approval bypass",
+    "durable memory evidence",
+    "persistence receipt"
+  ]
+}

--- a/docs/AGENTCRAFT_INTEGRATION.md
+++ b/docs/AGENTCRAFT_INTEGRATION.md
@@ -1,0 +1,91 @@
+# AgentCraft Integration
+
+## Purpose
+
+AgentCraft is an optional local observability overlay for BMO operator work. It can show active sessions, mission starts, file access summaries, command summaries, and idle states in a browser HUD.
+
+It is not the source of truth for BMO runtime state, approvals, receipts, policy, memory, or persistence claims.
+
+## Ownership boundary
+
+- `bmo-stack` owns runtime policy, council review, approvals, receipts, worktree discipline, and validation.
+- AgentCraft owns the local visual HUD.
+- BeMore and Prismtek app surfaces may consume approved runtime summaries, but should not treat AgentCraft as a command authority.
+
+## Safety defaults
+
+The bridge is disabled by default.
+
+```bash
+AGENTCRAFT_ENABLED=1 node scripts/agentcraft-report.mjs hero_active
+```
+
+Default behavior:
+
+- posts to the local AgentCraft server only
+- redacts prompt text by default
+- redacts common secret-like fields and token patterns
+- truncates command summaries to 120 characters by default
+- never fails the BMO runtime path if AgentCraft is offline
+
+## Local usage
+
+Start AgentCraft:
+
+```bash
+make agentcraft-start
+```
+
+Check the local AgentCraft server:
+
+```bash
+make agentcraft-health
+```
+
+Send a dry smoke event without transmission:
+
+```bash
+node scripts/agentcraft-report.mjs hero_active
+```
+
+Send local smoke events:
+
+```bash
+AGENTCRAFT_ENABLED=1 node scripts/agentcraft-report.mjs hero_active
+AGENTCRAFT_ENABLED=1 node scripts/agentcraft-report.mjs mission_start '{"name":"BMO smoke test","prompt":"redacted smoke test"}'
+AGENTCRAFT_ENABLED=1 node scripts/agentcraft-report.mjs hero_idle
+```
+
+Stop AgentCraft:
+
+```bash
+make agentcraft-stop
+```
+
+## Event mapping
+
+| BMO runtime event | AgentCraft event | Notes |
+| --- | --- | --- |
+| `launch_task` | `hero_active`, `mission_start` | Mission prompt is redacted by default. |
+| `status: thinking` | `hero_active` | HUD-only status cue. |
+| `status: acting` | `hero_active` | HUD-only status cue. |
+| file read/write/edit receipt | `file_access` | Prefer relative paths where possible. |
+| guarded command receipt | `bash_command` | Summary is truncated by default. |
+| `diff_proposed` | `file_access` | Treat as preview, not persistence. |
+| `status: completed` | `hero_idle` | Completion claim still requires BMO receipt. |
+| `status: failed` | `hero_idle` | Include error summary only after redaction. |
+
+## Recommended checks
+
+```bash
+make agentcraft-doctor
+make agentcraft-health || true
+make runtime-doctor
+```
+
+## Non-goals
+
+- Do not let AgentCraft bypass BMO approvals.
+- Do not expose browser-triggered local command execution.
+- Do not use AgentCraft events as durable memory evidence.
+- Do not claim install, publish, persistence, or file mutation success without BMO receipts.

--- a/operator-surface.manifest.json
+++ b/operator-surface.manifest.json
@@ -44,6 +44,12 @@
       "name": "Companion UX and resilience cues",
       "owner": "shared",
       "description": "Carry companion modes, Kairos world-state, and graceful degraded-state cues across the public and local surfaces."
+    },
+    {
+      "id": "agentcraft-observability",
+      "name": "AgentCraft local observability",
+      "owner": "local",
+      "description": "Mirror approved BMO runtime lifecycle cues into a local HUD without changing runtime authority."
     }
   ],
   "documentShortcuts": [
@@ -64,6 +70,12 @@
       "name": "Private App Repo Integration",
       "path": "docs/PRIVATE_APP_REPO_INTEGRATION.md",
       "description": "How prismtek.dev_mega-app and BMO-app map into Builder Studio, Prism Agent, and BMO."
+    },
+    {
+      "id": "agentcraft-integration",
+      "name": "AgentCraft Integration",
+      "path": "docs/AGENTCRAFT_INTEGRATION.md",
+      "description": "Local-only AgentCraft HUD bridge, event mapping, and safety defaults."
     }
   ],
   "validationActions": [
@@ -90,6 +102,24 @@
       "name": "Runtime doctor",
       "command": "make runtime-doctor",
       "description": "Validate runtime profile and launch assumptions."
+    },
+    {
+      "id": "agentcraft-doctor",
+      "name": "AgentCraft doctor",
+      "command": "make agentcraft-doctor",
+      "description": "Validate the optional local AgentCraft HUD integration."
+    },
+    {
+      "id": "agentcraft-health",
+      "name": "AgentCraft health",
+      "command": "make agentcraft-health",
+      "description": "Check whether the local AgentCraft server is reachable."
+    },
+    {
+      "id": "agentcraft-smoke",
+      "name": "AgentCraft smoke events",
+      "command": "make agentcraft-smoke",
+      "description": "Emit redacted smoke events through the optional AgentCraft reporter."
     }
   ]
 }

--- a/scripts/agentcraft-report.mjs
+++ b/scripts/agentcraft-report.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import process from "node:process";
+
+const DEFAULT_ENDPOINT = "http://localhost:2468/event";
+const DEFAULT_COMMAND_LIMIT = 120;
+
+function envFlag(name, defaultValue = false) {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return defaultValue;
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}
+
+function stableSessionId(cwd = process.cwd()) {
+  const hash = crypto.createHash("md5").update(cwd).digest("hex").slice(0, 12);
+  return `bmo_${hash}`;
+}
+
+function isLocalEndpoint(value) {
+  try {
+    const url = new URL(value);
+    return ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function parsePayload(rawParts) {
+  if (rawParts.length === 0) return {};
+  const raw = rawParts.join(" ").trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Payload must be valid JSON: ${error.message}`);
+  }
+}
+
+function redactSecrets(value) {
+  if (Array.isArray(value)) {
+    return value.map(redactSecrets);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => {
+        if (/token|secret|password|authorization|cookie|api[_-]?key/i.test(key)) {
+          return [key, "[redacted]"];
+        }
+        return [key, redactSecrets(nested)];
+      }),
+    );
+  }
+  if (typeof value === "string") {
+    return value
+      .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+      .replace(/sk-[A-Za-z0-9_-]{12,}/g, "sk-[redacted]")
+      .replace(/gh[pousr]_[A-Za-z0-9_]{12,}/g, "gh_[redacted]");
+  }
+  return value;
+}
+
+function normalizeEvent(type, payload) {
+  const cwd = payload.cwd ?? process.cwd();
+  const redactedPayload = redactSecrets(payload);
+  const redactPrompts = envFlag("AGENTCRAFT_REDACT_PROMPTS", true);
+  const maxCommandChars = Number.parseInt(
+    process.env.AGENTCRAFT_MAX_COMMAND_CHARS ?? `${DEFAULT_COMMAND_LIMIT}`,
+    10,
+  );
+
+  const event = {
+    client: process.env.AGENTCRAFT_CLIENT ?? "bmo-stack",
+    sessionId: process.env.AGENTCRAFT_SESSION_ID ?? payload.sessionId ?? stableSessionId(cwd),
+    cwd,
+    type,
+    ...redactedPayload,
+  };
+
+  if (redactPrompts && typeof event.prompt === "string") {
+    event.prompt = "[redacted]";
+  }
+
+  if (typeof event.command === "string" && Number.isFinite(maxCommandChars) && maxCommandChars > 0) {
+    event.command = event.command.slice(0, maxCommandChars);
+  }
+
+  return event;
+}
+
+async function postEvent(event) {
+  const endpoint = process.env.AGENTCRAFT_EVENT_URL ?? DEFAULT_ENDPOINT;
+  const allowRemote = envFlag("AGENTCRAFT_ALLOW_REMOTE", false);
+
+  if (!isLocalEndpoint(endpoint) && !allowRemote) {
+    return {
+      ok: false,
+      skipped: true,
+      reason: "non-local endpoint rejected; set AGENTCRAFT_ALLOW_REMOTE=1 to override",
+    };
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(event),
+    signal: AbortSignal.timeout(Number.parseInt(process.env.AGENTCRAFT_TIMEOUT_MS ?? "750", 10)),
+  });
+
+  return { ok: response.ok, status: response.status };
+}
+
+async function main() {
+  const [type, ...rawPayload] = process.argv.slice(2);
+  if (!type) {
+    console.error("Usage: agentcraft-report.mjs <event-type> [json-payload]");
+    process.exit(2);
+  }
+
+  const payload = parsePayload(rawPayload);
+  const event = normalizeEvent(type, payload);
+
+  if (!envFlag("AGENTCRAFT_ENABLED", false)) {
+    console.log(JSON.stringify({ ok: true, skipped: true, reason: "AGENTCRAFT_ENABLED is not set", event }));
+    return;
+  }
+
+  try {
+    const result = await postEvent(event);
+    console.log(JSON.stringify({ ...result, event }));
+  } catch (error) {
+    // AgentCraft is an optional observability overlay. Never fail the actual runtime path.
+    console.log(JSON.stringify({ ok: false, skipped: true, reason: error.message, event }));
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(2);
+});

--- a/scripts/agentcraft-report.mjs
+++ b/scripts/agentcraft-report.mjs
@@ -17,10 +17,10 @@ function stableSessionId(cwd = process.cwd()) {
   return `bmo_${hash}`;
 }
 
-function isLocalEndpoint(value) {
+function isLocalHttpEndpoint(value) {
   try {
     const url = new URL(value);
-    return ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+    return ["http:", "https:"].includes(url.protocol) && ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
   } catch {
     return false;
   }
@@ -90,13 +90,12 @@ function normalizeEvent(type, payload) {
 
 async function postEvent(event) {
   const endpoint = process.env.AGENTCRAFT_EVENT_URL ?? DEFAULT_ENDPOINT;
-  const allowRemote = envFlag("AGENTCRAFT_ALLOW_REMOTE", false);
 
-  if (!isLocalEndpoint(endpoint) && !allowRemote) {
+  if (!isLocalHttpEndpoint(endpoint)) {
     return {
       ok: false,
       skipped: true,
-      reason: "non-local endpoint rejected; set AGENTCRAFT_ALLOW_REMOTE=1 to override",
+      reason: "AgentCraft endpoint must be local HTTP(S).",
     };
   }
 


### PR DESCRIPTION
title:	Add optional AgentCraft local observability bridge
state:	OPEN
author:	codysumpter-cloud (Prismtek)
labels:	
assignees:	
reviewers:	chatgpt-codex-connector (Commented)
projects:	
milestone:	
number:	306
url:	https://github.com/codysumpter-cloud/bmo-stack/pull/306
additions:	309
deletions:	1
auto-merge:	disabled
--
## Summary

Adds a safe first slice of AgentCraft support for BMO as an optional local observability HUD, not a runtime authority.

### Added

- `scripts/agentcraft-report.mjs`
  - emits AgentCraft-compatible lifecycle events
  - disabled unless `AGENTCRAFT_ENABLED=1`
  - rejects non-local HTTP(S) endpoints
  - redacts prompt text by default
  - redacts common secret-like keys and token patterns
  - truncates command summaries by default
  - never fails the BMO runtime path if the HUD is offline
- `docs/AGENTCRAFT_INTEGRATION.md`
  - documents ownership boundary, safety defaults, event mapping, and local usage
- `config/agentcraft.safe.json`
  - records the intended safe defaults and source-of-truth files
- Make targets:
  - `agentcraft-start`
  - `agentcraft-stop`
  - `agentcraft-doctor`
  - `agentcraft-health`
  - `agentcraft-smoke`
- `operator-surface.manifest.json` entries for the AgentCraft document and validation actions

## Safety posture

- Local-only event endpoint enforcement is built into the reporter.
- AgentCraft is treated as optional observability only.
- BMO remains the source of truth for runtime state, approvals, receipts, memory, and persistence claims.
- No automatic hook installation is added.
- No browser-triggered command execution is added.

## Validation

I reviewed the branch diff:

- 5 files changed
- 309 additions
- 1 deletion

Recommended local checks after pulling this branch:

```bash
node scripts/agentcraft-report.mjs hero_active
make agentcraft-doctor
make agentcraft-health || true
make agentcraft-smoke
make runtime-doctor
```

`make agentcraft-health` and `make agentcraft-smoke` require a local AgentCraft server to be running for successful POSTs, but the reporter is intentionally non-fatal when the HUD is offline.

## Task contract
- **Goal**: Implement optional AgentCraft local observability HUD.
- **Constraint**: Local-only endpoints, redacts secrets, non-fatal HUD offline.
- **Verification**:  and  pass.