### PR TITLE
feat(agent-life): independently score stochastic Norn robustness

### DIFF
--- a/.github/workflows/norn-stochastic-score.yml
+++ b/.github/workflows/norn-stochastic-score.yml
@@ -1,0 +1,34 @@
+name: Norn stochastic score
+
+on:
+  pull_request:
+    paths:
+      - "scripts/norn_stochastic_score.py"
+      - "tests/test_norn_stochastic_score.py"
+      - "docs/NORN_STOCHASTIC_SCORE.md"
+      - ".github/workflows/norn-stochastic-score.yml"
+  push:
+    branches: [master]
+    paths:
+      - "scripts/norn_stochastic_score.py"
+      - "tests/test_norn_stochastic_score.py"
+      - "docs/NORN_STOCHASTIC_SCORE.md"
+      - ".github/workflows/norn-stochastic-score.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  score-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Compile scorer
+        run: python -m py_compile scripts/norn_stochastic_score.py
+      - name: Test aggregate thresholds and adversarial rejection
+        run: python -m unittest -v tests/test_norn_stochastic_score.py

--- a/docs/NORN_STOCHASTIC_SCORE.md
+++ b/docs/NORN_STOCHASTIC_SCORE.md
@@ -1,0 +1,24 @@
+# Stochastic Norn robustness scoring
+
+Buddy Brain independently scores `prismtek-norn-stochastic-arena-v1` receipts produced by the cortex-off Prismtek Buddy Core runtime.
+
+This layer complements the deterministic Norn parity score. It tests distributions and long-horizon behavior rather than repeating one fixture.
+
+## Required evidence
+
+The receipt must use seed `90210`, contain exactly 32 trials for repeated scenarios, pass SHA-256 verification, and include all six scenarios:
+
+| Scenario | Independent requirement | Weight |
+| --- | --- | ---: |
+| Noisy adaptation | Acquisition and reversal each succeed in at least 90% of trials; success counts match rates; worst reversal margin is at least `0.40` under 15% outcome noise | 25 |
+| Noisy unseen transfer | At least 90% of novel foods are selected; minimum category value stays positive; mean category value is at least `0.25` under 15% noise | 20 |
+| Random need planning | All 32 plans succeed and maximum final drive pressure is at most `0.10` | 15 |
+| Random persistence | All 32 restore trials reproduce the plan and category value with at most `1e-12` drift | 15 |
+| Ecology endurance | The simulation reaches exactly 1,000 ticks with zero extinctions, a viable population, and confirmed harvest nutrition | 15 |
+| Two-generation lineage | Two conceptions and births produce a distinct generation-two grandchild with two parents | 10 |
+
+The game runtime's pass flags are recorded for audit but do not determine the independent judgment.
+
+## Claim boundary
+
+A green `100/100` score establishes the measured seeded robustness, 1,000-tick ecology endurance, and two-generation lineage for the exact receipt. It does not establish consciousness, unrestricted general intelligence, OpenC2E behavioral equivalence, unseeded performance, or behavior outside the tested distributions.

--- a/scripts/norn_stochastic_score.py
+++ b/scripts/norn_stochastic_score.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Independently score seeded Prismtek Norn robustness receipts."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+RECEIPT_SCHEMA = "prismtek-norn-stochastic-arena-v1"
+SCORE_SCHEMA = "prismtek-norn-stochastic-score-v1"
+EXPECTED_SEED = 90210
+EXPECTED_TRIALS = 32
+REQUIRED_SCENARIOS = {
+    "noisy-adaptation": 25,
+    "noisy-unseen-transfer": 20,
+    "random-need-planning": 15,
+    "random-persistence": 15,
+    "ecology-endurance-1000-ticks": 15,
+    "two-generation-lineage": 10,
+}
+
+
+class NornStochasticScoreError(ValueError):
+    """The stochastic receipt is malformed, tampered with, or insufficient."""
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _without_hash(value: dict[str, Any]) -> dict[str, Any]:
+    copied = copy.deepcopy(value)
+    copied.pop("receipt_sha256", None)
+    return copied
+
+
+def _verify_hash(payload: dict[str, Any], label: str) -> None:
+    supplied = str(payload.get("receipt_sha256", ""))
+    if not supplied:
+        raise NornStochasticScoreError(f"{label} is missing receipt_sha256")
+    if supplied != _digest(_without_hash(payload)):
+        raise NornStochasticScoreError(f"{label} hash mismatch")
+
+
+def _number(value: Any, field: str) -> float:
+    if isinstance(value, bool):
+        raise NornStochasticScoreError(f"{field} must be numeric")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as error:
+        raise NornStochasticScoreError(f"{field} must be numeric") from error
+
+
+def _measurement(scenario: dict[str, Any], name: str) -> Any:
+    measurements = scenario.get("measurements")
+    if not isinstance(measurements, dict) or name not in measurements:
+        raise NornStochasticScoreError(
+            f"scenario {scenario.get('id')} is missing measurement {name}"
+        )
+    return measurements[name]
+
+
+def _scenario_map(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = receipt.get("scenarios")
+    if not isinstance(raw, list):
+        raise NornStochasticScoreError("receipt.scenarios must be an array")
+    result: dict[str, dict[str, Any]] = {}
+    for index, scenario in enumerate(raw):
+        if not isinstance(scenario, dict):
+            raise NornStochasticScoreError(f"scenario[{index}] must be an object")
+        scenario_id = str(scenario.get("id", ""))
+        if not scenario_id:
+            raise NornStochasticScoreError(f"scenario[{index}] requires id")
+        if scenario_id in result:
+            raise NornStochasticScoreError(f"duplicate scenario {scenario_id}")
+        _verify_hash(scenario, f"scenario {scenario_id}")
+        result[scenario_id] = scenario
+    missing = sorted(set(REQUIRED_SCENARIOS) - set(result))
+    extra = sorted(set(result) - set(REQUIRED_SCENARIOS))
+    if missing:
+        raise NornStochasticScoreError(f"missing required scenarios: {', '.join(missing)}")
+    if extra:
+        raise NornStochasticScoreError(f"unknown scenarios: {', '.join(extra)}")
+    return result
+
+
+def _rate_consistent(successes: int, trials: int, rate: float) -> bool:
+    return trials > 0 and successes >= 0 and successes <= trials and abs(rate - successes / trials) <= 1e-12
+
+
+def _judge_adaptation(scenario: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    trials = int(_number(_measurement(scenario, "trials"), "trials"))
+    acquisition_successes = int(
+        _number(_measurement(scenario, "acquisition_successes"), "acquisition_successes")
+    )
+    reversal_successes = int(
+        _number(_measurement(scenario, "reversal_successes"), "reversal_successes")
+    )
+    acquisition_rate = _number(_measurement(scenario, "acquisition_rate"), "acquisition_rate")
+    reversal_rate = _number(_measurement(scenario, "reversal_rate"), "reversal_rate")
+    margin = _number(
+        _measurement(scenario, "minimum_reversal_margin"), "minimum_reversal_margin"
+    )
+    noise = _number(_measurement(scenario, "noise_probability"), "noise_probability")
+    passed = (
+        trials == EXPECTED_TRIALS
+        and _rate_consistent(acquisition_successes, trials, acquisition_rate)
+        and _rate_consistent(reversal_successes, trials, reversal_rate)
+        and acquisition_rate >= 0.90
+        and reversal_rate >= 0.90
+        and margin >= 0.40
+        and abs(noise - 0.15) <= 1e-12
+    )
+    return passed, {
+        "trials": trials,
+        "acquisition_rate": acquisition_rate,
+        "reversal_rate": reversal_rate,
+        "minimum_reversal_margin": margin,
+        "noise_probability": noise,
+    }
+
+
+def _judge_transfer(scenario: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    trials = int(_number(_measurement(scenario, "trials"), "trials"))
+    successes = int(_number(_measurement(scenario, "successes"), "successes"))
+    rate = _number(_measurement(scenario, "success_rate"), "success_rate")
+    minimum = _number(
+        _measurement(scenario, "minimum_category_value"), "minimum_category_value"
+    )
+    mean = _number(_measurement(scenario, "mean_category_value"), "mean_category_value")
+    noise = _number(_measurement(scenario, "noise_probability"), "noise_probability")
+    passed = (
+        trials == EXPECTED_TRIALS
+        and _rate_consistent(successes, trials, rate)
+        and rate >= 0.90
+        and minimum > 0.0
+        and mean >= 0.25
+        and abs(noise - 0.15) <= 1e-12
+    )
+    return passed, {
+        "trials": trials,
+        "success_rate": rate,
+        "minimum_category_value": minimum,
+        "mean_category_value": mean,
+        "noise_probability": noise,
+    }
+
+
+def _judge_planning(scenario: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    trials = int(_number(_measurement(scenario, "trials"), "trials"))
+    successes = int(_number(_measurement(scenario, "successes"), "successes"))
+    rate = _number(_measurement(scenario, "success_rate"), "success_rate")
+    pressure = _number(
+        _measurement(scenario, "maximum_final_pressure"), "maximum_final_pressure"
+    )
+    passed = (
+        trials == EXPECTED_TRIALS
+        and _rate_consistent(successes, trials, rate)
+        and rate == 1.0
+        and pressure <= 0.10
+    )
+    return passed, {
+        "trials": trials,
+        "success_rate": rate,
+        "maximum_final_pressure": pressure,
+    }
+
+
+def _judge_persistence(scenario: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    trials = int(_number(_measurement(scenario, "trials"), "trials"))
+    successes = int(_number(_measurement(scenario, "successes"), "successes"))
+    rate = _number(_measurement(scenario, "success_rate"), "success_rate")
+    delta = _number(
+        _measurement(scenario, "maximum_value_delta"), "maximum_value_delta"
+    )
+    passed = (
+        trials == EXPECTED_TRIALS
+        and _rate_consistent(successes, trials, rate)
+        and rate == 1.0
+        and delta <= 1e-12
+    )
+    return passed, {
+        "trials": trials,
+        "success_rate": rate,
+        "maximum_value_delta": delta,
+    }
+
+
+def _judge_ecology(scenario: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    ticks = int(_number(_measurement(scenario, "ticks"), "ticks"))
+    extinctions = int(_number(_measurement(scenario, "extinctions"), "extinctions"))
+    minimum = _number(_measurement(scenario, "minimum_population"), "minimum_population")
+    final = _number(_measurement(scenario, "final_population"), "final_population")
+    nutrition = _number(
+        _measurement(scenario, "total_harvest_nutrition"), "total_harvest_nutrition"
+    )
+    passed = ticks == 1000 and extinctions == 0 and minimum > 1.0 and final > 1.0 and nutrition > 0.0
+    return passed, {
+        "ticks": ticks,
+        "extinctions": extinctions,
+        "minimum_population": minimum,
+        "final_population": final,
+        "total_harvest_nutrition": nutrition,
+    }
+
+
+def _judge_lineage(scenario: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    first = bool(_measurement(scenario, "first_conception"))
+    second = bool(_measurement(scenario, "second_conception"))
+    first_births = int(_number(_measurement(scenario, "first_birth_count"), "first_birth_count"))
+    second_births = int(
+        _number(_measurement(scenario, "second_birth_count"), "second_birth_count")
+    )
+    child = str(_measurement(scenario, "child_id"))
+    grandchild = str(_measurement(scenario, "grandchild_id"))
+    generation = int(
+        _number(_measurement(scenario, "grandchild_generation"), "grandchild_generation")
+    )
+    parents = int(
+        _number(_measurement(scenario, "grandchild_parent_count"), "grandchild_parent_count")
+    )
+    passed = (
+        first
+        and second
+        and first_births == 1
+        and second_births == 1
+        and bool(child)
+        and bool(grandchild)
+        and child != grandchild
+        and generation == 2
+        and parents == 2
+    )
+    return passed, {
+        "first_conception": first,
+        "second_conception": second,
+        "first_birth_count": first_births,
+        "second_birth_count": second_births,
+        "child_id": child,
+        "grandchild_id": grandchild,
+        "grandchild_generation": generation,
+        "grandchild_parent_count": parents,
+    }
+
+
+Judge = Callable[[dict[str, Any]], tuple[bool, dict[str, Any]]]
+JUDGES: dict[str, Judge] = {
+    "noisy-adaptation": _judge_adaptation,
+    "noisy-unseen-transfer": _judge_transfer,
+    "random-need-planning": _judge_planning,
+    "random-persistence": _judge_persistence,
+    "ecology-endurance-1000-ticks": _judge_ecology,
+    "two-generation-lineage": _judge_lineage,
+}
+
+
+def score_norn_stochastic_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    if receipt.get("schema") != RECEIPT_SCHEMA:
+        raise NornStochasticScoreError("unsupported stochastic Norn receipt schema")
+    if receipt.get("mode") != "cortex-off":
+        raise NornStochasticScoreError("stochastic Norn scoring requires cortex-off mode")
+    if receipt.get("seed") != EXPECTED_SEED or receipt.get("trials") != EXPECTED_TRIALS:
+        raise NornStochasticScoreError("unexpected stochastic seed or trial count")
+    _verify_hash(receipt, "stochastic Norn receipt")
+    scenarios = _scenario_map(receipt)
+
+    awarded = 0
+    judgments: list[dict[str, Any]] = []
+    for scenario_id, points in REQUIRED_SCENARIOS.items():
+        scenario = scenarios[scenario_id]
+        passed, evidence = JUDGES[scenario_id](scenario)
+        awarded += points if passed else 0
+        judgments.append(
+            {
+                "id": scenario_id,
+                "passed": passed,
+                "points_awarded": points if passed else 0,
+                "points_available": points,
+                "runtime_reported_pass": bool(scenario.get("passed", False)),
+                "runtime_receipt_sha256": str(scenario["receipt_sha256"]),
+                "evidence": evidence,
+            }
+        )
+
+    summary_consistent = (
+        receipt.get("scenario_count") == len(REQUIRED_SCENARIOS)
+        and receipt.get("passed_count") == len(REQUIRED_SCENARIOS)
+        and receipt.get("failed_count") == 0
+        and receipt.get("passed") is True
+    )
+    passed = all(item["passed"] for item in judgments) and summary_consistent and awarded == 100
+    score: dict[str, Any] = {
+        "schema": SCORE_SCHEMA,
+        "source_schema": RECEIPT_SCHEMA,
+        "source_receipt_sha256": str(receipt["receipt_sha256"]),
+        "mode": "cortex-off",
+        "seed": EXPECTED_SEED,
+        "trials": EXPECTED_TRIALS,
+        "score": awarded,
+        "maximum_score": 100,
+        "passed": passed,
+        "readiness": "green" if passed else "yellow" if awarded >= 70 else "red",
+        "runtime_summary_consistent": summary_consistent,
+        "judgments": judgments,
+        "claim_boundary": (
+            "A green score establishes the measured seeded robustness, 1,000-tick "
+            "ecology endurance, and two-generation lineage for the exact receipt. "
+            "It does not establish consciousness, unrestricted general intelligence, "
+            "OpenC2E behavioral equivalence, or untested distributions."
+        ),
+    }
+    score["score_sha256"] = _digest(score)
+    return score
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Independently score a stochastic Norn receipt.")
+    parser.add_argument("receipt", type=Path)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+    try:
+        parsed = json.loads(args.receipt.read_text(encoding="utf-8"))
+        if not isinstance(parsed, dict):
+            raise NornStochasticScoreError("receipt must be a JSON object")
+        score = score_norn_stochastic_receipt(parsed)
+    except (NornStochasticScoreError, json.JSONDecodeError, OSError) as error:
+        parser.error(str(error))
+    rendered = json.dumps(score, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if score["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_norn_stochastic_score.py
+++ b/tests/test_norn_stochastic_score.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from norn_stochastic_score import (  # noqa: E402
+    NornStochasticScoreError,
+    score_norn_stochastic_receipt,
+)
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _scenario(scenario_id: str, measurements: dict[str, object]) -> dict[str, object]:
+    value: dict[str, object] = {
+        "id": scenario_id,
+        "passed": True,
+        "measurements": measurements,
+    }
+    value["receipt_sha256"] = _digest(value)
+    return value
+
+
+def _receipt() -> dict[str, object]:
+    scenarios = [
+        _scenario(
+            "noisy-adaptation",
+            {
+                "acquisition_rate": 1.0,
+                "acquisition_successes": 32,
+                "minimum_reversal_margin": 0.85706015960603,
+                "noise_probability": 0.15,
+                "reversal_rate": 1.0,
+                "reversal_successes": 32,
+                "trials": 32,
+            },
+        ),
+        _scenario(
+            "noisy-unseen-transfer",
+            {
+                "mean_category_value": 0.43821862396833,
+                "minimum_category_value": 0.0809491382117401,
+                "noise_probability": 0.15,
+                "success_rate": 1.0,
+                "successes": 32,
+                "trials": 32,
+            },
+        ),
+        _scenario(
+            "random-need-planning",
+            {
+                "maximum_final_pressure": 0.0913552403450012,
+                "success_rate": 1.0,
+                "successes": 32,
+                "trials": 32,
+            },
+        ),
+        _scenario(
+            "random-persistence",
+            {
+                "maximum_value_delta": 0.0,
+                "success_rate": 1.0,
+                "successes": 32,
+                "trials": 32,
+            },
+        ),
+        _scenario(
+            "ecology-endurance-1000-ticks",
+            {
+                "extinctions": 0,
+                "final_population": 39.3428781808381,
+                "minimum_population": 9.26,
+                "ticks": 1000,
+                "total_harvest_nutrition": 3.0,
+            },
+        ),
+        _scenario(
+            "two-generation-lineage",
+            {
+                "child_id": "founder_a_child_1",
+                "first_birth_count": 1,
+                "first_conception": True,
+                "grandchild_generation": 2,
+                "grandchild_id": "founder_a_child_1_child_1",
+                "grandchild_parent_count": 2,
+                "second_birth_count": 1,
+                "second_conception": True,
+            },
+        ),
+    ]
+    value: dict[str, object] = {
+        "claim_boundary": "Seeded stochastic artificial-life robustness only.",
+        "failed_count": 0,
+        "mode": "cortex-off",
+        "passed": True,
+        "passed_count": 6,
+        "scenario_count": 6,
+        "scenarios": scenarios,
+        "schema": "prismtek-norn-stochastic-arena-v1",
+        "seed": 90210,
+        "trials": 32,
+    }
+    value["receipt_sha256"] = _digest(value)
+    return value
+
+
+def _rehash(receipt: dict[str, object]) -> None:
+    scenarios = receipt["scenarios"]
+    assert isinstance(scenarios, list)
+    for scenario in scenarios:
+        assert isinstance(scenario, dict)
+        scenario["receipt_sha256"] = _digest(
+            {key: value for key, value in scenario.items() if key != "receipt_sha256"}
+        )
+    receipt["receipt_sha256"] = _digest(
+        {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    )
+
+
+class NornStochasticScoreTests(unittest.TestCase):
+    def test_exact_green_receipt_scores_one_hundred(self) -> None:
+        score = score_norn_stochastic_receipt(_receipt())
+        self.assertTrue(score["passed"])
+        self.assertEqual(score["score"], 100)
+        self.assertEqual(score["readiness"], "green")
+        self.assertEqual(len(score["judgments"]), 6)
+
+    def test_runtime_green_cannot_hide_weak_mean_transfer(self) -> None:
+        receipt = _receipt()
+        scenarios = receipt["scenarios"]
+        assert isinstance(scenarios, list)
+        transfer = scenarios[1]
+        assert isinstance(transfer, dict)
+        measurements = transfer["measurements"]
+        assert isinstance(measurements, dict)
+        measurements["mean_category_value"] = 0.10
+        _rehash(receipt)
+        score = score_norn_stochastic_receipt(receipt)
+        self.assertFalse(score["passed"])
+        self.assertEqual(score["score"], 80)
+        judgment = next(
+            item for item in score["judgments"] if item["id"] == "noisy-unseen-transfer"
+        )
+        self.assertTrue(judgment["runtime_reported_pass"])
+        self.assertFalse(judgment["passed"])
+
+    def test_inconsistent_success_rate_is_rejected_by_judgment(self) -> None:
+        receipt = _receipt()
+        scenarios = receipt["scenarios"]
+        assert isinstance(scenarios, list)
+        adaptation = scenarios[0]
+        assert isinstance(adaptation, dict)
+        measurements = adaptation["measurements"]
+        assert isinstance(measurements, dict)
+        measurements["acquisition_successes"] = 20
+        _rehash(receipt)
+        score = score_norn_stochastic_receipt(receipt)
+        self.assertFalse(score["passed"])
+        judgment = next(
+            item for item in score["judgments"] if item["id"] == "noisy-adaptation"
+        )
+        self.assertFalse(judgment["passed"])
+
+    def test_short_ecology_run_cannot_claim_endurance(self) -> None:
+        receipt = _receipt()
+        scenarios = receipt["scenarios"]
+        assert isinstance(scenarios, list)
+        ecology = scenarios[4]
+        assert isinstance(ecology, dict)
+        measurements = ecology["measurements"]
+        assert isinstance(measurements, dict)
+        measurements["ticks"] = 100
+        _rehash(receipt)
+        score = score_norn_stochastic_receipt(receipt)
+        self.assertFalse(score["passed"])
+
+    def test_tampered_receipt_is_rejected(self) -> None:
+        receipt = _receipt()
+        receipt["seed"] = 7
+        with self.assertRaisesRegex(NornStochasticScoreError, "seed or trial count"):
+            score_norn_stochastic_receipt(receipt)
+
+    def test_cortex_on_receipt_is_rejected(self) -> None:
+        receipt = _receipt()
+        receipt["mode"] = "cortex-on"
+        _rehash(receipt)
+        with self.assertRaisesRegex(NornStochasticScoreError, "cortex-off"):
+            score_norn_stochastic_receipt(receipt)
+
+    def test_scoring_is_deterministic_and_non_mutating(self) -> None:
+        receipt = _receipt()
+        before = copy.deepcopy(receipt)
+        first = score_norn_stochastic_receipt(receipt)
+        second = score_norn_stochastic_receipt(receipt)
+        self.assertEqual(first, second)
+        self.assertEqual(receipt, before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this builds

This stacked follow-up to #328 independently scores the seeded robustness receipt from `prismtek-apps#318`.

It evaluates six aggregate and long-horizon scenarios:

- 32 noisy acquisition and reversal trials;
- 32 noisy unseen-category transfer trials;
- 32 randomized multi-need plans;
- 32 randomized restore/persistence trials;
- 1,000 ecology ticks with repeated harvesting;
- two generations of hereditary lineage.

## Independent boundary

The scorer recomputes every scenario and receipt SHA-256, verifies the exact seed and trial count, checks success counts against reported rates, and ignores runtime pass flags while applying Buddy Brain-owned thresholds.

It rejects:

- weak mean transfer hidden behind 32 successful choices;
- inconsistent counts and rates;
- shortened ecology runs presented as endurance;
- cortex-on substitution;
- tampered or incomplete receipts.

## Exact-head verification

Automated-green on exact Buddy Brain head `d4fd8a0eef5b762b7da94305e1ac0abfbf6f8a71`:

- dedicated `Norn stochastic score`: passed;
- Buddy Brain `ci`: passed;
- lint: passed;
- task-readiness: passed;
- CodeQL: passed;
- BeMoreAgent iOS simulator validation: passed;
- bootstrap smoke: passed;
- autonomy foundation smoke: passed;
- BMO runtime slice smoke: passed.

Seven adversarial tests passed for the exact green receipt, weak mean transfer, inconsistent success counts/rates, shortened ecology, seed/tamper rejection, cortex-off enforcement, and deterministic non-mutating scoring.

## Live cross-repository proof

`prismtek-apps#318` pins this exact scorer commit and regenerates the stochastic Godot receipt on the Mac M5.

The live proof checked out:

- Prismtek Apps exact head `c1163d9222842a7713f90a15f55a365f9c68c914`;
- this exact Buddy Brain scorer `d4fd8a0eef5b762b7da94305e1ac0abfbf6f8a71`.

Result:

- stochastic game receipt SHA-256: `05d3384a8bd9a187e3ba8c328f2081e6b5099a23e899e27d0c31c215af2df615`;
- independent score: `100/100`;
- score receipt SHA-256: `70f6f29907ad15fb8e929399db194b4d26b67dbb6bbeafe0b49dfb09d2b1d2e7`;
- cross-repository proof SHA-256: `384ccdf4953a4ec5f3c74fa34e8e24b869de5177687ad99d888f0b183f1e8bda`;
- artifact digest: `sha256:b558fe494f02a699cfc6279cd851bfad76b2c40f3b48f6fd230609469f3b0ab1`;
- workflow run: `30583652041`.

The independently confirmed measurements include:

- noisy acquisition: `32/32`;
- noisy reversal: `32/32`, worst reversal margin `0.85706015960603`;
- noisy unseen transfer: `32/32`, mean category value `0.43821862396833`, minimum positive value `0.0809491382117401`;
- randomized planning: `32/32`, maximum final pressure `0.0913552403450012`;
- randomized restore: `32/32`, maximum value drift `0.0`;
- ecology: `1,000` ticks, zero extinctions, minimum population `9.26`, final population `39.3428781808381`;
- lineage: two conceptions and births, generation-two grandchild with two parents.

## Claim boundary

A green score establishes the measured seeded robustness, 1,000-tick ecology endurance, and two-generation lineage for the exact receipt. It does not establish consciousness, unrestricted general intelligence, OpenC2E behavioral equivalence, or untested distributions.

## Task contract

Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem

One deterministic parity receipt does not show that learning survives noisy outcomes, randomized needs, long simulated time, or multiple generations.

## Smallest useful wedge

Independently score the exact six-scenario stochastic receipt emitted by `prismtek-apps#318`, then pin the exact scorer from the game workflow.

## Verification plan

Completed. The full Buddy Brain repository gate passed, and the exact external scorer independently awarded the live Godot stochastic receipt `100/100`.

## Rollback plan

Delete the additive scorer, tests, documentation, and workflow. No runtime state, memory, permissions, deployments, or existing scorer behavior is mutated.