### PR TITLE
Add Buddy Training policy and state contract

### DIFF
--- a/contracts/buddy-training/README.md
+++ b/contracts/buddy-training/README.md
@@ -1,0 +1,83 @@
+# Buddy Training Contract
+
+Buddy Training is a local companion progression contract for Buddy surfaces. It may make Buddy feel more alive, reward useful interactions, and unlock cosmetic or training milestones.
+
+## Source of truth
+
+- `buddy-brain` owns this contract and the schema in `contracts/buddy-training/state.schema.json`.
+- `buddy-agent` owns executable state updates and CLI/runtime behavior.
+- `prismtek-apps` owns app UI rendering and app-local storage/sync surfaces.
+- AgentCraft may visualize training events, but it is not the source of truth.
+
+## Training state meaning
+
+Training state may describe:
+
+- Buddy level and XP
+- cosmetic resources such as sparks and snacks
+- companion stats such as bond, focus, curiosity, discipline, creativity, reliability, and autonomy
+- achievements and cosmetics
+- evolution stage
+- last explicitly recorded training action
+
+Training state must not be used as:
+
+- durable memory evidence
+- approval state
+- proof that a file changed
+- proof that a command succeeded
+- proof that user intent was satisfied
+- hidden productivity tracking
+
+## Allowed training actions
+
+The MVP action vocabulary is:
+
+```text
+chat
+remember
+recall
+skill_used
+quest_completed
+test_passed
+doc_added
+code_reviewed
+memory_reviewed
+approval_handled
+```
+
+App surfaces may add visual labels, icons, and animations, but should not invent new persisted action names until this contract is updated.
+
+## Privacy defaults
+
+Buddy Training must be explicit and consent-first.
+
+Allowed signals:
+
+- Buddy runtime receipts
+- explicit app-local Buddy interactions
+- completed Buddy tasks
+- user-approved memory review or skill practice
+- test or validation completion events
+
+Disallowed default signals:
+
+- raw keystroke capture
+- global click capture
+- prompt/content scraping for XP
+- hidden productivity monitoring
+- using AgentCraft HUD events as receipt evidence
+
+## AgentCraft bridge
+
+AgentCraft can receive safe, redacted, local-only HUD events for training progress. AgentCraft events are decorative observability and must not bypass Buddy approvals, policy gates, receipts, or memory rules.
+
+## App rendering guidance
+
+`prismtek-apps` should treat this as a companion UI contract:
+
+```text
+Buddy action -> Buddy Agent reward -> Buddy Training state -> app renders growth
+```
+
+The app should prefer original Buddy Garden or Buddy Workshop styling over directly copying referenced idle-game branding.

--- a/contracts/buddy-training/state.schema.json
+++ b/contracts/buddy-training/state.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Buddy Training State",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "buddy_id",
+    "level",
+    "xp",
+    "lifetime_xp",
+    "sparks",
+    "snacks",
+    "stats",
+    "achievements",
+    "cosmetics",
+    "evolution",
+    "last_action"
+  ],
+  "properties": {
+    "buddy_id": { "type": "string", "minLength": 1 },
+    "level": { "type": "integer", "minimum": 1 },
+    "xp": { "type": "integer", "minimum": 0 },
+    "lifetime_xp": { "type": "integer", "minimum": 0 },
+    "sparks": { "type": "integer", "minimum": 0 },
+    "snacks": { "type": "integer", "minimum": 0 },
+    "stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bond", "focus", "curiosity", "discipline", "creativity", "reliability", "autonomy"],
+      "properties": {
+        "bond": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "focus": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "curiosity": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "discipline": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "creativity": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "reliability": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "autonomy": { "type": "integer", "minimum": 0, "maximum": 100 }
+      }
+    },
+    "achievements": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "cosmetics": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "evolution": { "type": "string", "enum": ["seedling", "apprentice", "specialist", "guardian"] },
+    "last_action": { "type": "string" }
+  }
+}

--- a/contracts/buddy-training/state.schema.json
+++ b/contracts/buddy-training/state.schema.json
@@ -40,6 +40,21 @@
     "achievements": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
     "cosmetics": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
     "evolution": { "type": "string", "enum": ["seedling", "apprentice", "specialist", "guardian"] },
-    "last_action": { "type": "string" }
+    "last_action": {
+      "type": "string",
+      "enum": [
+        "none",
+        "chat",
+        "remember",
+        "recall",
+        "skill_used",
+        "quest_completed",
+        "test_passed",
+        "doc_added",
+        "code_reviewed",
+        "memory_reviewed",
+        "approval_handled"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds the Buddy Training source-of-truth contract in `buddy-brain`:

- `contracts/buddy-training/README.md` defines ownership, allowed actions, boundaries, and AgentCraft/app rendering guidance.
- `contracts/buddy-training/state.schema.json` defines the shared persisted state shape for Buddy Training.

## Task contract

Plan: PR_BODY

- Owner repo: `buddy-brain`
- Scope: Buddy Training policy and persisted-state schema only
- Runtime authority: remains in `buddy-agent`
- App rendering authority: remains in `prismtek-apps`
- Validation target: schema constrains `last_action` to `none` plus the documented MVP action vocabulary
- Verification: yes
- Rollback: yes

## Problem

Buddy Training needs a repo-owned policy and schema contract before runtime and app surfaces can safely persist or render training state.

## Smallest useful wedge

Add a minimal contract README and JSON schema that define ownership, action vocabulary, and persisted state shape.

## Verification plan

Use GitHub Actions readiness, lint, CI, smoke, and CodeQL checks for this PR. The schema change is docs/schema-only and should not alter runtime behavior.

## Rollback plan

Revert this PR to remove the Buddy Training contract and schema if downstream runtime/app surfaces need a different contract shape.

## Notes

- Keeps Buddy Training as cosmetic/progression state only.
- Coordinates with the runtime PR in `buddy-agent` and app-facing type PR in `prismtek-apps`.

## Validation

GitHub Actions are expected to validate this PR. The `task-readiness` workflow requires this task contract block.