### PR TITLE
feat(skills): track Buddy YouTube lipsync skill

### DIFF
--- a/skills/media/prismtek-youtube-buddy-lipsync/SKILL.md
+++ b/skills/media/prismtek-youtube-buddy-lipsync/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: prismtek-youtube-buddy-lipsync
+description: Produce a Prismtek/Buddy talking-host overlay for narrated videos using pixel-art visemes and FFmpeg audio RMS animation.
+version: 1.1.0
+author: Prismtek
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [youtube, video, ffmpeg, imagemagick, pixel-art, vtuber, buddy, prismtek]
+    related_skills: [youtube-content, media-rendering, buddy-appearance]
+---
+
+# Prismtek YouTube Buddy Lip-Sync
+
+Use this skill to turn a clean Buddy host PNG into a lightweight audio-reactive talking-host overlay for Prismtek/Buddy videos.
+
+The workflow is intentionally simple and robust:
+
+- no ML lip-sync dependency;
+- no face-swap, cloning, impersonation, or deepfake pipeline;
+- no private media assets committed;
+- ImageMagick for deterministic pixel-art mouth/viseme generation;
+- FFmpeg/ffprobe for audio RMS analysis and video compositing;
+- JSON receipts for repeatable render review.
+
+## Required Tools
+
+```bash
+command -v magick
+command -v ffmpeg
+command -v ffprobe
+python3 --version
+```
+
+## Generate Buddy Visemes
+
+```bash
+python3 scripts/generate_buddy_v12_visemes.py \
+  ~/.hermes/assets/prismtek-youtube/avatar/buddy-host-main-clean.png \
+  --out-dir ~/.hermes/assets/prismtek-youtube/avatar
+```
+
+## Render a Proof Clip
+
+```bash
+python3 scripts/prismtek_youtube_avatar_lipsync.py \
+  /path/to/base-video.mp4 \
+  --closed ~/.hermes/assets/prismtek-youtube/avatar/buddy-host-main-v12-mouth-closed.png \
+  --open ~/.hermes/assets/prismtek-youtube/avatar/buddy-host-main-v12-mouth-small-open.png \
+  --output /tmp/buddy-lipsync-proof.mp4 \
+  --limit-seconds 20
+```
+
+For full render, omit `--limit-seconds`.
+
+## Operator Notes
+
+This skill renders local media only. Keep source media, generated avatars, rendered MP4s, and receipts out of public git history.

--- a/skills/media/prismtek-youtube-buddy-lipsync/skill.manifest.json
+++ b/skills/media/prismtek-youtube-buddy-lipsync/skill.manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "prismtek-youtube-buddy-lipsync",
+  "version": "1.1.0",
+  "description": "Produce a Buddy talking-host overlay for narrated videos using pixel-art visemes and FFmpeg audio RMS animation.",
+  "owner": "Prismtek",
+  "license": "MIT",
+  "platforms": ["macos", "linux"],
+  "requires": {
+    "python": ">=3.11",
+    "commands": ["magick", "ffmpeg", "ffprobe"]
+  },
+  "entrypoints": {
+    "generate_visemes": "scripts/generate_buddy_v12_visemes.py",
+    "render_lipsync": "scripts/prismtek_youtube_avatar_lipsync.py"
+  },
+  "artifacts": {
+    "committed": ["SKILL.md", "skill.manifest.json", "scripts/*.py", "tests/*.py"],
+    "generated": ["render outputs", "generated avatar states", "receipt json"]
+  },
+  "verification": [
+    "python3 -m py_compile scripts/*.py",
+    "python3 -m pytest tests/test_prismtek_youtube_buddy_lipsync.py"
+  ]
+}


### PR DESCRIPTION
## Summary

Tracks the Prismtek YouTube Buddy lip-sync skill reference in `buddy-brain`.

## Changes

- Adds `skills/media/prismtek-youtube-buddy-lipsync/SKILL.md`
- Adds `skills/media/prismtek-youtube-buddy-lipsync/skill.manifest.json`
- Documents a local, deterministic Buddy talking-host overlay workflow using pixel-art visemes plus FFmpeg/ffprobe audio RMS animation
- Keeps the workflow explicitly local-only: no face-swap, cloning, impersonation, deepfake pipeline, or committed private media assets

## Operator posture

Generated media, source media, avatar outputs, rendered MP4s, and receipts should stay out of public git history unless explicitly sanitized and approved.

## Verification notes

The tracked skill declares expected local verification commands in its manifest. Follow-up work should ensure registry coverage and any referenced scripts/tests are committed before relying on the skill as runnable automation.