### PR TITLE
feat: report Trust Fabric policy and verified outcomes

### DIFF
--- a/.github/workflows/trust-fabric-report.yml
+++ b/.github/workflows/trust-fabric-report.yml
@@ -1,0 +1,36 @@
+name: Trust Fabric report
+
+on:
+  push:
+    paths:
+      - "scripts/buddy_trust_fabric_report.py"
+      - "tests/test_trust_fabric_report.py"
+      - "prismtek.component.json"
+      - "PRISMTEK_STACK.md"
+      - ".github/workflows/trust-fabric-report.yml"
+  pull_request:
+    paths:
+      - "scripts/buddy_trust_fabric_report.py"
+      - "tests/test_trust_fabric_report.py"
+      - "prismtek.component.json"
+      - "PRISMTEK_STACK.md"
+      - ".github/workflows/trust-fabric-report.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install pytest
+        run: python -m pip install pytest
+      - name: Compile report
+        run: python -m py_compile scripts/buddy_trust_fabric_report.py
+      - name: Run focused tests
+        run: pytest -q tests/test_trust_fabric_report.py

--- a/.github/workflows/trust-fabric-report.yml
+++ b/.github/workflows/trust-fabric-report.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "scripts/buddy_trust_fabric_report.py"
+      - "scripts/__init__.py"
       - "tests/test_trust_fabric_report.py"
       - "prismtek.component.json"
       - "PRISMTEK_STACK.md"
@@ -11,6 +12,7 @@ on:
   pull_request:
     paths:
       - "scripts/buddy_trust_fabric_report.py"
+      - "scripts/__init__.py"
       - "tests/test_trust_fabric_report.py"
       - "prismtek.component.json"
       - "PRISMTEK_STACK.md"
@@ -33,4 +35,6 @@ jobs:
       - name: Compile report
         run: python -m py_compile scripts/buddy_trust_fabric_report.py
       - name: Run focused tests
-        run: pytest -q tests/test_trust_fabric_report.py
+        env:
+          PYTHONPATH: .
+        run: python -m pytest -q tests/test_trust_fabric_report.py

--- a/PRISMTEK_STACK.md
+++ b/PRISMTEK_STACK.md
@@ -1,0 +1,25 @@
+# Prismtek Buddy Stack
+
+Buddy Brain is the **governance and measurement layer** of the Prismtek Buddy Agent Platform. It does not retrieve private data directly and it does not perform guarded runtime actions.
+
+Its machine-readable ownership and dependencies are declared in [`prismtek.component.json`](prismtek.component.json). The canonical topology is maintained by BUAP.
+
+## Buddy Brain owns
+
+- council and operator policy
+- repository readiness scoring
+- routing feedback
+- trust-policy outcome reporting
+- cost per verified completion
+
+## Trust Fabric reporting
+
+Buddy Agent produces policy decisions, verification receipts, and task economics. Buddy Brain aggregates those records without treating retrieval success as completion.
+
+```bash
+python scripts/buddy_trust_fabric_report.py build/run-a build/run-b \
+  --format markdown \
+  --output build/trust-fabric-report.md
+```
+
+The report separates allow, review, and block decisions; stale and conflicting evidence; verified artifact completion; direct cost; and human review time.

--- a/prismtek.component.json
+++ b/prismtek.component.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://raw.githubusercontent.com/codysumpter-cloud/buddy-universal-agent-profile/main/schemas/prismtek-component.schema.json",
+  "schema_version": "1.0",
+  "component": "buddy-brain",
+  "repository": "codysumpter-cloud/buddy-brain",
+  "role": "governance, council policy, repository readiness, routing feedback, and verified-outcome economics",
+  "owns": [
+    "governance",
+    "policy",
+    "readiness-scoring",
+    "routing-feedback",
+    "outcome-economics"
+  ],
+  "provides": [
+    {
+      "contract": "buddy.policy-report.v1",
+      "path": "scripts/buddy_trust_fabric_report.py"
+    },
+    {
+      "contract": "buddy.task-economics-report.v1",
+      "path": "scripts/buddy_task_economics.py"
+    }
+  ],
+  "consumes": [
+    {
+      "contract": "buddy.policy-decision.v1",
+      "from": "buddy-agent"
+    },
+    {
+      "contract": "buddy.task-economics.v1",
+      "from": "buddy-agent"
+    },
+    {
+      "contract": "knowledge.graph.v1",
+      "from": "knowledge-vault"
+    }
+  ],
+  "events": {
+    "emits": [
+      "policy_decision_made",
+      "council_update"
+    ],
+    "receives": [
+      "evidence_evaluated",
+      "execution_verified"
+    ]
+  },
+  "health_checks": [
+    "pytest -q tests/test_trust_fabric_report.py",
+    "python -m py_compile scripts/buddy_trust_fabric_report.py"
+  ],
+  "stack_map": "https://github.com/codysumpter-cloud/buddy-universal-agent-profile/blob/main/linked-repos/prismtek-stack.manifest.json"
+}

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Importable Buddy Brain operator scripts used by focused tests."""

--- a/scripts/buddy_trust_fabric_report.py
+++ b/scripts/buddy_trust_fabric_report.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Summarize Trust Fabric admissibility, verification, and economics outcomes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class TrustRun:
+    task_id: str
+    decision: str
+    risk_level: str
+    stale_sources: int
+    conflicting_sources: int
+    verified: bool
+    artifact_accepted: bool
+    security_gate: str
+    total_cost: float
+    human_review_minutes: float
+
+    @classmethod
+    def from_directory(cls, directory: Path) -> "TrustRun":
+        decision = _read(directory / "policy-decision.json", required=True)
+        receipt = _read(directory / "execution-receipt.json", required=False) or {}
+        economics = _read(directory / "task-economics.json", required=False) or {}
+        return cls(
+            task_id=str(decision["task_id"]),
+            decision=str(decision["decision"]),
+            risk_level=str(decision["risk_level"]),
+            stale_sources=len(decision.get("stale_source_ids", [])),
+            conflicting_sources=len(decision.get("conflicting_source_ids", [])),
+            verified=bool(receipt.get("verified", False)),
+            artifact_accepted=bool(receipt.get("artifact_accepted", False)),
+            security_gate=str(
+                receipt.get("security_gate", economics.get("security_gate", "not-run"))
+            ),
+            total_cost=float(economics.get("model_cost", 0.0))
+            + float(economics.get("tool_cost", 0.0)),
+            human_review_minutes=float(economics.get("human_review_minutes", 0.0)),
+        )
+
+    @property
+    def verified_completion(self) -> bool:
+        return self.verified and self.artifact_accepted and self.security_gate == "pass"
+
+
+def _read(path: Path, *, required: bool) -> dict[str, Any] | None:
+    if not path.exists():
+        if required:
+            raise ValueError(f"missing required Trust Fabric output: {path}")
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def summarize(runs: Iterable[TrustRun]) -> dict[str, Any]:
+    items = list(runs)
+    total = len(items)
+    decisions = {
+        name: sum(run.decision == name for run in items)
+        for name in ("allow", "review", "block")
+    }
+    verified = sum(run.verified_completion for run in items)
+    direct_cost = sum(run.total_cost for run in items)
+    review_minutes = sum(run.human_review_minutes for run in items)
+    return {
+        "schema_version": "1.0",
+        "runs": total,
+        "decisions": decisions,
+        "allow_rate": round(decisions["allow"] / total, 4) if total else 0.0,
+        "review_rate": round(decisions["review"] / total, 4) if total else 0.0,
+        "block_rate": round(decisions["block"] / total, 4) if total else 0.0,
+        "stale_evidence_rate": round(
+            sum(run.stale_sources > 0 for run in items) / total, 4
+        )
+        if total
+        else 0.0,
+        "conflict_rate": round(
+            sum(run.conflicting_sources > 0 for run in items) / total, 4
+        )
+        if total
+        else 0.0,
+        "verified_completions": verified,
+        "verified_completion_rate": round(verified / total, 4) if total else 0.0,
+        "direct_cost": round(direct_cost, 6),
+        "human_review_minutes": round(review_minutes, 2),
+        "cost_per_verified_completion": round(direct_cost / verified, 6)
+        if verified
+        else None,
+        "high_risk_blocks": sum(
+            run.risk_level in {"high", "critical"} and run.decision == "block"
+            for run in items
+        ),
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    cost = summary["cost_per_verified_completion"]
+    cost_text = "n/a" if cost is None else f"${cost:,.4f}"
+    return "\n".join(
+        [
+            "# Buddy Trust Fabric report",
+            "",
+            f"- Runs evaluated: {summary['runs']}",
+            f"- Allowed: {summary['allow_rate'] * 100:.1f}%",
+            f"- Human review required: {summary['review_rate'] * 100:.1f}%",
+            f"- Blocked: {summary['block_rate'] * 100:.1f}%",
+            f"- Stale evidence detected: {summary['stale_evidence_rate'] * 100:.1f}%",
+            f"- Conflicts detected: {summary['conflict_rate'] * 100:.1f}%",
+            f"- Verified completion rate: {summary['verified_completion_rate'] * 100:.1f}%",
+            f"- Cost per verified completion: {cost_text}",
+            f"- Human review: {summary['human_review_minutes']:g} minutes",
+            "",
+            "A retrieval answer is not a verified completion. Only artifact acceptance plus a passing security gate counts as verified.",
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Summarize one or more Buddy Trust Fabric output directories."
+    )
+    parser.add_argument("runs", nargs="+", type=Path)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    result = summarize(TrustRun.from_directory(path) for path in args.runs)
+    rendered = (
+        json.dumps(result, indent=2) + "\n"
+        if args.format == "json"
+        else render_markdown(result)
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_trust_fabric_report.py
+++ b/tests/test_trust_fabric_report.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.buddy_trust_fabric_report import TrustRun, render_markdown, summarize
+
+
+def write(path: Path, name: str, payload: dict) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def run_dir(tmp_path: Path, name: str, decision: str, *, verified: bool = False) -> Path:
+    directory = tmp_path / name
+    write(
+        directory,
+        "policy-decision.json",
+        {
+            "task_id": name,
+            "decision": decision,
+            "risk_level": "high" if decision == "block" else "medium",
+            "stale_source_ids": ["old"] if decision == "review" else [],
+            "conflicting_source_ids": ["a", "b"] if decision == "block" else [],
+        },
+    )
+    write(
+        directory,
+        "execution-receipt.json",
+        {
+            "verified": verified,
+            "artifact_accepted": verified,
+            "security_gate": "pass" if verified else "not-run",
+        },
+    )
+    if verified:
+        write(
+            directory,
+            "task-economics.json",
+            {
+                "model_cost": 0.1,
+                "tool_cost": 0.02,
+                "human_review_minutes": 2,
+            },
+        )
+    return directory
+
+
+def test_summarizes_policy_and_verified_outcomes(tmp_path: Path):
+    paths = [
+        run_dir(tmp_path, "allowed", "allow", verified=True),
+        run_dir(tmp_path, "review", "review"),
+        run_dir(tmp_path, "blocked", "block"),
+    ]
+    result = summarize(TrustRun.from_directory(path) for path in paths)
+    assert result["runs"] == 3
+    assert result["decisions"] == {"allow": 1, "review": 1, "block": 1}
+    assert result["verified_completions"] == 1
+    assert result["high_risk_blocks"] == 1
+    assert result["cost_per_verified_completion"] == 0.12
+
+
+def test_markdown_states_verification_boundary(tmp_path: Path):
+    result = summarize(
+        [TrustRun.from_directory(run_dir(tmp_path, "allowed", "allow", verified=True))]
+    )
+    rendered = render_markdown(result)
+    assert "retrieval answer is not a verified completion" in rendered


### PR DESCRIPTION
## Summary

Adds the governance/reporting half of the Prismtek Trust Fabric.

- declares Buddy Brain's stack ownership and dependencies;
- documents its role as policy, readiness, routing feedback, and economics—not retrieval or execution;
- reads Buddy Agent Trust Fabric output directories;
- reports allow/review/block rates, stale evidence, conflicts, verified artifact completion, cost, and human review time;
- refuses to count retrieval success as verified completion;
- adds focused tests and GitHub Actions.

## Task contract

Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem

The Prismtek stack had no governance-layer report that converted Buddy Agent evidence decisions and verification receipts into policy outcomes and cost-per-verified-completion metrics.

## Smallest useful wedge

Add a dependency-light report over sanitized Trust Fabric output directories. Keep retrieval, guarded execution, artifact verification, and durable graph ingestion in their owning repositories.

## Verification plan

- Compile the reporting script.
- Run focused report tests in GitHub Actions.
- Preserve the repository's existing CI, lint, CodeQL, runtime, bootstrap, autonomy, task-readiness, and iOS checks.
- Confirm retrieval success is never counted as verified completion.

## Rollback plan

Revert this PR. The report, tests, workflow, declaration, and documentation are additive and do not alter existing runtime state or persistent data.

## Verification

Locally verified in an isolated source-layout harness:

- `pytest -q tests/test_trust_fabric_report.py` — 2 passed;
- Python compile check — passed;
- mixed allow/review/block aggregation — passed;
- cost-per-verified-completion calculation — passed;
- report explicitly states the verification boundary.

GitHub Actions still needs to rerun on the latest branch head.

## Boundary

The report consumes sanitized policy/receipt/economics outputs. It does not ingest raw prompts, credentials, browser state, or private source excerpts.