### PR TITLE
fix(actions): stop scheduled fork-sync runner churn

### DIFF
--- a/.github/workflows/fork-governor.yml
+++ b/.github/workflows/fork-governor.yml
@@ -1,17 +1,27 @@
 name: Govern forks and donors
 
 on:
-  schedule:
-    - cron: '31 */6 * * *'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/fork-governor.yml'
+      - 'scripts/fork-governor.mjs'
+      - 'scripts/fork-sync-policy.mjs'
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: fork-governor
+  cancel-in-progress: true
+
 jobs:
   govern-forks:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -31,12 +41,18 @@ jobs:
             exit 1
           fi
 
-      - name: Refresh fork inventory and seed fork sync workflows
+      - name: Refresh fork inventory
         env:
           FORK_GOVERNOR_TOKEN: ${{ secrets.FORK_GOVERNOR_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           DONORS_PATH: DONORS.yaml
         run: node scripts/fork-governor.mjs
+
+      - name: Enforce manual conflict-safe fork sync policy
+        env:
+          FORK_GOVERNOR_TOKEN: ${{ secrets.FORK_GOVERNOR_TOKEN }}
+          GITHUB_OWNER: ${{ github.repository_owner }}
+        run: node scripts/fork-sync-policy.mjs
 
       - name: Open, update, merge, or close DONORS refresh PR
         env:

--- a/docs/runbooks/FORK_GOVERNOR.md
+++ b/docs/runbooks/FORK_GOVERNOR.md
@@ -1,23 +1,34 @@
 # Fork Governor Runbook
 
-`bmo-stack` hosts the central fork governor.
+`buddy-brain` hosts the central fork governor.
 
 ## What it does
 
-On a schedule or manual dispatch, the governor will:
+When manually dispatched or when the governor policy changes, the governor will:
 
-1. enumerate the authenticated owner's fork repos
-2. install or update `.github/workflows/sync-fork-upstream.yml` inside each fork
-3. regenerate `DONORS.yaml` from the live fork inventory
-4. open or update a PR against the default branch when `DONORS.yaml` changes
+1. enumerate the authenticated owner's fork repositories
+2. refresh `.github/workflows/sync-fork-upstream.yml` inside each fork
+3. enforce a manual-only, conflict-safe sync policy
+4. regenerate `DONORS.yaml` from the live fork inventory
+5. open or update a PR against the default branch when `DONORS.yaml` changes
 
 ## Why this exists
 
-This keeps fork repos fresh from upstream without sending fork-local work back to the original repo. It also makes `DONORS.yaml` a live inventory instead of a stale hand-edited file.
+The governor keeps fork management centralized without launching hosted runners across the entire fork fleet every day. Forks remain easy to sync on demand, while diverged forks no longer fail repeatedly just because upstream has merge conflicts.
+
+## Fork sync policy
+
+Each managed fork receives `.github/workflows/sync-fork-upstream.yml` with these rules:
+
+- `workflow_dispatch` only; there is no scheduled runner usage
+- one sync may run at a time and newer requests cancel older ones
+- jobs time out after two minutes
+- GitHub responses `409` and `422` are recorded as notices requiring manual resolution, not failed runs
+- unexpected API responses still fail so genuine authentication or platform problems remain visible
 
 ## Required secret
 
-Add this repository secret to `bmo-stack`:
+Add this repository secret to `buddy-brain`:
 
 - `FORK_GOVERNOR_TOKEN`
 
@@ -28,20 +39,26 @@ Recommended token capabilities:
 - workflows: write
 - metadata: read
 
-The token must be able to access the owner's fork repos that should receive the sync workflow.
+The token must be able to access the owner's fork repositories that should receive the sync workflow.
 
 ## Workflow files
 
 - `.github/workflows/fork-governor.yml`
 - `scripts/fork-governor.mjs`
+- `scripts/fork-sync-policy.mjs`
 - `scripts/fork-governor-pr.sh`
 
 ## Generated inventory
 
 - `DONORS.yaml`
 
+## Operations
+
+Run **Govern forks and donors** manually after adding or removing forks, changing sync policy, or rotating the governor token. A policy-file change on `master` also triggers one reconciliation run automatically.
+
 ## Operational notes
 
-- fork repos may still require manual attention if upstream sync hits conflicts
-- repo-level locks or write restrictions will be surfaced in `DONORS.yaml`
-- canonical repos remain PR-driven; the governor opens or updates a PR for donor inventory refreshes instead of pushing directly to the default branch
+- fork repositories may still require manual attention when upstream and local history conflict
+- repository locks or write restrictions are surfaced by the governor
+- canonical repositories remain PR-driven
+- do not restore a fleet-wide schedule unless the expected runner usage and notification volume have been reviewed first

--- a/scripts/fork-sync-policy.mjs
+++ b/scripts/fork-sync-policy.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+const owner = process.env.GITHUB_OWNER || process.env.GITHUB_REPOSITORY_OWNER || 'codysumpter-cloud';
+const token = process.env.FORK_GOVERNOR_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+const apiBase = 'https://api.github.com';
+const workflowPath = '.github/workflows/sync-fork-upstream.yml';
+
+const workflowContent = [
+  'name: Sync fork from upstream',
+  '',
+  'on:',
+  '  workflow_dispatch:',
+  '',
+  'permissions:',
+  '  contents: write',
+  '',
+  'concurrency:',
+  '  group: sync-fork-upstream',
+  '  cancel-in-progress: true',
+  '',
+  'jobs:',
+  '  sync:',
+  '    runs-on: ubuntu-latest',
+  '    timeout-minutes: 2',
+  '    steps:',
+  '      - name: Sync default branch from upstream',
+  '        env:',
+  '          GH_TOKEN: ${{ github.token }}',
+  '          REPO: ${{ github.repository }}',
+  '          BRANCH: ${{ github.event.repository.default_branch }}',
+  '        run: |',
+  '          set -euo pipefail',
+  '          payload=$(printf \'{"branch":"%s"}\' "$BRANCH")',
+  '          status=$(curl -sS -o response.json -w "%{http_code}" \\',
+  '            -X POST \\',
+  '            -H "Accept: application/vnd.github+json" \\',
+  '            -H "Authorization: Bearer ${GH_TOKEN}" \\',
+  '            -H "X-GitHub-Api-Version: 2022-11-28" \\',
+  '            "https://api.github.com/repos/${REPO}/merge-upstream" \\',
+  '            -d "$payload")',
+  '          cat response.json',
+  '          if [ "$status" = "200" ]; then',
+  '            echo "Upstream sync complete."',
+  '          elif [ "$status" = "409" ] || [ "$status" = "422" ]; then',
+  '            echo "::notice title=Fork sync needs manual resolution::GitHub returned status $status for $REPO. No retry was scheduled."',
+  '            exit 0',
+  '          else',
+  '            echo "Unexpected response: $status" >&2',
+  '            exit 1',
+  '          fi',
+  ''
+].join('\n');
+
+function encodePath(path) {
+  return path.split('/').map(encodeURIComponent).join('/');
+}
+
+async function github(path, options = {}) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    ...(options.headers || {})
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const response = await fetch(`${apiBase}${path}`, { ...options, headers });
+  if (response.status === 204) return null;
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    const error = new Error(data?.message || `GitHub API request failed: ${response.status}`);
+    error.status = response.status;
+    error.data = data;
+    throw error;
+  }
+  return data;
+}
+
+async function listOwnedRepos() {
+  const repos = [];
+  let page = 1;
+  while (true) {
+    const batch = await github(`/user/repos?visibility=all&affiliation=owner&per_page=100&page=${page}&sort=full_name`);
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    repos.push(...batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+  return repos.filter((repo) => repo.owner?.login === owner && repo.fork && !repo.archived);
+}
+
+async function getContents(repoFullName, path, ref) {
+  try {
+    return await github(`/repos/${repoFullName}/contents/${encodePath(path)}?ref=${encodeURIComponent(ref)}`);
+  } catch (error) {
+    if (error.status === 404) return null;
+    throw error;
+  }
+}
+
+async function upsertWorkflow(repo) {
+  const existing = await getContents(repo.full_name, workflowPath, repo.default_branch);
+  if (existing?.type === 'file') {
+    const current = Buffer.from(existing.content, 'base64').toString('utf8');
+    if (current === workflowContent) return 'unchanged';
+    await github(`/repos/${repo.full_name}/contents/${encodePath(workflowPath)}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        message: 'chore(actions): make upstream sync manual and conflict-safe',
+        content: Buffer.from(workflowContent, 'utf8').toString('base64'),
+        sha: existing.sha,
+        branch: repo.default_branch
+      })
+    });
+    return 'updated';
+  }
+
+  await github(`/repos/${repo.full_name}/contents/${encodePath(workflowPath)}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      message: 'chore(actions): add manual conflict-safe upstream sync',
+      content: Buffer.from(workflowContent, 'utf8').toString('base64'),
+      branch: repo.default_branch
+    })
+  });
+  return 'created';
+}
+
+async function main() {
+  if (!token) throw new Error('Missing FORK_GOVERNOR_TOKEN (or GH_TOKEN / GITHUB_TOKEN).');
+
+  const repos = await listOwnedRepos();
+  const results = [];
+  for (const repo of repos) {
+    try {
+      results.push({ repo: repo.full_name, result: await upsertWorkflow(repo) });
+    } catch (error) {
+      results.push({ repo: repo.full_name, result: `error:${error.status || 'unknown'}` });
+    }
+  }
+
+  for (const row of results) console.log(`${row.result}\t${row.repo}`);
+  const failed = results.filter((row) => row.result.startsWith('error:'));
+  console.log(`Fork sync policy complete: ${results.length} forks scanned, ${failed.length} errors.`);
+  if (failed.length > 0) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

The fork governor was running every six hours and stamping a daily `Sync fork from upstream` workflow into 44 managed forks. Diverged forks then launched hosted runners each day only to return GitHub API `409` merge-conflict failures, generating repeated CI mail and unnecessary automation churn.

## Task contract

Plan: `PR_BODY`

- Verification: yes
- Rollback: yes

## Problem

The current control plane creates two avoidable recurring workloads: the governor itself runs four times per day, and every managed fork receives a daily hosted-runner sync. Expected merge conflicts are treated as failures, producing repeated alerts without resolving the divergence.

## Smallest useful wedge

Keep the existing fork inventory and one-click sync capability, but remove all schedules. Run the governor only manually or when its policy changes, and install a manual-only fork workflow that records expected conflicts as notices.

## Verification plan

- Validate `scripts/fork-sync-policy.mjs` with `node --check`.
- Parse the updated workflow YAML.
- Require the repository CI and readiness checks to pass.
- After merge, confirm the policy-triggered governor run completes and managed fork workflows no longer contain a `schedule` block.

## Rollback plan

Revert the squash commit for this PR. That restores the previous governor workflow and removes the new policy script. If scheduled syncing is intentionally restored later, review the expected runner volume before enabling it.

## Changes

- Remove the governor's recurring schedule; it now runs manually or once when its policy files change on `master`.
- Add concurrency cancellation and a 15-minute governor timeout.
- Add `scripts/fork-sync-policy.mjs` to replace fork-local schedules with manual-only sync workflows.
- Limit manual sync jobs to two minutes and cancel superseded requests.
- Treat expected `409` / `422` upstream conflicts as notices instead of failed runs.
- Preserve the existing donor inventory refresh and PR workflow.
- Update the operational runbook.

## Validation completed

- New Node script passed `node --check` locally.
- Workflow YAML parsed successfully.
- Branch is 3 commits ahead of `master` and 0 behind.
- Diff is limited to the governor workflow, policy script, and runbook.

## Rollout

Merging this PR triggers the updated governor once on `master`. That run first refreshes inventory, then enforces the manual-only policy across the managed fork fleet.