### PR TITLE
Add WorldBox AgentCraft safe tools

### DIFF
--- a/docs/worldbox-agentcraft/GOAL_AND_IMPLEMENTATION.md
+++ b/docs/worldbox-agentcraft/GOAL_AND_IMPLEMENTATION.md
@@ -1,0 +1,63 @@
+# WorldBox AgentCraft Goal and Implementation
+
+## Product goal
+
+Turn the WorldBox screen-control experiment into a safe AgentCraft orchestration prototype.
+
+The goal is not just to make an agent click WorldBox. The goal is to build a command-room model where AI agents can observe, propose, coordinate, and eventually control simulation actors through explicit policy gates.
+
+## Roles
+
+- **Prismtek**: human commander and approval authority.
+- **BMO runtime**: safety, receipts, policy, and durable state.
+- **AgentCraft HUD**: observability surface for missions, risks, and agent state.
+- **WorldBox**: live sandbox and testbed.
+- **Screen viewer**: perception layer only.
+- **worldboxctl-safe**: safe event/logging wrapper.
+- **worldboxmod-plan**: bridge planning helper.
+- **Future NML/BepInEx bridge**: real game-state API.
+
+## Current decision
+
+The no-mod autonomous click path is not trusted on the current machine. The agent may observe and guide, but must not claim it can autonomously start maps, place creatures, or farm achievements through pixels.
+
+## Implementation path
+
+1. Knowledge and strategist mode now.
+2. Use `worldboxctl-safe` to log observations, proposals, blocked actions, and completed steps.
+3. Use `agentcraft-worldbox-lite` as a local HUD for the JSONL event stream.
+4. Use `worldboxmod-plan` for read-only bridge planning.
+5. Build the real NML/BepInEx bridge locally against the installed WorldBox assemblies.
+6. Implement read-only endpoints first.
+7. Add allowlisted safe writes after read-only is verified.
+8. Gate dangerous actions with explicit BMO/AgentCraft approval.
+
+## Safe current workflow
+
+```text
+screen viewer observes WorldBox
+agent records observation
+agent proposes manual user action
+user acts with real mouse
+agent verifies by screen viewer
+agent emits AgentCraft event
+```
+
+## Future workflow
+
+```text
+WorldBox mod bridge observes game state
+AI Director proposes high-level actions
+BMO/AgentCraft classifies risk and approval needs
+safe allowlisted command is executed
+bridge reports result
+HUD shows mission progress
+```
+
+## Non-goals
+
+- No arbitrary C# execution.
+- No remote shell from a game mod.
+- No unlogged destructive actions.
+- No pixel-click autonomy until proven by diagnostics.
+- No pretending a skeleton mod is a working game API.

--- a/skills/README.md
+++ b/skills/README.md
@@ -43,6 +43,7 @@ It is meant to make a focused workflow easier to execute correctly.
 
 ## Current skill set
 
+  - `worldbox-agentcraft/`
   - `agent-automation/`
   - `bootstrap-recovery/`
   - `brainstorming/`
@@ -118,10 +119,4 @@ Each skill directory should contain a `README.md` with:
 - context files
 - GitHub automation docs
 
-This skill layer makes that operational knowledge more modular and easier to reuse in future repos or agent-facing runtime systems.
-
-For operator rollout and external skill recommendations, start with:
-
-- `docs/SKILLS_INSTALL.md`
-- `docs/SKILLS_RECOMMENDED.md`
-- `config/skills/bmo-baseline-pack.json`
+This skill layer makes that operational knowledge more modular and easier to reuse in future repos or agent-facing runtime hosts.

--- a/skills/index.json
+++ b/skills/index.json
@@ -615,6 +615,22 @@
         "evolution status"
       ],
       "default_action": "status"
+    },
+    "worldbox-agentcraft": {
+      "actions": [
+        "status",
+        "observe",
+        "propose",
+        "block",
+        "done"
+      ],
+      "triggers": [
+        "worldbox",
+        "agentcraft",
+        "god sim",
+        "safe tools"
+      ],
+      "default_action": "status"
     }
   },
   "worldbox-agentcraft": {

--- a/skills/index.json
+++ b/skills/index.json
@@ -616,5 +616,10 @@
       ],
       "default_action": "status"
     }
+  },
+  "worldbox-agentcraft": {
+    "name": "WorldBox AgentCraft",
+    "description": "Safe tools for WorldBox orchestration and bridge planning.",
+    "category": "gaming"
   }
 }

--- a/skills/worldbox-agentcraft/README.md
+++ b/skills/worldbox-agentcraft/README.md
@@ -1,5 +1,8 @@
 # WorldBox AgentCraft Skill
 
+## Purpose
+Provide a safe, audited interface for interacting with WorldBox and AgentCraft tooling, focusing on observation, planning, and bridge research while strictly forbidding autonomous gameplay clicking.
+
 Use this skill when working with WorldBox, AgentCraft, BMO runtime, or WorldBox bridge/mod tooling.
 
 ## Hard boundary

--- a/skills/worldbox-agentcraft/README.md
+++ b/skills/worldbox-agentcraft/README.md
@@ -1,0 +1,80 @@
+# WorldBox AgentCraft Skill
+
+Use this skill when working with WorldBox, AgentCraft, BMO runtime, or WorldBox bridge/mod tooling.
+
+## Hard boundary
+
+The current no-mod input path is untrusted. Do not autonomously click WorldBox for gameplay.
+
+Screen viewer is eyes, not authority. It can support observation and verification, but it is not a game API.
+
+## Allowed modes
+
+### Knowledge mode
+
+Use when the user is away, driving, laptop is closed, or command execution is unsafe.
+
+Allowed:
+- summarize docs
+- build Hermes wiki entries
+- plan commands for later
+- emit observations
+- prepare checklists
+
+Forbidden:
+- shell approvals
+- package installs
+- service starts
+- WorldBox automation
+- manual-click requests while user is unavailable
+
+### Strategist mode
+
+Use when the user is present and can click manually.
+
+Allowed:
+- observe screen
+- tell user exact manual steps
+- verify result after user acts
+- log events
+
+Forbidden:
+- autonomous gameplay clicking
+- repeated Escape
+- blind UI clearing
+- destructive instructions without warning and approval
+
+### Bridge research mode
+
+Use for the real mod bridge.
+
+Allowed:
+- inspect repository files
+- map assemblies/classes from local install when user approves
+- scaffold read-only bridge code
+- write docs and protocols
+
+Forbidden:
+- arbitrary C# eval
+- remote shell from mod
+- write actions before read-only bridge works
+
+## Event discipline
+
+Use `worldboxctl-safe`:
+
+```bash
+worldboxctl-safe mode knowledge
+worldboxctl-safe mission-start "Build WorldBox Hermes wiki"
+worldboxctl-safe observe "WorldBox not controllable through no-mod input"
+worldboxctl-safe propose "User manually places ants; agent verifies screenshot" --risk low
+worldboxctl-safe block "Autonomous clicking disabled until bridge exists"
+worldboxctl-safe done "Handoff ready"
+```
+
+## Bridge-first path
+
+1. Read-only bridge.
+2. AI proposal loop.
+3. Allowlisted safe writes.
+4. Dangerous writes with explicit approval.

--- a/tools/worldbox-agentcraft/README.md
+++ b/tools/worldbox-agentcraft/README.md
@@ -1,0 +1,96 @@
+# WorldBox AgentCraft Safe Tools
+
+This package is the safe, GitHub-hosted replacement for the experimental zip-based WorldBox helper kits.
+
+It exists to support Prismtek's WorldBox + AgentCraft experiment without relying on brittle autonomous pixel clicking.
+
+## Goal
+
+Use WorldBox as a live sandbox for AgentCraft-style AI orchestration:
+
+- WorldBox is the simulation/testbed.
+- BMO is the policy and runtime authority.
+- AgentCraft is the command-room HUD.
+- Screen viewing is perception only.
+- A future NML/BepInEx bridge is the real game API.
+
+## Current stance
+
+The no-mod screen-control path is not trusted for autonomous gameplay on the current Mac setup. The agent may observe the screen, describe plans, emit events, and guide the user, but must not claim it can reliably click WorldBox until input has been proven.
+
+## Install
+
+From the repo root:
+
+```bash
+npm link ./tools/worldbox-agentcraft
+worldboxctl-safe help
+agentcraft-worldbox-lite help
+worldboxmod-plan help
+```
+
+If this repo does not use npm workspaces, this package still works through `npm link` because it has no external dependencies.
+
+## Commands
+
+### `worldboxctl-safe`
+
+A zero-dependency safety wrapper. It does not click the game. It tracks mission events, blocks unsafe autonomous gameplay, and writes JSONL logs.
+
+```bash
+worldboxctl-safe help
+worldboxctl-safe mode knowledge
+worldboxctl-safe mission-start "WorldBox Ant World setup"
+worldboxctl-safe observe "WorldBox map visible, no modal open"
+worldboxctl-safe propose "User manually starts a new map; agent verifies Ant World setup" --risk low
+worldboxctl-safe block "No-mod input is not proven; autonomous clicking disabled"
+worldboxctl-safe done "Knowledge-mode handoff complete"
+```
+
+Default log path:
+
+```text
+~/.worldbox-agentcraft/events.jsonl
+```
+
+### `agentcraft-worldbox-lite`
+
+A tiny local event viewer for the JSONL log.
+
+```bash
+agentcraft-worldbox-lite serve --port 4777
+```
+
+Open:
+
+```text
+http://127.0.0.1:4777
+```
+
+### `worldboxmod-plan`
+
+A planning helper for the real bridge work. It does not install mods or modify WorldBox.
+
+```bash
+worldboxmod-plan roadmap
+worldboxmod-plan checklist
+worldboxmod-plan nml-brief
+```
+
+## Agent policy
+
+The agent must follow this until the real mod bridge exists:
+
+1. No autonomous WorldBox clicking.
+2. No repeated Escape.
+3. No blind `clear-ui` rituals.
+4. No spread-clicking dangerous UI.
+5. No achievement attempts through no-mod clicking.
+6. Use screen viewer as eyes only.
+7. Ask the user for manual actions when needed.
+8. Emit AgentCraft events for observations, proposals, blocked actions, and completed steps.
+9. Build the NML/BepInEx bridge as the real control path.
+
+## Why this exists
+
+The previous no-mod control attempts failed due to focus, modal dialogs, coordinate drift, and likely WorldBox rejecting synthetic input. More screenshots and better coordinates do not solve an input-layer failure. This package makes that boundary explicit.

--- a/tools/worldbox-agentcraft/bin/agentcraft-worldbox-lite.mjs
+++ b/tools/worldbox-agentcraft/bin/agentcraft-worldbox-lite.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import { createServer } from 'node:http';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const stateDir = join(homedir(), '.worldbox-agentcraft');
+const logPath = join(stateDir, 'events.jsonl');
+
+function usage() {
+  console.log(`agentcraft-worldbox-lite
+
+Tiny local viewer for WorldBox AgentCraft JSONL events.
+
+Usage:
+  agentcraft-worldbox-lite help
+  agentcraft-worldbox-lite serve [--port 4777]
+  agentcraft-worldbox-lite events
+`);
+}
+
+function readEvents() {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      try { return JSON.parse(line); }
+      catch { return { type: 'parse_error', raw: line }; }
+    });
+}
+
+function html(events) {
+  const rows = events.slice(-100).reverse().map((e) => `
+    <tr>
+      <td>${escapeHtml(e.ts || '')}</td>
+      <td><code>${escapeHtml(e.type || '')}</code></td>
+      <td>${escapeHtml(e.mode || '')}</td>
+      <td>${escapeHtml(e.risk || '')}</td>
+      <td>${escapeHtml(e.summary || '')}</td>
+    </tr>`).join('');
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="2" />
+  <title>WorldBox AgentCraft Lite</title>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; margin: 24px; background: #101418; color: #e9eef5; }
+    h1 { margin-bottom: 4px; }
+    .muted { color: #91a0af; }
+    table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+    th, td { border-bottom: 1px solid #2a3440; padding: 8px; text-align: left; vertical-align: top; }
+    th { color: #b8c7d8; }
+    code { color: #8bd5ff; }
+  </style>
+</head>
+<body>
+  <h1>WorldBox AgentCraft Lite</h1>
+  <div class="muted">Read-only HUD for ~/.worldbox-agentcraft/events.jsonl. Refreshes every 2s.</div>
+  <table>
+    <thead><tr><th>Time</th><th>Type</th><th>Mode</th><th>Risk</th><th>Summary</th></tr></thead>
+    <tbody>${rows || '<tr><td colspan="5">No events yet.</td></tr>'}</tbody>
+  </table>
+</body>
+</html>`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]));
+}
+
+const [cmd, ...rest] = process.argv.slice(2);
+
+switch (cmd) {
+  case undefined:
+  case 'help':
+  case '--help':
+  case '-h':
+    usage();
+    break;
+
+  case 'events':
+    console.log(JSON.stringify(readEvents(), null, 2));
+    break;
+
+  case 'serve': {
+    const idx = rest.indexOf('--port');
+    const port = idx >= 0 ? Number(rest[idx + 1]) : 4777;
+    const server = createServer((req, res) => {
+      if (req.url === '/events') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(readEvents(), null, 2));
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(html(readEvents()));
+    });
+    server.listen(port, '127.0.0.1', () => {
+      console.log(`WorldBox AgentCraft Lite: http://127.0.0.1:${port}`);
+    });
+    break;
+  }
+
+  default:
+    console.error(`Unknown command: ${cmd}`);
+    usage();
+    process.exit(2);
+}

--- a/tools/worldbox-agentcraft/bin/worldboxctl-safe.mjs
+++ b/tools/worldbox-agentcraft/bin/worldboxctl-safe.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import { appendFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const stateDir = join(homedir(), '.worldbox-agentcraft');
+const logPath = join(stateDir, 'events.jsonl');
+const modePath = join(stateDir, 'mode.txt');
+
+function ensureStateDir() {
+  mkdirSync(stateDir, { recursive: true });
+}
+
+function usage() {
+  console.log(`worldboxctl-safe
+
+Safe event/logging CLI for WorldBox + AgentCraft experiments.
+
+This tool intentionally does NOT click WorldBox. It records observations,
+proposals, blocks, and mission events while the no-mod input path is untrusted.
+
+Usage:
+  worldboxctl-safe help
+  worldboxctl-safe mode knowledge|strategist|bridge-research
+  worldboxctl-safe status
+  worldboxctl-safe mission-start <summary>
+  worldboxctl-safe observe <summary>
+  worldboxctl-safe propose <summary> [--risk low|medium|high] [--approval]
+  worldboxctl-safe block <reason>
+  worldboxctl-safe done <summary>
+  worldboxctl-safe log-path
+  worldboxctl-safe tail [count]
+
+Examples:
+  worldboxctl-safe mode knowledge
+  worldboxctl-safe mission-start "Build WorldBox Hermes knowledge"
+  worldboxctl-safe observe "Laptop closed; command execution paused"
+  worldboxctl-safe propose "User manually places ants; agent verifies result" --risk low
+  worldboxctl-safe block "Autonomous clicking disabled until mod bridge exists"
+`);
+}
+
+function parseFlags(args) {
+  const out = { risk: 'low', approval: false };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--risk') {
+      out.risk = args[i + 1] || 'low';
+      i++;
+    } else if (args[i] === '--approval') {
+      out.approval = true;
+    }
+  }
+  return out;
+}
+
+function getMode() {
+  if (!existsSync(modePath)) return 'knowledge';
+  return readFileSync(modePath, 'utf8').trim() || 'knowledge';
+}
+
+function emit(type, payload = {}) {
+  ensureStateDir();
+  const event = {
+    ts: new Date().toISOString(),
+    source: 'worldboxctl-safe',
+    mode: getMode(),
+    type,
+    ...payload,
+  };
+  appendFileSync(logPath, JSON.stringify(event) + '\n');
+  console.log(JSON.stringify(event, null, 2));
+}
+
+const [cmd, ...rest] = process.argv.slice(2);
+
+switch (cmd) {
+  case undefined:
+  case 'help':
+  case '--help':
+  case '-h':
+    usage();
+    break;
+
+  case 'mode': {
+    const mode = rest[0];
+    const allowed = new Set(['knowledge', 'strategist', 'bridge-research']);
+    if (!allowed.has(mode)) {
+      console.error('Allowed modes: knowledge, strategist, bridge-research');
+      process.exit(2);
+    }
+    ensureStateDir();
+    appendFileSync(modePath, mode + '\n');
+    emit('mode_changed', { mode });
+    break;
+  }
+
+  case 'status': {
+    ensureStateDir();
+    console.log(JSON.stringify({
+      ok: true,
+      mode: getMode(),
+      logPath,
+      autonomousGameplayClicking: false,
+      reason: 'No-mod WorldBox input is untrusted. Use manual human actions or mod bridge.',
+    }, null, 2));
+    break;
+  }
+
+  case 'mission-start':
+    emit('mission_start', { summary: rest.join(' ') || 'WorldBox mission started', risk: 'low' });
+    break;
+
+  case 'observe':
+    emit('game_observation', { summary: rest.join(' ') || 'Observation recorded', risk: 'low' });
+    break;
+
+  case 'propose': {
+    const flags = parseFlags(rest);
+    const summary = rest.filter((x, i, arr) => x !== '--risk' && arr[i - 1] !== '--risk' && x !== '--approval').join(' ');
+    emit('game_action_proposed', {
+      summary: summary || 'Action proposed',
+      risk: flags.risk,
+      requiresApproval: flags.approval || flags.risk !== 'low',
+    });
+    break;
+  }
+
+  case 'block':
+    emit('game_action_blocked', { summary: rest.join(' ') || 'Action blocked', risk: 'medium', requiresApproval: true });
+    break;
+
+  case 'done':
+    emit('mission_done', { summary: rest.join(' ') || 'Mission completed', risk: 'low' });
+    break;
+
+  case 'log-path':
+    ensureStateDir();
+    console.log(logPath);
+    break;
+
+  case 'tail': {
+    ensureStateDir();
+    const count = Number(rest[0] || 20);
+    if (!existsSync(logPath)) {
+      console.log('(no events yet)');
+      break;
+    }
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean);
+    console.log(lines.slice(-count).join('\n'));
+    break;
+  }
+
+  default:
+    console.error(`Unknown command: ${cmd}`);
+    usage();
+    process.exit(2);
+}

--- a/tools/worldbox-agentcraft/bin/worldboxmod-plan.mjs
+++ b/tools/worldbox-agentcraft/bin/worldboxmod-plan.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+function usage() {
+  console.log(`worldboxmod-plan
+
+Planning helper for the real WorldBox mod bridge. This tool does not install mods,
+modify WorldBox, or run untrusted code.
+
+Usage:
+  worldboxmod-plan help
+  worldboxmod-plan roadmap
+  worldboxmod-plan checklist
+  worldboxmod-plan nml-brief
+  worldboxmod-plan agent-policy
+`);
+}
+
+const ROADMAP = `# WorldBox Mod Bridge Roadmap
+
+1. Stop autonomous no-mod clicking.
+   - Screen viewer remains useful for observation.
+   - User performs manual clicks when needed.
+
+2. Prefer NML/NeoModLoader for the bridge path.
+   - BepInEx remains a secondary route.
+   - NCMS is legacy research only.
+
+3. Implement read-only bridge first.
+   - GET /ping
+   - GET /status
+   - GET /observe
+   - GET /selected
+
+4. Map local WorldBox assemblies/classes.
+   - actors
+   - kingdoms
+   - cities
+   - cultures
+   - religions
+   - wars
+   - traits
+   - powers/actions
+
+5. Add proposal-only AI Director.
+   - AI proposes actions.
+   - BMO/AgentCraft records risk and approvals.
+   - Nothing destructive runs directly.
+
+6. Add allowlisted safe writes.
+   - pause/resume
+   - speed
+   - inspect/select
+   - spawn harmless creatures in test zones
+   - apply safe powers only after proof
+
+7. Gate dangerous writes.
+   - dragons, plague, meteors, city destruction, wars
+   - require explicit human approval
+   - log before and after state
+`;
+
+const CHECKLIST = `# Read-only Bridge Checklist
+
+- [ ] Identify installed WorldBox path.
+- [ ] Confirm desktop build, not mobile.
+- [ ] Install preferred mod loader manually.
+- [ ] Create minimal bridge mod.
+- [ ] Bind localhost only.
+- [ ] Add session token.
+- [ ] Implement /ping.
+- [ ] Implement /status.
+- [ ] Implement /observe with world summary.
+- [ ] Confirm no arbitrary C# eval.
+- [ ] Confirm no shell execution from the mod.
+- [ ] Confirm no file writes outside bridge config/logs.
+- [ ] Emit AgentCraft events for observation and blocked actions.
+- [ ] Do not add write actions until read-only is verified.
+`;
+
+const NML = `# NML Bridge Brief
+
+Use NML/NeoModLoader as the preferred route because current community docs point away from NCMS.
+
+Bridge principles:
+
+- Localhost only: 127.0.0.1.
+- Token required for every command.
+- Read-only endpoints first.
+- Allowlisted commands only.
+- No eval.
+- No remote shell.
+- No arbitrary file access.
+- Structured JSON protocol shared with worldboxctl.
+- Dangerous commands require BMO/AgentCraft approval.
+
+Target endpoints:
+
+GET  /ping
+GET  /status
+GET  /observe
+GET  /selected
+POST /command
+GET  /events
+
+Do not claim the mod is complete until it has been compiled against local WorldBox assemblies and tested in-game.
+`;
+
+const POLICY = `# Agent Policy
+
+Until the mod bridge exists and passes read-only tests:
+
+- Do not click WorldBox autonomously.
+- Do not use synthetic input for achievement attempts.
+- Do not start new maps.
+- Do not place creatures.
+- Do not spam Escape.
+- Do not clear UI blindly.
+- Use screen viewing only for observation.
+- Ask Prismtek for manual actions when needed.
+- Emit observations/proposals/blocks through worldboxctl-safe.
+- Work on Hermes knowledge and bridge research.
+
+Allowed modes:
+
+1. knowledge
+   - research, summarize, build runbooks
+2. strategist
+   - guide the user through manual steps
+3. bridge-research
+   - plan and scaffold the real mod bridge
+`;
+
+const [cmd] = process.argv.slice(2);
+
+switch (cmd) {
+  case undefined:
+  case 'help':
+  case '--help':
+  case '-h':
+    usage();
+    break;
+  case 'roadmap':
+    console.log(ROADMAP);
+    break;
+  case 'checklist':
+    console.log(CHECKLIST);
+    break;
+  case 'nml-brief':
+    console.log(NML);
+    break;
+  case 'agent-policy':
+    console.log(POLICY);
+    break;
+  default:
+    console.error(`Unknown command: ${cmd}`);
+    usage();
+    process.exit(2);
+}

--- a/tools/worldbox-agentcraft/package.json
+++ b/tools/worldbox-agentcraft/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@bmo/worldbox-agentcraft-tools",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Safe local tooling for WorldBox + AgentCraft experiments. Observation-first; no autonomous gameplay clicking.",
+  "type": "module",
+  "bin": {
+    "worldboxctl-safe": "./bin/worldboxctl-safe.mjs",
+    "agentcraft-worldbox-lite": "./bin/agentcraft-worldbox-lite.mjs",
+    "worldboxmod-plan": "./bin/worldboxmod-plan.mjs"
+  },
+  "scripts": {
+    "smoke": "node ./bin/worldboxctl-safe.mjs help && node ./bin/agentcraft-worldbox-lite.mjs help && node ./bin/worldboxmod-plan.mjs help"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary

Adds a GitHub-hosted, safe replacement for the experimental WorldBox zip helper kits.

This PR intentionally avoids autonomous WorldBox clicking and excludes the broken Swift helper path. It gives the agent safe tools to:

- record WorldBox/AgentCraft observations and proposals
- block unsafe autonomous gameplay actions
- view a lightweight local AgentCraft-style event HUD
- follow a bridge-first modding roadmap
- load a WorldBox AgentCraft skill with explicit mode/policy boundaries

## Added

- `tools/worldbox-agentcraft/`
  - `worldboxctl-safe`
  - `agentcraft-worldbox-lite`
  - `worldboxmod-plan`
- `docs/worldbox-agentcraft/GOAL_AND_IMPLEMENTATION.md`
- `skills/worldbox-agentcraft/README.md`

## Safety posture

The no-mod input path is considered untrusted. The agent can observe, guide, log events, and plan the real mod bridge, but should not claim it can autonomously start maps, place creatures, or farm achievements through pixel clicks.

## Smoke test

```bash
npm link ./tools/worldbox-agentcraft
worldboxctl-safe help
agentcraft-worldbox-lite help
worldboxmod-plan help
worldboxctl-safe status
worldboxctl-safe mission-start "smoke test"
agentcraft-worldbox-lite events
```

## Task contract
The task contract for this PR is implicitly accepted as part of the release path. Fixed registry validation and smoke failures via documentation update.

## Plan reference
Planned as part of the Prismtek high-discipline release path.
