### PR TITLE
Add Buddy Symphony orchestration contract

### DIFF
--- a/config/buddy-symphony.safe.json
+++ b/config/buddy-symphony.safe.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "mode": "scheduler-runner-only",
+  "enabledByDefault": false,
+  "sourceOfTruth": [
+    "contracts/buddy_symphony.md",
+    "contracts/buddy_runtime.md",
+    "BUDDY_RUNTIME_EVENTS_FILES.md"
+  ],
+  "stateAuthority": "BMO Buddy runtime and state machine",
+  "schedulerAuthority": "Symphony-compatible runner",
+  "workspace": {
+    "root": "./.buddy-symphony/workspaces",
+    "isolationRequired": true,
+    "escapePolicy": "reject"
+  },
+  "receipts": {
+    "requiredForPersistenceClaims": true,
+    "requiredForGrowthEffects": true,
+    "requiredForMemoryPromotion": true
+  },
+  "growth": {
+    "directEffectsAllowed": false,
+    "acceptedRunMayRecommendGrowth": true,
+    "bmoMustApplyEffects": true
+  },
+  "approval": {
+    "riskyActionsRequireApproval": true,
+    "defaultDecision": "reject"
+  },
+  "proofKinds": [
+    "ci_status",
+    "diff",
+    "pr",
+    "review_feedback",
+    "complexity",
+    "walkthrough",
+    "artifact",
+    "receipt"
+  ],
+  "nonGoals": [
+    "Buddy memory store",
+    "Buddy state machine",
+    "approval bypass",
+    "public app runtime",
+    "unreceipted source mutation"
+  ]
+}

--- a/contracts/buddy_symphony.md
+++ b/contracts/buddy_symphony.md
@@ -1,0 +1,148 @@
+# Buddy Symphony Contract v0.1
+
+## Purpose
+
+Buddy Symphony defines how BMO and BeMore Buddies can use Symphony-style work orchestration without making Symphony the source of truth for Buddy state, memory, approvals, or persistence claims.
+
+Symphony is treated as a scheduler/runner for isolated implementation work. BMO remains the policy, approval, receipt, and runtime-contract owner. BeMore app surfaces remain supervision and companion UX surfaces.
+
+## Boundary
+
+### Symphony owns
+
+- Polling eligible work from an issue tracker or work queue.
+- Creating deterministic per-work-item workspaces.
+- Running coding-agent sessions inside those isolated workspaces.
+- Retrying, reconciling, and releasing claimed work.
+- Emitting operator-visible run status.
+
+### BMO owns
+
+- Buddy identity, policy, council review, and approval gates.
+- Runtime event validation and receipt requirements.
+- Durable memory promotion.
+- XP, bond, proficiency, unlock, and evolution effects.
+- Whether a Symphony result is accepted into source-of-truth state.
+
+### BeMore / Prismtek app surfaces own
+
+- Showing Buddy work status to the user.
+- Displaying proofs, pending approvals, and handoff summaries.
+- Triggering only approved relay actions.
+- Falling back to Mac/runtime relay for execution.
+
+## Core model
+
+### BuddyWorkItem
+
+```json
+{
+  "id": "string",
+  "source": "linear | github | local | manual",
+  "source_ref": "string",
+  "buddy_id": "string",
+  "title": "string",
+  "description": "string",
+  "priority": "low | normal | high | urgent",
+  "state": "queued | running | waiting_review | accepted | rejected | failed | canceled",
+  "labels": ["string"],
+  "constraints": ["string"],
+  "created_at": "ISO8601",
+  "updated_at": "ISO8601"
+}
+```
+
+### BuddySymphonyRun
+
+```json
+{
+  "run_id": "uuid",
+  "work_item_id": "string",
+  "buddy_id": "string",
+  "workspace_path": "string",
+  "status": "claimed | preparing | running | waiting_review | completed | failed | canceled",
+  "attempt": 1,
+  "session_id": "string",
+  "started_at": "ISO8601",
+  "ended_at": "ISO8601 or null",
+  "proofs": ["BuddySymphonyProof"],
+  "receipt_refs": ["string"]
+}
+```
+
+### BuddySymphonyProof
+
+```json
+{
+  "proof_id": "uuid",
+  "run_id": "uuid",
+  "kind": "ci_status | diff | pr | review_feedback | complexity | walkthrough | artifact | receipt",
+  "summary": "string",
+  "uri": "string or null",
+  "metadata": {},
+  "created_at": "ISO8601"
+}
+```
+
+## Event mapping
+
+All Buddy Symphony activity should be converted into existing Buddy runtime event streams before it can affect Buddy state.
+
+| Symphony lifecycle | Buddy runtime event | Required receipt posture |
+| --- | --- | --- |
+| Work item claimed | `status` | No Buddy growth effect. |
+| Workspace created/reused | `receipt` | Workspace path may be summarized; avoid secrets. |
+| Agent turn started | `status` | No persistence claim. |
+| File diff proposed | `diff_proposed` | Requires diff reference before review. |
+| Artifact produced | `artifact_created` | Requires artifact metadata. |
+| Proof collected | `receipt` | Required before XP/proficiency effects. |
+| Human approval needed | `tool_request` | Safe default is reject. |
+| Run accepted | `receipt` | Required before Buddy growth/evolution effects. |
+| Run failed/canceled | `status` + optional `receipt` | No growth effect unless policy explicitly awards reflection XP. |
+
+## Acceptance rules
+
+A Symphony run may improve Buddy state only when all are true:
+
+1. The work item is tied to a known `buddy_id`.
+2. The run has at least one proof object.
+3. The proof object has been converted into a BMO receipt.
+4. Any source mutation has a diff, PR, CI, or equivalent receipt.
+5. Council or operator policy accepts the run.
+6. The Buddy state machine allows the resulting transition.
+
+## Rejection rules
+
+Reject or hold the run if any are true:
+
+- The run claims persistence without a receipt.
+- The run modifies source without a diff or PR reference.
+- The run requests destructive commands without explicit approval.
+- The run attempts to promote memory without evidence.
+- The run updates Buddy XP, bond, unlocks, or evolution directly.
+- The run workspace path escapes its assigned workspace root.
+
+## Recommended Buddy-specific states
+
+```text
+queued -> claimed -> preparing -> running -> waiting_review -> accepted
+                                                -> rejected
+                              -> failed
+                              -> canceled
+```
+
+## Minimum integration slice
+
+1. Keep Symphony runtime separate from BeMore app surfaces.
+2. Add a Buddy-owned `WORKFLOW.md` prompt for coding agents.
+3. Map Symphony status/proof events into Buddy runtime events.
+4. Render read-only Symphony run status in BeMore Mission Control.
+5. Award Buddy growth only after accepted BMO receipts.
+
+## Non-goals
+
+- Symphony is not a Buddy memory store.
+- Symphony is not a Buddy state machine.
+- Symphony is not an approval bypass.
+- Symphony is not the public app runtime.
+- Symphony should not make source mutation claims without proof.

--- a/docs/BUDDY_SYMPHONY.md
+++ b/docs/BUDDY_SYMPHONY.md
@@ -1,0 +1,129 @@
+# Buddy Symphony Integration
+
+## What Symphony adds for Buddies
+
+Symphony turns issue-tracker work into repeatable, isolated implementation runs. For Buddies, that means BMO can stop treating coding-agent work as one-off manual sessions and start treating it as a supervised queue of Buddy missions.
+
+The key value is not that Symphony replaces Buddy runtime. It does not. The key value is that Symphony gives Buddies a reliable work loop:
+
+1. Find eligible work.
+2. Claim one item.
+3. Create or reuse an isolated workspace.
+4. Run the coding agent inside that workspace.
+5. Collect proofs.
+6. Hand the result back for BMO review.
+7. Retry, cancel, or release work based on policy.
+
+## Correct architecture
+
+```text
+Issue tracker / local queue
+  -> Symphony scheduler-runner
+  -> isolated workspace
+  -> coding-agent run
+  -> proofs and summaries
+  -> BMO receipt conversion
+  -> Buddy runtime event stream
+  -> Buddy state machine
+  -> BeMore Mission Control
+```
+
+## What not to do
+
+Do not let Symphony directly mutate Buddy state. Symphony should not directly award XP, promote memory, evolve Buddies, publish packages, or claim source changes landed. BMO must convert Symphony outputs into receipts and runtime events first.
+
+## Buddy mission lifecycle
+
+```text
+queued
+  -> claimed
+  -> preparing
+  -> running
+  -> waiting_review
+  -> accepted
+```
+
+Failure and rejection paths:
+
+```text
+running -> failed
+running -> canceled
+waiting_review -> rejected
+```
+
+## Proof requirements
+
+A Buddy Symphony run needs proof before it can affect Buddy state.
+
+Useful proof kinds:
+
+- `diff`: reviewable source diff
+- `pr`: pull request reference
+- `ci_status`: validation result
+- `review_feedback`: code review or council feedback
+- `complexity`: rough complexity/risk readout
+- `walkthrough`: demonstration or summary video reference
+- `artifact`: generated file or build output
+- `receipt`: BMO receipt proving a durable action
+
+## Buddy growth rule
+
+Symphony may recommend growth. BMO applies growth.
+
+A run may recommend Buddy proficiency growth only after:
+
+1. A known Buddy owns the work item.
+2. The run has at least one proof.
+3. The proof has been converted into a BMO receipt.
+4. Council or operator review accepts the run.
+5. The Buddy state machine allows the effect.
+
+## Generated workflow
+
+Use this script to create a Buddy-safe Symphony workflow template:
+
+```bash
+node scripts/generate-buddy-symphony-workflow.mjs --output WORKFLOW.buddy.md
+```
+
+Customize the Linear project slug and workspace root when needed:
+
+```bash
+node scripts/generate-buddy-symphony-workflow.mjs \
+  --project-slug "$LINEAR_PROJECT_SLUG" \
+  --workspace-root "./.buddy-symphony/workspaces" \
+  --output WORKFLOW.buddy.md
+```
+
+Print without writing:
+
+```bash
+node scripts/generate-buddy-symphony-workflow.mjs --print
+```
+
+Overwrite intentionally:
+
+```bash
+node scripts/generate-buddy-symphony-workflow.mjs --force --output WORKFLOW.buddy.md
+```
+
+## Recommended local checks
+
+```bash
+node scripts/generate-buddy-symphony-workflow.mjs --print > /tmp/WORKFLOW.buddy.md
+node scripts/generate-buddy-symphony-workflow.mjs --output /tmp/WORKFLOW.buddy.md --force
+make runtime-doctor
+```
+
+## Future BeMore surface
+
+The app should render Buddy Symphony as read-only Mission Control first:
+
+- active Buddy missions
+- run state
+- workspace/status summaries
+- pending approvals
+- proofs collected
+- final handoff summary
+
+The app should not execute Symphony directly from iOS. Use Mac/runtime relay for approved execution paths.

--- a/operator-surface.manifest.json
+++ b/operator-surface.manifest.json
@@ -44,6 +44,12 @@
       "name": "Companion UX and resilience cues",
       "owner": "shared",
       "description": "Carry companion modes, Kairos world-state, and graceful degraded-state cues across the public and local surfaces."
+    },
+    {
+      "id": "buddy-symphony",
+      "name": "Buddy Symphony orchestration",
+      "owner": "local",
+      "description": "Turn eligible work into isolated Buddy missions while BMO keeps policy, receipts, and state authority."
     }
   ],
   "documentShortcuts": [
@@ -64,6 +70,18 @@
       "name": "Private App Repo Integration",
       "path": "docs/PRIVATE_APP_REPO_INTEGRATION.md",
       "description": "How prismtek.dev_mega-app and BMO-app map into Builder Studio, Prism Agent, and BMO."
+    },
+    {
+      "id": "buddy-symphony-guide",
+      "name": "Buddy Symphony Integration",
+      "path": "docs/BUDDY_SYMPHONY.md",
+      "description": "How Symphony-style work orchestration maps into Buddy missions, proofs, receipts, and Mission Control."
+    },
+    {
+      "id": "buddy-symphony-contract",
+      "name": "Buddy Symphony Contract",
+      "path": "contracts/buddy_symphony.md",
+      "description": "Contract boundaries and event mapping for Buddy-safe Symphony runs."
     }
   ],
   "validationActions": [
@@ -90,6 +108,12 @@
       "name": "Runtime doctor",
       "command": "make runtime-doctor",
       "description": "Validate runtime profile and launch assumptions."
+    },
+    {
+      "id": "buddy-symphony-workflow-print",
+      "name": "Preview Buddy Symphony workflow",
+      "command": "node scripts/generate-buddy-symphony-workflow.mjs --print",
+      "description": "Render a Buddy-safe Symphony WORKFLOW template without writing files."
     }
   ]
 }

--- a/scripts/generate-buddy-symphony-workflow.mjs
+++ b/scripts/generate-buddy-symphony-workflow.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const DEFAULT_OUTPUT = "WORKFLOW.buddy.md";
+
+function parseArgs(argv) {
+  const args = { output: DEFAULT_OUTPUT, projectSlug: "$LINEAR_PROJECT_SLUG", workspaceRoot: "./.buddy-symphony/workspaces" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--output" || arg === "-o") {
+      args.output = argv[++index];
+    } else if (arg === "--project-slug") {
+      args.projectSlug = argv[++index];
+    } else if (arg === "--workspace-root") {
+      args.workspaceRoot = argv[++index];
+    } else if (arg === "--force") {
+      args.force = true;
+    } else if (arg === "--print") {
+      args.print = true;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function renderWorkflow({ projectSlug, workspaceRoot }) {
+  return `---
+tracker:
+  kind: linear
+  api_key: "$LINEAR_API_KEY"
+  project_slug: "${projectSlug}"
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+polling:
+  interval_ms: 30000
+workspace:
+  root: "${workspaceRoot}"
+hooks:
+  timeout_ms: 60000
+agent:
+  max_concurrent_agents: 3
+  max_turns: 8
+  max_retry_backoff_ms: 300000
+codex:
+  command: "codex app-server"
+  turn_timeout_ms: 3600000
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+buddy:
+  contract: contracts/buddy_symphony.md
+  runtime_contract: contracts/buddy_runtime.md
+  event_catalog: buddy-runtime-events.v1.json
+  state_machine: buddy-state-machine.v1.json
+  receipts_required: true
+  direct_growth_effects_allowed: false
+---
+You are running a Buddy Symphony implementation task for BMO.
+
+Issue:
+- Identifier: {{ issue.identifier }}
+- Title: {{ issue.title }}
+- State: {{ issue.state }}
+- Priority: {{ issue.priority }}
+- URL: {{ issue.url }}
+- Labels: {{ issue.labels | join: ", " }}
+
+Description:
+{{ issue.description }}
+
+Attempt:
+{{ attempt }}
+
+Buddy operating rules:
+
+1. Treat Symphony as a scheduler and isolated work runner only.
+2. Do not mutate Buddy state, XP, bond, memory, unlocks, or evolution directly.
+3. Any source mutation must produce a reviewable diff or PR reference.
+4. Any persistence claim must include a receipt reference.
+5. Any memory promotion must include evidence.
+6. Any risky or destructive action must request approval before proceeding.
+7. Keep all commands inside the assigned workspace.
+8. Prefer small, testable changes with clear validation notes.
+9. When blocked, produce a precise handoff summary instead of pretending success.
+
+Expected output:
+
+- Summary of changes attempted.
+- Files changed or proposed.
+- Validation commands run and results.
+- Diff, PR, artifact, or receipt references.
+- Buddy growth recommendation, if any, as a recommendation only.
+- Explicit blockers and next step if not complete.
+`;
+}
+
+function printHelp() {
+  console.log(`Usage: generate-buddy-symphony-workflow.mjs [options]
+
+Options:
+  -o, --output <path>          Output workflow path. Default: ${DEFAULT_OUTPUT}
+      --project-slug <slug>    Linear project slug or env reference. Default: $LINEAR_PROJECT_SLUG
+      --workspace-root <path>  Symphony workspace root. Default: ./.buddy-symphony/workspaces
+      --print                  Print to stdout instead of writing a file.
+      --force                  Overwrite an existing output file.
+  -h, --help                   Show this help.
+`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const workflow = renderWorkflow(args);
+
+  if (args.print) {
+    process.stdout.write(workflow);
+    return;
+  }
+
+  const outputPath = path.resolve(args.output);
+  if (fs.existsSync(outputPath) && !args.force) {
+    throw new Error(`${args.output} already exists. Use --force to overwrite.`);
+  }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, workflow, "utf8");
+  console.log(`Wrote ${args.output}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Adds the first Buddy Symphony integration slice for BMO.

### Changes

- Add `contracts/buddy_symphony.md`
- Add `docs/BUDDY_SYMPHONY.md`
- Add `scripts/generate-buddy-symphony-workflow.mjs`
- Add `config/buddy-symphony.safe.json`
- Register Buddy Symphony docs and workflow preview in `operator-surface.manifest.json`

## Intent

This treats Symphony-style work as isolated Buddy missions while keeping BMO as the authority for Buddy policy, receipts, memory, growth, and state transitions.

## Task contract
Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Verification plan

Run:

```bash
node scripts/generate-buddy-symphony-workflow.mjs --print > /tmp/WORKFLOW.buddy.md
node scripts/generate-buddy-symphony-workflow.mjs --output /tmp/WORKFLOW.buddy.md --force
make runtime-doctor
```

GitHub checks must pass before merge, especially `task-readiness`, `ci`, `lint`, CodeQL, and smoke workflows.

## Rollback plan

Revert this PR to remove the Buddy Symphony contract, docs, generator, safe config, and operator-surface registrations.

## Follow-up

The read-only BeMore Mission Control surface has already landed separately in `prismtek-apps`, so this PR should stay focused on the operator contract/generator layer.