### PR TITLE
Refresh Buddy Brain README and visual contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,114 @@
-# BMO Stack
+<p align="center">
+  <img src="assets/buddy-brain-mascot.svg" alt="Buddy Brain animated ASCII mascot" width="320">
+</p>
 
-`BeMore-stack` is the operator, policy, and integration repository for BMO.
+<h1 align="center">Buddy Brain</h1>
 
-It is the canonical source for BMO startup context, council contracts, operator workflows, runtime
-runbooks, workspace sync, and cross-repo integration glue. It does not pretend to own every live
-surface in the broader system.
+<p align="center"><strong>Operator brain, policy layer, council memory, and cross-repo coordination stack for Buddy / BeMore.</strong></p>
 
-It does not own the iPhone app's core lovable Buddy loop. `prismtek-apps` now owns the standalone
-phone-first Buddy product surface: care, training, customization, collection, sparring, and
-trade-ready Buddy packages. `BeMore-stack` remains the deeper operator/runtime truth behind that
-product when the app needs posture, contracts, or integration depth.
+<p align="center">
+  <a href="#what-works-today"><strong>What works</strong></a>
+  &nbsp;•&nbsp;
+  <a href="#what-does-not-work-yet"><strong>What does not work yet</strong></a>
+  &nbsp;•&nbsp;
+  <a href="#buddy-visual-contract"><strong>Buddy visual contract</strong></a>
+  &nbsp;•&nbsp;
+  <a href="#quick-start"><strong>Quick start</strong></a>
+</p>
+
+<p align="center">
+  <img src="assets/default-buddy.svg" alt="Default mint pixel Buddy avatar" width="180">
+</p>
+
+## What this repo is
+
+`buddy-brain` is the operator-side source of truth for the Buddy / BeMore system.
+
+It owns the durable context, policy, council roles, operator runbooks, runtime posture, skills registry, sync helpers, and coordination contracts that the app/runtime repos should consume. It is not the iPhone app, not the public website, not the Telegram host runtime, and not a magic autonomous operator that can safely act everywhere without review.
+
+Historical names still appear in docs and scripts:
+
+- **BMO Stack**: older visible name for this operator stack.
+- **BeMore-stack**: current stack identity used in some paths/docs.
+- **Buddy Brain**: this repo’s clearer role in the broader Buddy system.
+
+The core boundary is simple: this repo defines the brain, posture, memory, runbooks, skills, and operator contracts. Product surfaces like `prismtek-apps`, `buddy-agent`, `omni-buddy`, `knowledge-vault`, and public website/runtime repos should use those contracts instead of inventing a second source of truth.
+
+## What works today
+
+| Area | Owned here | Useful commands / files | Status |
+| --- | --- | --- | --- |
+| Startup posture | Canonical cold-start order and operator rules | `AGENTS.md`, `soul.md`, `memory.md`, `routines.md`, `RESPONSE_GUIDE.md` | Usable source of truth |
+| Council contracts | Role definitions, council posture, coordination docs | `context/council/`, `config/council/`, `context/identity/AGENTS.md` | Usable docs/config |
+| Context and continuity | Runtime memory, task state, work-in-progress, continuity reports | `context/`, `memory/`, `TASK_STATE.md`, `WORK_IN_PROGRESS.md` | Usable, but some older state may be stale |
+| Operator runbook | Day-to-day commands and recovery flows | `context/RUNBOOK.md`, `make doctor`, `make doctor-plus`, `make health-check` | Local-first checks |
+| Workspace sync | Host/repo context sync and project snapshots | `make sync-context`, `make workspace-sync`, `make project-snapshot` | Local sync helpers |
+| Runtime profiles | BMO runtime launch/profile routing helpers | `make runtime-doctor`, `make runtime-launch-dry`, `make runtime-cloud-dry`, `make runtime-router` | Local/runtime operator tools |
+| Worker sandbox | OpenShell/OpenClaw worker sandbox setup | `make worker-create`, `make worker-upload-config`, `make worker-status`, `make worker-ready` | Host-dependent helpers |
+| OpenClaw boundary | MacBook/OpenClaw boundary and host policy docs/checks | `make openclaw-boundary-doctor`, `make openclaw-host-policy` | Guardrail tooling |
+| Durable tasks | Resume/cancel/status loop for longer operator work | `make durable-init`, `make durable-run-next`, `make durable-status`, `make durable-resume`, `make durable-cancel` | Local task runtime surface |
+| AgentCraft bridge | Local observability / hero event reporting | `make agentcraft-start`, `make agentcraft-health`, `make agentcraft-smoke` | Optional local bridge |
+| Prismtek site reports | Public-site parity and route reporting helpers | `make site-route-report`, `make site-parity-report`, `make site-work-report` | Reporting/scaffold helpers |
+| Omni handoff | Raspberry Pi / Omni Buddy sync and launch helpers | `make omni-sync`, `make omni-doctor`, `make omni-launch` | Host/device-dependent helpers |
+| Skills | Operator skills, manifests, validation expectations | `skills/`, `skills/README.md`, `context/skills/SKILLS.md` | Usable registry with ongoing cleanup |
+| Codex bridge | Repo-local Codex dispatch contract | `mcp/codex-bridge/` | Local integration seam |
+| Licensing/provenance | Related-repo notices and matrix | `LICENSE`, `NOTICE`, `THIRD_PARTY_NOTICES.md`, `docs/LICENSE_MATRIX.md` | Tracked docs |
+
+## What does not work yet
+
+These are explicit boundaries, not failures to hide.
+
+| Area | Current boundary |
+| --- | --- |
+| Standalone iPhone Buddy UX | Owned by `prismtek-apps`, not this repo. This repo provides contracts/posture only. |
+| Telegram-facing runtime delivery | Owned by the live OpenClaw host/runtime path. Do not claim Telegram fixes from this repo alone. |
+| Public `prismtek.dev` behavior | Owned by the public web repo/runtime. Site docs/reports here are coordination aids, not deployment proof. |
+| Fully autonomous account actions | Not safe by default. External actions need explicit user approval, secrets gates, and owner-specific adapters. |
+| Secrets/runtime auth | Must be configured outside public git history. Do not commit `.env`, account tokens, runtime keys, generated private media, or receipts with sensitive data. |
+| Host-only dependencies | Docker, OpenClaw, OpenShell, local model tools, AgentCraft, FFmpeg/ImageMagick, and device-specific paths must exist locally before related make targets work. |
+| Single perfect source of freshness | Some continuity/task files can lag. Prefer current repo state, current PRs/checks, and live host validation over old status notes. |
+| Runtime parity across all repos | This repo coordinates, but actual product/runtime parity requires changes in the owning repo as well. |
+| Unsafe destructive automation | Purchases, money movement, destructive file changes, account changes, posting, messaging, or calendar creation are not allowed without explicit approval and audited adapters. |
 
 ## System boundaries
 
-- `BeMore-stack`: operator workflows, startup context, council policy, GitHub automation, and local
-  integration glue
-- `prismtek-apps`: shipped product UX, including the standalone iPhone Buddy companion experience
-- `openclaw`: live Telegram/runtime delivery behavior
-- `prismtek-site`: public-web `prismtek.dev` surface and site-backed APIs
+| Repo / surface | Role |
+| --- | --- |
+| `buddy-brain` | Operator brain, policy, council, memory, runbooks, cross-repo coordination, skills registry, local helper commands |
+| `buddy-agent` | Runnable local companion/runtime package, CLI, Alpha Runtime path, appearance template, Game Studio/playground surfaces |
+| `prismtek-apps` | Shipped iOS/macOS Buddy product UX: care loop, training UI, customization, models tab, app surfaces |
+| `omni-buddy` | Raspberry Pi / local multimodal voice, vision, local model, and device runtime path |
+| `knowledge-vault` | Agent-readable knowledge base, long-form memory, wiki/reading path engine, human navigable docs |
+| OpenClaw host path | Live Telegram/runtime delivery behavior |
+| `prismtek-site` / public web runtime | Public `prismtek.dev` site and site-backed APIs |
 
 This repo stays explicit about those ownership lines so operator claims remain honest.
 
 ## What this repo owns
 
-- the BMO operating contract in `AGENTS.md`, `soul.md`, `memory.md`, and `routines.md`
-- council role definitions in `context/council/` and `config/council/`
-- operator plans, runbooks, continuity, and decision records in `context/`
-- workspace sync, runtime helpers, and maintenance scripts in `scripts/`
-- reusable operator skills in `skills/`
-- the repo-local Codex bridge in `mcp/codex-bridge/`
-- cross-repo donor, licensing, and integration documentation
+- the BMO/Buddy operating contract in `AGENTS.md`, `soul.md`, `memory.md`, and `routines.md`;
+- council role definitions in `context/council/` and `config/council/`;
+- operator plans, runbooks, continuity, and decision records in `context/`;
+- workspace sync, runtime helpers, recovery scripts, and maintenance targets in `scripts/` and `Makefile`;
+- reusable operator skills in `skills/`;
+- the repo-local Codex bridge in `mcp/codex-bridge/`;
+- cross-repo donor, licensing, provenance, and integration documentation;
+- visual/art-direction contracts for Buddy-branded operator assets.
 
 ## Quick start
 
-Read these first:
+Read these first on a fresh operator session:
 
 1. `AGENTS.md`
 2. `soul.md`
 3. `memory.md`
 4. `routines.md`
-5. `context/identity/AGENTS.md`
-6. `context/RUNBOOK.md`
-7. `TASK_STATE.md`
-8. `WORK_IN_PROGRESS.md`
+5. `RESPONSE_GUIDE.md`
+6. `context/identity/AGENTS.md`
+7. `context/RUNBOOK.md`
+8. `TASK_STATE.md`
+9. `WORK_IN_PROGRESS.md`
+10. `skills/README.md`
 
 Run the core validation path:
 
@@ -60,49 +126,76 @@ make doctor-plus
 make health-check
 make sync-context
 make project-snapshot
+make continuity-report
 make site-route-report
 make site-parity-report
+make agentcraft-smoke
 ```
+
+Host-dependent commands may fail until Docker, OpenClaw, OpenShell, AgentCraft, local model tooling, or device-specific paths are installed and configured.
+
+## Buddy visual contract
+
+The Buddy avatar used by this repo should match the attached Buddy reference style and stay consistent with `buddy-agent`:
+
+- round mint/cyan pixel-pet body;
+- deep navy high-contrast pixel outline;
+- heart-shaped antler/ear nubs;
+- small top tuft;
+- large soft face panel with tiny dot eyes, small smile, and plus/blush cheeks;
+- tiny side arms and rounded feet;
+- gold heart belly charm;
+- crisp pixel clusters with no blurry painterly rendering;
+- transparent sprite background for app/runtime assets.
+
+The ASCII mascot should cycle through the same default state order:
+
+```text
+idle -> happy -> thinking -> sleepy -> repeat
+```
+
+See [`docs/BUDDY_VISUAL_CONTRACT.md`](docs/BUDDY_VISUAL_CONTRACT.md) and [`config/buddy-visual-contract.json`](config/buddy-visual-contract.json) for the repo-local contract.
 
 ## Repository map
 
-- `context/`: plans, council docs, continuity, site notes, and operating documents
-- `config/`: machine-readable council, GitHub, routine, and operator manifests
-- `scripts/`: runtime doctor, sync, bootstrap, recovery, and reporting helpers
-- `skills/`: repo-owned operator skill packs
-- `mcp/codex-bridge/`: isolated Codex CLI dispatch into per-run git worktrees with structured artifacts
-- `memory/`: persistent notes and decision trails
-- `docs/`: architecture, integration, upgrade, and licensing references
+| Path | Purpose |
+| --- | --- |
+| `AGENTS.md` | Cold-start entry point and operator rules |
+| `context/` | Plans, council docs, continuity, site notes, operating documents |
+| `config/` | Machine-readable council, GitHub, routine, operator, and visual manifests |
+| `scripts/` | Runtime doctor, sync, bootstrap, recovery, reporting, and helper scripts |
+| `skills/` | Repo-owned operator skill packs |
+| `mcp/codex-bridge/` | Isolated Codex CLI dispatch into per-run git worktrees with structured artifacts |
+| `memory/` | Persistent notes and decision trails |
+| `docs/` | Architecture, integration, upgrade, visual, and licensing references |
+| `assets/` | Lightweight README/brand assets for Buddy Brain docs |
 
 ## Product adapter boundary
 
-`prismtek-apps` may present Buddy Studio, memory review, and Codex task controls to end users, but
-it should consume the posture, council contracts, skills manifests, and Codex execution path defined
-here instead of inventing a second agent system.
+`prismtek-apps` may present Buddy Studio, memory review, council controls, and Codex task controls to end users, but it should consume the posture, council contracts, skills manifests, and Codex execution path defined here instead of inventing a second agent system.
+
+`buddy-agent` may package runnable companion/runtime features, but durable policy, council posture, and operator continuity should still come back through this repo when they become shared system truth.
 
 ## Runtime posture
 
 This repo is intentionally local-first and operator-visible.
 
-- Host OpenClaw handles Telegram-facing runtime behavior.
-- OpenShell and NemoClaw provide disposable worker sandboxes.
-- `BeMore-stack` provides the canonical operating environment, policy surface, and integration glue.
-- The iOS app uses its own app-container workspace. It must not read or mutate the MacBook `~/.openclaw` runtime unless Cody explicitly connects it through a gateway, pairing, or export/import path.
-
 Manual operator steps still exist:
 
-1. Install host prerequisites such as Docker, OpenClaw, OpenShell, and any local model/runtime dependencies.
+1. Install host prerequisites such as Docker, OpenClaw, OpenShell, AgentCraft, FFmpeg/ImageMagick, and any local model/runtime dependencies.
 2. Configure `.env`, secrets, and runtime auth outside this repo.
-3. Merge and deploy `openclaw` changes when Telegram runtime behavior changes.
-4. Merge and deploy `prismtek-site` changes when public-web behavior changes.
+3. Merge and deploy OpenClaw changes when Telegram runtime behavior changes.
+4. Merge and deploy public web changes when `prismtek.dev` behavior changes.
 5. Restart or repoint live runtime owners when their deployment path requires it.
+6. Verify host/device behavior before claiming a live fix.
 
 ## Source-of-truth rules
 
-- Do not claim Telegram runtime fixes from `BeMore-stack` alone unless the relevant `openclaw` path was changed and validated.
-- Do not claim `prismtek.dev` web-chat fixes from `BeMore-stack` alone unless the relevant `prismtek-site` path was changed and validated.
+- Do not claim Telegram runtime fixes from `buddy-brain` alone unless the relevant OpenClaw path was changed and validated.
+- Do not claim `prismtek.dev` web-chat fixes from `buddy-brain` alone unless the relevant web runtime path was changed and validated.
 - Do not patch vendored or donor paths first when the real owner is upstream.
 - Prefer machine-checkable manifests, validators, and runbooks over doc-only promises.
+- Keep repo state, host runtime state, and public/live state separate in status reports.
 - Use `make openclaw-boundary-doctor` to verify the MacBook OpenClaw/runtime boundary and `make openclaw-host-policy` to reapply the host Telegram delivery policy.
 
 ## Licensing and provenance
@@ -122,3 +215,4 @@ This repository is licensed under the Apache License 2.0.
 - `docs/BMO_NATIVE_RUNTIME.md`
 - `docs/BMO_MYTHOS_LITE.md`
 - `docs/MISSION_CONTROL_BMO_STACK_SYNC.md`
+- `docs/BUDDY_VISUAL_CONTRACT.md`

--- a/assets/buddy-brain-mascot.svg
+++ b/assets/buddy-brain-mascot.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 330" role="img" aria-labelledby="title desc" style="background:transparent;image-rendering:pixelated;text-rendering:geometricPrecision">
+<title id="title">Buddy Brain animated ASCII mascot</title>
+<desc id="desc">Transparent animated ASCII Buddy Brain mascot cycling through idle, happy, thinking, and sleepy operator states.</desc>
+<style>
+  .label,.caption,.ascii{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace;font-weight:800;letter-spacing:0}
+  .label{font-size:30px;fill:#08165c}
+  .caption{font-size:12px;fill:#2fb8cf}
+  .ascii{font-size:9.2px;white-space:pre;fill:#08165c}
+  .bob{animation:bob 2.4s ease-in-out infinite}
+  .frame{opacity:0;animation-duration:4.8s;animation-iteration-count:infinite;animation-timing-function:steps(1,end)}
+  .idle{animation-name:idleFrame}
+  .happy{animation-name:happyFrame}
+  .thinking{animation-name:thinkingFrame}
+  .sleepy{animation-name:sleepyFrame}
+  @keyframes bob{0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}}
+  @keyframes idleFrame{0%,24.99%{opacity:1}25%,100%{opacity:0}}
+  @keyframes happyFrame{0%,24.99%{opacity:0}25%,49.99%{opacity:1}50%,100%{opacity:0}}
+  @keyframes thinkingFrame{0%,49.99%{opacity:0}50%,74.99%{opacity:1}75%,100%{opacity:0}}
+  @keyframes sleepyFrame{0%,74.99%{opacity:0}75%,99.99%{opacity:1}100%{opacity:0}}
+  @media (prefers-reduced-motion:reduce){.bob,.frame{animation:none}.idle{opacity:1}}
+  @media (prefers-color-scheme:dark){.label,.ascii{fill:#cffff2}.caption{fill:#8ee9df}}
+</style>
+<text class="label" x="210" y="34" text-anchor="middle">buddy brain</text>
+<text class="caption" x="210" y="54" text-anchor="middle">operator memory • council policy • safe coordination</text>
+<g class="bob">
+  <g class="frame idle">
+    <text class="ascii" x="38" y="80" xml:space="preserve">
+      <tspan x="38">             .&lt;3.                 .&lt;3.</tspan>
+      <tspan x="38" dy="13">           .'    '.             .'    '.</tspan>
+      <tspan x="38" dy="13">          /  ..   \    _^_    /   ..  \</tspan>
+      <tspan x="38" dy="13">             ___/#############\___</tspan>
+      <tspan x="38" dy="13">           .##ooo----[ BRAIN ]----ooo##.</tspan>
+      <tspan x="38" dy="13">      o   /##o+----.---------.----+o##\   o</tspan>
+      <tspan x="38" dy="13">          |##+----|  o     o  |----+##|</tspan>
+      <tspan x="38" dy="13">          |##+----|     u     |----+##|</tspan>
+      <tspan x="38" dy="13">          |##+----'-----------'----+##|</tspan>
+      <tspan x="38" dy="13">           \##ooo--- policy ---ooo##/</tspan>
+      <tspan x="38" dy="13">             '###%%---&lt;3---%%###'</tspan>
+      <tspan x="38" dy="13">                ##           ##</tspan>
+    </text>
+  </g>
+  <g class="frame happy">
+    <text class="ascii" x="38" y="80" xml:space="preserve">
+      <tspan x="38">           \&lt;3/                 \&lt;3/</tspan>
+      <tspan x="38" dy="13">           .' '.               .' '.</tspan>
+      <tspan x="38" dy="13">          /  ** \    _^_      / **  \</tspan>
+      <tspan x="38" dy="13">             ___/#############\___</tspan>
+      <tspan x="38" dy="13">        *.##ooo----[ BRAIN ]----ooo##.*</tspan>
+      <tspan x="38" dy="13">  \o/  /##o+----.---------.----+o##\  \o/</tspan>
+      <tspan x="38" dy="13">          |##+----|  ^     ^  |----+##|</tspan>
+      <tspan x="38" dy="13">          |##+----|   \___/   |----+##|</tspan>
+      <tspan x="38" dy="13">          |##+----'-----------'----+##|</tspan>
+      <tspan x="38" dy="13">           \##ooo--- green ---ooo##/</tspan>
+      <tspan x="38" dy="13">             '###%%---&lt;3---%%###'</tspan>
+      <tspan x="38" dy="13">                ##           ##</tspan>
+    </text>
+  </g>
+  <g class="frame thinking">
+    <text class="ascii" x="38" y="80" xml:space="preserve">
+      <tspan x="38">             .&lt;3.                 .&lt;3.   ?</tspan>
+      <tspan x="38" dy="13">           .'    '.             .'    '.</tspan>
+      <tspan x="38" dy="13">          /  ..   \    _^_    /   ..  \</tspan>
+      <tspan x="38" dy="13">             ___/#############\___     ?</tspan>
+      <tspan x="38" dy="13">           .##ooo----[ BRAIN ]----ooo##.</tspan>
+      <tspan x="38" dy="13">      o   /##o+----.---------.----+o##\</tspan>
+      <tspan x="38" dy="13">          |##+----|  o     o  |----+##|</tspan>
+      <tspan x="38" dy="13">          |##+----|     -     |----+##| ...</tspan>
+      <tspan x="38" dy="13">          |##+----'-----------'----+##|</tspan>
+      <tspan x="38" dy="13">           \##ooo--- review --ooo##/</tspan>
+      <tspan x="38" dy="13">             '###%%---&lt;3---%%###'</tspan>
+      <tspan x="38" dy="13">                ##           ##</tspan>
+    </text>
+  </g>
+  <g class="frame sleepy">
+    <text class="ascii" x="38" y="80" xml:space="preserve">
+      <tspan x="38">             .&lt;3.                 .&lt;3.</tspan>
+      <tspan x="38" dy="13">           .'    '.             .'    '.</tspan>
+      <tspan x="38" dy="13">          /  zz   \    _^_    /   zz  \</tspan>
+      <tspan x="38" dy="13">             ___/#############\___    Zz</tspan>
+      <tspan x="38" dy="13">           .##ooo----[ BRAIN ]----ooo##.</tspan>
+      <tspan x="38" dy="13">          /##o+----.---------.----+o##\</tspan>
+      <tspan x="38" dy="13">          |##+----|  -     -  |----+##|</tspan>
+      <tspan x="38" dy="13">          |##+----|     .     |----+##|</tspan>
+      <tspan x="38" dy="13">          |##+----'-----------'----+##|</tspan>
+      <tspan x="38" dy="13">           \##ooo--- standby -ooo##/</tspan>
+      <tspan x="38" dy="13">             '###%%---&lt;3---%%###'</tspan>
+      <tspan x="38" dy="13">                ##           ##</tspan>
+    </text>
+  </g>
+</g>
+<text class="caption" x="210" y="308" text-anchor="middle">drafts before actions • repo truth before claims</text>
+</svg>

--- a/assets/default-buddy.svg
+++ b/assets/default-buddy.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc" shape-rendering="crispEdges">
+  <title id="title">Default Pixel Buddy</title>
+  <desc id="desc">Round mint pixel Buddy with heart antler ears, navy outline, face panel, tiny limbs, top tuft, and gold heart charm.</desc>
+  <style>
+    svg{background:transparent;image-rendering:pixelated}
+    .o{fill:#08165c}.s{fill:#2fb8cf}.b{fill:#8ee9df}.f{fill:#cffff2}.hi{fill:#effff9}.g{fill:#ffd45e}.gs{fill:#f69c45}.w{fill:#f8fbff}
+  </style>
+
+  <path class="o" d="M31 13h9v5h6v8h-5v6h-10v-5h-6v-9h6zM88 13h9v5h6v9h-6v5H87v-6h-5v-8h6z"/>
+  <path class="b" d="M32 17h7v5h5v4h-6v4h-6v-5h-5v-5h5zM89 17h7v5h5v5h-5v4h-7v-5h-5v-4h5z"/>
+  <rect class="hi" x="34" y="18" width="8" height="4"/>
+  <rect class="hi" x="91" y="18" width="8" height="4"/>
+
+  <path class="o" d="M59 18h8v7h5v6h-7v5h-8v-6h-5v-6h7z"/>
+  <path class="b" d="M61 20h4v7h4v2h-6v5h-4v-6h-4v-2h6z"/>
+  <rect class="hi" x="63" y="20" width="4" height="4"/>
+
+  <rect class="o" x="45" y="24" width="38" height="6"/>
+  <rect class="o" x="35" y="30" width="58" height="8"/>
+  <rect class="o" x="27" y="38" width="74" height="10"/>
+  <rect class="o" x="22" y="48" width="84" height="14"/>
+  <rect class="o" x="19" y="62" width="90" height="16"/>
+  <rect class="o" x="22" y="78" width="84" height="12"/>
+  <rect class="o" x="28" y="90" width="72" height="10"/>
+  <rect class="o" x="39" y="100" width="50" height="8"/>
+
+  <rect class="b" x="45" y="30" width="38" height="6"/>
+  <rect class="b" x="37" y="36" width="54" height="8"/>
+  <rect class="b" x="30" y="44" width="68" height="12"/>
+  <rect class="b" x="25" y="56" width="78" height="16"/>
+  <rect class="b" x="24" y="72" width="80" height="12"/>
+  <rect class="b" x="30" y="84" width="68" height="10"/>
+  <rect class="b" x="41" y="94" width="46" height="8"/>
+  <rect class="s" x="25" y="72" width="12" height="12"/>
+  <rect class="s" x="31" y="84" width="16" height="8"/>
+  <rect class="s" x="47" y="94" width="40" height="4"/>
+
+  <rect class="hi" x="37" y="42" width="18" height="5"/>
+  <rect class="hi" x="33" y="49" width="8" height="4"/>
+  <rect class="hi" x="88" y="37" width="8" height="5"/>
+  <rect class="s" x="75" y="31" width="12" height="5"/>
+  <rect class="s" x="84" y="44" width="10" height="5"/>
+
+  <rect class="o" x="14" y="61" width="12" height="19"/>
+  <rect class="b" x="17" y="64" width="9" height="12"/>
+  <rect class="hi" x="18" y="64" width="6" height="4"/>
+  <rect class="o" x="102" y="61" width="12" height="19"/>
+  <rect class="b" x="102" y="64" width="9" height="12"/>
+  <rect class="hi" x="104" y="64" width="6" height="4"/>
+
+  <rect class="o" x="35" y="100" width="18" height="12"/>
+  <rect class="b" x="38" y="101" width="13" height="8"/>
+  <rect class="hi" x="39" y="101" width="8" height="3"/>
+  <rect class="o" x="75" y="100" width="18" height="12"/>
+  <rect class="b" x="77" y="101" width="13" height="8"/>
+  <rect class="hi" x="79" y="101" width="8" height="3"/>
+
+  <rect class="s" x="37" y="45" width="54" height="38"/>
+  <rect class="f" x="40" y="48" width="48" height="32"/>
+  <rect class="f" x="34" y="56" width="6" height="18"/>
+  <rect class="f" x="88" y="56" width="6" height="18"/>
+  <rect class="s" x="40" y="80" width="48" height="4"/>
+
+  <rect class="o" x="50" y="59" width="8" height="12"/>
+  <rect class="w" x="53" y="60" width="3" height="3"/>
+  <rect class="o" x="70" y="59" width="8" height="12"/>
+  <rect class="w" x="73" y="60" width="3" height="3"/>
+  <rect class="o" x="61" y="72" width="4" height="3"/>
+  <rect class="o" x="65" y="75" width="9" height="3"/>
+  <rect class="f" x="61" y="74" width="4" height="2"/>
+  <rect class="s" x="43" y="70" width="4" height="10"/>
+  <rect class="s" x="40" y="73" width="10" height="4"/>
+  <rect class="s" x="81" y="70" width="4" height="10"/>
+  <rect class="s" x="78" y="73" width="10" height="4"/>
+
+  <path class="o" d="M63 88h4v3h5v5h-3v4h-4v4h-4v-4h-4v-4h-3v-5h5v-3z"/>
+  <path class="g" d="M63 91h3v3h4v2h-3v3h-3v3h-2v-3h-3v-3h-3v-2h4v-3z"/>
+  <rect class="w" x="60" y="92" width="3" height="3"/>
+  <rect class="gs" x="66" y="97" width="3" height="3"/>
+</svg>

--- a/config/buddy-visual-contract.json
+++ b/config/buddy-visual-contract.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "name": "buddy-brain-visual-contract",
+  "display_name": "Buddy Brain Visual Contract",
+  "canonical_buddy_style": {
+    "body": "round mint/cyan pixel-pet body",
+    "outline": "deep navy high-contrast pixel outline",
+    "ears": "heart-shaped antler ears",
+    "tuft": "small top tuft",
+    "face": "large soft face panel with dot eyes, small smile, and plus/blush cheeks",
+    "limbs": "tiny side arms and rounded feet",
+    "charm": "gold heart belly charm",
+    "highlights": "asymmetric cyan and white pixel highlights",
+    "background": "transparent for reusable runtime/app assets"
+  },
+  "palette": {
+    "outline": "#08165c",
+    "cyan_shadow": "#56d6d2",
+    "mint_body": "#8ee9df",
+    "face_panel": "#cffff2",
+    "highlight": "#effff9",
+    "gold_heart": "#ffd45e",
+    "heart_shadow": "#f69c45",
+    "eye_highlight": "#f8fbff"
+  },
+  "render_modes": ["pixel", "ascii"],
+  "states": ["idle", "happy", "thinking", "sleepy"],
+  "animation": {
+    "cycle": ["idle", "happy", "thinking", "sleepy"],
+    "frame_duration_ms": 900,
+    "loop": true,
+    "reduced_motion_state": "idle"
+  },
+  "assets": {
+    "readme_mascot": "assets/buddy-brain-mascot.svg",
+    "default_pixel": "assets/default-buddy.svg"
+  },
+  "rules": {
+    "buddy_is_pet": true,
+    "device_shape_allowed": false,
+    "transparent_background": true,
+    "prefer_crisp_pixels": true,
+    "avoid_blur": true,
+    "avoid_3d_mascot_style": true,
+    "avoid_existing_character_silhouette": true
+  },
+  "repo_overlay": {
+    "allowed_motifs": [
+      "operator brain",
+      "policy",
+      "council",
+      "memory",
+      "repo status",
+      "review state"
+    ],
+    "must_preserve_base_buddy_silhouette": true
+  }
+}

--- a/docs/BUDDY_VISUAL_CONTRACT.md
+++ b/docs/BUDDY_VISUAL_CONTRACT.md
@@ -1,0 +1,86 @@
+# Buddy Visual Contract
+
+This repo uses Buddy visuals for operator-facing docs, status surfaces, and coordination diagrams. The goal is consistency with the broader Buddy system, not a new mascot fork.
+
+## Roles
+
+| Role | Asset | Purpose |
+| --- | --- | --- |
+| Buddy Brain README mascot | `assets/buddy-brain-mascot.svg` | Animated ASCII operator mascot for this repo |
+| Default pixel Buddy | `assets/default-buddy.svg` | Canonical mint pixel Buddy avatar for docs/contracts |
+| Machine-readable contract | `config/buddy-visual-contract.json` | Shared style and animation metadata |
+
+## Canonical style
+
+Buddy should look like the attached mint/cyan pixel-pet reference:
+
+- round mint/cyan body;
+- deep navy high-contrast outline;
+- heart-shaped antler/ear nubs;
+- small top tuft;
+- large soft face panel;
+- tiny dot eyes with small highlights;
+- small friendly smile;
+- plus/blush cheek marks;
+- tiny side arms;
+- tiny rounded feet;
+- gold heart belly charm;
+- asymmetric cyan and white highlight clusters;
+- transparent background for reusable assets.
+
+The look should be crisp, readable, and game/sprite friendly. Prefer hard pixel edges over soft gradients.
+
+## Animation states
+
+Buddy Brain uses the same state contract as `buddy-agent`:
+
+```text
+idle -> happy -> thinking -> sleepy -> repeat
+```
+
+| State | Operator meaning |
+| --- | --- |
+| `idle` | Ready, watching repo state, no active claim |
+| `happy` | Green checks, good handoff, completed draft/review |
+| `thinking` | Reviewing policy, reconstructing context, resolving ambiguity |
+| `sleepy` | Standby, paused, waiting for host/runtime/user action |
+
+Default timing:
+
+| Setting | Value |
+| --- | --- |
+| Frame duration | `900ms` |
+| Full cycle | `3600ms` to `4800ms` depending on surface |
+| Loop | `true` |
+| Reduced motion | Show `idle` only |
+
+## Do not draw Buddy as
+
+- a phone;
+- a gamepad;
+- a monitor/screen body;
+- a generic robot head;
+- a 3D rendered mascot;
+- a blurry painterly creature;
+- an existing copyrighted character silhouette.
+
+Buddy is the living companion. The app, terminal, website, or HUD is the device around Buddy.
+
+## Repo-specific overlay rules
+
+Buddy Brain may add operator-brain context around the base Buddy style, such as:
+
+- small `[ BRAIN ]` label in ASCII/docs mascot;
+- policy/review/green/standby captions;
+- council or memory motifs in diagrams;
+- repo-status text around the mascot.
+
+Do not change the base silhouette away from the canonical Buddy shape.
+
+## Asset hygiene
+
+- Keep SVGs lightweight and text-readable.
+- Do not commit generated private media or user-specific source assets.
+- Prefer transparent backgrounds for reusable Buddy assets.
+- Keep README assets small enough for GitHub rendering.
+- Update `config/buddy-visual-contract.json` when the style contract changes.

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 const root = path.resolve(import.meta.dirname, "..");
 const skillsDir = path.join(root, "skills");
 const registryPath = path.join(skillsDir, "index.json");
+const collectionDirectories = new Set(["media"]);
 
 function fail(message) {
   console.error(`ERROR: ${message}`);
@@ -22,6 +23,19 @@ function section(text, heading, label) {
   const remaining = text.slice(start + heading.length);
   const nextHeading = remaining.search(/\n## /);
   return nextHeading === -1 ? remaining : remaining.slice(0, nextHeading);
+}
+
+function validateCollectionDirectory(directory) {
+  const readmePath = path.join(skillsDir, directory, "README.md");
+  ensureFile(
+    readmePath,
+    `collection directory '${directory}' must have ${path.relative(root, readmePath).replaceAll("\\", "/")}`,
+  );
+
+  const text = fs.readFileSync(readmePath, "utf8");
+  if (!text.includes("## Purpose")) {
+    fail(`collection directory '${directory}' must document a ## Purpose section`);
+  }
 }
 
 const registryRaw = fs.readFileSync(registryPath, "utf8");
@@ -78,6 +92,11 @@ const skillDirectories = fs
 const registeredSkills = Object.keys(skills).sort();
 
 for (const directory of skillDirectories) {
+  if (collectionDirectories.has(directory)) {
+    validateCollectionDirectory(directory);
+    continue;
+  }
+
   if (!skills[directory]) fail(`skills/${directory} exists but is missing from skills/index.json`);
 }
 
@@ -110,4 +129,4 @@ for (const token of ["`skills/README.md`", "`skills/index.json`"]) {
   }
 }
 
-console.log("skills registry and skill docs are valid");
+console.log("skills registry, collection bundles, and skill docs are valid");

--- a/skills/media/README.md
+++ b/skills/media/README.md
@@ -1,0 +1,22 @@
+# Media Skill Bundle
+
+## Purpose
+
+`skills/media/` groups operator-side media workflow references that are not yet promoted into standalone top-level runtime skills.
+
+Use this bundle for safe, local-only media production references such as Buddy avatar visemes, talking-host overlays, render receipts, and FFmpeg/ImageMagick command notes.
+
+## Source of truth
+
+- `skills/media/prismtek-youtube-buddy-lipsync/SKILL.md`
+- `skills/media/prismtek-youtube-buddy-lipsync/skill.manifest.json`
+
+## Safety posture
+
+Media workflows in this directory are local reference workflows unless their scripts, tests, and runtime dependencies are committed and validated.
+
+Do not commit private source media, generated avatars, rendered MP4s, receipts containing sensitive paths, credentials, tokens, or user-specific raw assets.
+
+## Default action
+
+`status` — review the available media workflow references and confirm whether a given workflow is runnable, documentation-only, or blocked on missing local assets/tools.


### PR DESCRIPTION
## Summary

Refreshes `buddy-brain` so the repo presents itself as the Buddy / BeMore operator brain instead of an outdated BMO-only stack README.

## What changed

- Rewrites `README.md` with:
  - clearer `Buddy Brain` naming while preserving BMO / BeMore-stack historical context
  - explicit system boundaries across `buddy-brain`, `buddy-agent`, `prismtek-apps`, `omni-buddy`, `knowledge-vault`, OpenClaw, and public web runtime
  - `What works today` table for Makefile targets, context, council, skills, runtime helpers, durable tasks, AgentCraft, site reports, Omni handoff, Codex bridge, and licensing/provenance
  - `What does not work yet` table for live runtime/product boundaries, host dependencies, secrets, freshness, unsafe automation, and cross-repo parity gaps
  - updated quick start and source-of-truth rules
- Adds `assets/buddy-brain-mascot.svg`
  - animated ASCII Buddy Brain mascot cycling through `idle`, `happy`, `thinking`, and `sleepy`
  - reduced-motion fallback
- Adds `assets/default-buddy.svg`
  - canonical mint/cyan pixel Buddy avatar matching the attached reference style
- Adds `docs/BUDDY_VISUAL_CONTRACT.md`
  - human-readable Buddy visual/art-direction contract
- Adds `config/buddy-visual-contract.json`
  - machine-readable style, palette, animation, asset, and guardrail metadata
- Adds `skills/media/README.md`
  - documents `skills/media/` as a collection bundle so the skill validator has a top-level README for the pre-existing media subtree
- Updates `scripts/validate-skills.mjs`
  - treats `skills/media/` as a documented collection bundle instead of requiring it to be a runnable top-level skill in `skills/index.json`

## Safety / honesty posture

This is docs/assets/config/validator metadata only. It does not claim live Telegram, website, app, runtime, or external account behavior changed. The README now explicitly separates repo truth, host runtime truth, and public/live truth.

## Task contract

Plan: `PR_BODY`

## Problem

PR #316 was blocked because required checks failed after the README/asset refresh. The task-readiness workflow requires an explicit task contract in the PR body, and the autonomy smoke path executes skill validation that does not currently distinguish documented collection bundles such as `skills/media/` from runnable top-level skills.

## Smallest useful wedge

Keep the README and Buddy visual contract changes, add the missing PR task contract, document the `skills/media/` collection, and make the skill validator treat `media` as a documented collection bundle rather than a registry-backed runnable skill.

## Verification plan

- Confirm `task-readiness` accepts this PR body with `Plan: PR_BODY`, required headings, `- Verification: yes`, and `- Rollback: yes`.
- Confirm autonomy smoke can pass `node scripts/validate-skills.mjs` with the documented `skills/media/` collection.
- Confirm general CI/lint/codeql checks remain green.

## Rollback plan

Revert the README/assets/config/docs changes and the validator collection-bundle exception if the repo decides `skills/media/` should instead be promoted into a full registry-backed runnable skill.

- Verification: yes
- Rollback: yes