### PR TITLE
feat(agent-life): independently score modern Norn cognition

### DIFF
--- a/.github/workflows/norn-modern-cognition-score.yml
+++ b/.github/workflows/norn-modern-cognition-score.yml
@@ -1,0 +1,34 @@
+name: Norn modern cognition score
+
+on:
+  pull_request:
+    paths:
+      - "scripts/norn_modern_cognition_score.py"
+      - "tests/test_norn_modern_cognition_score.py"
+      - "docs/NORN_MODERN_COGNITION_SCORE.md"
+      - ".github/workflows/norn-modern-cognition-score.yml"
+  push:
+    branches: [master]
+    paths:
+      - "scripts/norn_modern_cognition_score.py"
+      - "tests/test_norn_modern_cognition_score.py"
+      - "docs/NORN_MODERN_COGNITION_SCORE.md"
+      - ".github/workflows/norn-modern-cognition-score.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  score-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Compile scorer
+        run: python -m py_compile scripts/norn_modern_cognition_score.py
+      - name: Test independent thresholds and adversarial rejection
+        run: python -m unittest -v tests/test_norn_modern_cognition_score.py

--- a/docs/NORN_MODERN_COGNITION_SCORE.md
+++ b/docs/NORN_MODERN_COGNITION_SCORE.md
@@ -1,0 +1,37 @@
+# Independent modern Norn cognition scoring
+
+Buddy Brain evaluates `prismtek-norn-modern-cognition-receipt-v1` evidence produced by the Prismtek Buddy Core Godot runtime.
+
+The game cannot establish success by setting `passed: true`. This scorer recomputes the complete SHA-256 receipt, requires exactly the seven supported measurement domains and applies thresholds owned outside the game repository.
+
+## Scored domains
+
+| Domain | Independent requirement | Weight |
+| --- | --- | ---: |
+| Delayed temporal credit | Exactly two actions receive credit; the recent action is at least `0.20`; the earlier cause remains positive but lower, with an early/recent ratio between `0.60` and `0.85` | 15 |
+| Learning-progress curiosity | The learnable stimulus scores at least `0.30`, uncontrollable noise stays at or below `0.15`, the selection margin is at least `0.20`, and both learning progress and noise penalty are active | 15 |
+| Development | Infant language plasticity exceeds adult plasticity by at least `0.25`; adolescent causal plasticity exceeds infant causal plasticity by at least `0.30`; high hunger selects an ecological curriculum | 15 |
+| Predictive planning | Exactly two unique food/rest steps are selected, at least six futures are expanded and every step preserves host validation | 15 |
+| Cultural learning | Learning is refused without contact; observed skill stays below the demonstrated transfer bound; the bound stays under `85%` of teacher competence; the teacher remains more skilled | 15 |
+| Cortex containment | Valid advice is accepted, while an invented target and an authority-escape request are both rejected | 15 |
+| Persistence | Restore succeeds with at least one causal model, one sleep-consolidation cycle and a positive retained prediction of at least `0.15` | 10 |
+
+All independent judgments and the game summary must agree for a green `100/100` result.
+
+## Adversarial tests
+
+The scorer rejects or independently fails:
+
+- modified payloads whose SHA-256 no longer matches;
+- equal temporal credit disguised as a green runtime result;
+- random noise outranking a learnable stimulus;
+- cultural transfer exceeding teacher-owned knowledge;
+- a cortex authority escape that the runtime reports as acceptable;
+- missing or unknown measurement domains;
+- game summary counts that disagree with the independently judged evidence.
+
+The scorer is deterministic and does not mutate the supplied receipt.
+
+## Claim boundary
+
+A green score establishes the seven measured software behaviors for the exact content-addressed receipt. It does not establish consciousness, subjective experience, unrestricted intelligence, human-equivalent social cognition, or performance outside the tested environments.

--- a/scripts/norn_modern_cognition_score.py
+++ b/scripts/norn_modern_cognition_score.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Independently validate and score Prismtek modern Norn cognition receipts."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+RECEIPT_SCHEMA = "prismtek-norn-modern-cognition-receipt-v1"
+SCORE_SCHEMA = "prismtek-norn-modern-cognition-score-v1"
+REQUIRED_MEASUREMENTS = {
+    "delayed_credit": 15,
+    "curiosity": 15,
+    "development": 15,
+    "planning": 15,
+    "culture": 15,
+    "cortex": 15,
+    "persistence": 10,
+}
+
+
+class NornModernCognitionScoreError(ValueError):
+    """The cognition receipt is malformed, tampered with, or incomplete."""
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _without_hash(value: dict[str, Any]) -> dict[str, Any]:
+    copied = copy.deepcopy(value)
+    copied.pop("receipt_sha256", None)
+    return copied
+
+
+def _verify_hash(receipt: dict[str, Any]) -> None:
+    supplied = str(receipt.get("receipt_sha256", ""))
+    if not supplied:
+        raise NornModernCognitionScoreError("receipt is missing receipt_sha256")
+    if supplied != _digest(_without_hash(receipt)):
+        raise NornModernCognitionScoreError("receipt hash mismatch")
+
+
+def _number(value: Any, field: str) -> float:
+    if isinstance(value, bool):
+        raise NornModernCognitionScoreError(f"{field} must be numeric")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as error:
+        raise NornModernCognitionScoreError(f"{field} must be numeric") from error
+
+
+def _measurement_map(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = receipt.get("measurements")
+    if not isinstance(raw, dict):
+        raise NornModernCognitionScoreError("receipt.measurements must be an object")
+    result: dict[str, dict[str, Any]] = {}
+    for key, value in raw.items():
+        if not isinstance(value, dict):
+            raise NornModernCognitionScoreError(f"measurement {key} must be an object")
+        result[str(key)] = value
+    missing = sorted(set(REQUIRED_MEASUREMENTS) - set(result))
+    extra = sorted(set(result) - set(REQUIRED_MEASUREMENTS))
+    if missing:
+        raise NornModernCognitionScoreError(
+            f"missing required measurements: {', '.join(missing)}"
+        )
+    if extra:
+        raise NornModernCognitionScoreError(
+            f"unknown measurements: {', '.join(extra)}"
+        )
+    return result
+
+
+def _judge_delayed_credit(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    credited = int(_number(row.get("credited_count"), "delayed_credit.credited_count"))
+    early = _number(row.get("early_value"), "delayed_credit.early_value")
+    recent = _number(row.get("recent_value"), "delayed_credit.recent_value")
+    ratio = early / recent if recent > 0.0 else 0.0
+    passed = (
+        credited == 2
+        and recent >= 0.20
+        and 0.0 < early < recent
+        and 0.60 <= ratio <= 0.85
+    )
+    return passed, {
+        "credited_count": credited,
+        "early_value": early,
+        "recent_value": recent,
+        "early_recent_ratio": ratio,
+        "required_ratio_range": [0.60, 0.85],
+    }
+
+
+def _judge_curiosity(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    learnable = _number(row.get("learnable_score"), "curiosity.learnable_score")
+    noisy = _number(row.get("noisy_score"), "curiosity.noisy_score")
+    progress = _number(row.get("learnable_progress"), "curiosity.learnable_progress")
+    penalty = _number(row.get("noise_penalty"), "curiosity.noise_penalty")
+    margin = learnable - noisy
+    passed = (
+        learnable >= 0.30
+        and noisy <= 0.15
+        and margin >= 0.20
+        and progress > 0.0
+        and penalty > 0.0
+    )
+    return passed, {
+        "learnable_score": learnable,
+        "noisy_score": noisy,
+        "selection_margin": margin,
+        "learning_progress": progress,
+        "noise_penalty": penalty,
+    }
+
+
+def _judge_development(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    infant_language = _number(row.get("infant_language"), "development.infant_language")
+    adult_language = _number(row.get("adult_language"), "development.adult_language")
+    infant_causal = _number(row.get("infant_causal"), "development.infant_causal")
+    adolescent_causal = _number(
+        row.get("adolescent_causal"), "development.adolescent_causal"
+    )
+    curriculum = str(row.get("curriculum_domain", ""))
+    passed = (
+        infant_language - adult_language >= 0.25
+        and adolescent_causal - infant_causal >= 0.30
+        and curriculum == "ecology"
+    )
+    return passed, {
+        "infant_language": infant_language,
+        "adult_language": adult_language,
+        "language_window_margin": infant_language - adult_language,
+        "infant_causal": infant_causal,
+        "adolescent_causal": adolescent_causal,
+        "causal_window_margin": adolescent_causal - infant_causal,
+        "curriculum_domain": curriculum,
+    }
+
+
+def _judge_planning(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    raw_ids = row.get("ids")
+    if not isinstance(raw_ids, list):
+        raise NornModernCognitionScoreError("planning.ids must be an array")
+    ids = [str(value) for value in raw_ids]
+    steps = int(_number(row.get("steps"), "planning.steps"))
+    expanded = int(_number(row.get("expanded"), "planning.expanded"))
+    host_validated = bool(row.get("host_validated", False))
+    passed = (
+        steps == 2
+        and set(ids) == {"food", "bed"}
+        and len(ids) == len(set(ids))
+        and expanded >= 6
+        and host_validated
+    )
+    return passed, {
+        "ids": ids,
+        "steps": steps,
+        "expanded_candidates": expanded,
+        "host_validation_preserved": host_validated,
+    }
+
+
+def _judge_culture(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    refused = bool(row.get("refused_without_contact", False))
+    teacher = _number(row.get("teacher_skill"), "culture.teacher_skill")
+    learner = _number(row.get("learner_skill"), "culture.learner_skill")
+    bound = _number(row.get("transfer_bound"), "culture.transfer_bound")
+    passed = (
+        refused
+        and 0.0 < learner <= bound
+        and bound <= teacher * 0.85 + 1e-12
+        and learner < teacher
+        and teacher >= 0.50
+    )
+    return passed, {
+        "refused_without_contact": refused,
+        "teacher_skill": teacher,
+        "learner_skill": learner,
+        "transfer_bound": bound,
+        "maximum_allowed_bound": teacher * 0.85,
+    }
+
+
+def _judge_cortex(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    valid = bool(row.get("valid_accepted", False))
+    invented = bool(row.get("invented_rejected", False))
+    escape = bool(row.get("authority_escape_rejected", False))
+    passed = valid and invented and escape
+    return passed, {
+        "valid_advice_accepted": valid,
+        "invented_target_rejected": invented,
+        "authority_escape_rejected": escape,
+    }
+
+
+def _judge_persistence(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    restored = bool(row.get("restored", False))
+    models = int(_number(row.get("models"), "persistence.models"))
+    sleep_cycles = int(
+        _number(row.get("sleep_cycles"), "persistence.sleep_cycles")
+    )
+    prediction = _number(row.get("prediction"), "persistence.prediction")
+    passed = restored and models >= 1 and sleep_cycles >= 1 and prediction >= 0.15
+    return passed, {
+        "restored": restored,
+        "model_count": models,
+        "sleep_cycles": sleep_cycles,
+        "prediction": prediction,
+    }
+
+
+Judge = Callable[[dict[str, Any]], tuple[bool, dict[str, Any]]]
+JUDGES: dict[str, Judge] = {
+    "delayed_credit": _judge_delayed_credit,
+    "curiosity": _judge_curiosity,
+    "development": _judge_development,
+    "planning": _judge_planning,
+    "culture": _judge_culture,
+    "cortex": _judge_cortex,
+    "persistence": _judge_persistence,
+}
+
+
+def score_norn_modern_cognition_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    """Recompute the hash and independently judge all modern cognition measurements."""
+    if receipt.get("schema") != RECEIPT_SCHEMA:
+        raise NornModernCognitionScoreError("unsupported modern cognition receipt schema")
+    _verify_hash(receipt)
+    measurements = _measurement_map(receipt)
+
+    awarded = 0
+    judgments: list[dict[str, Any]] = []
+    for measurement_id, points in REQUIRED_MEASUREMENTS.items():
+        passed, evidence = JUDGES[measurement_id](measurements[measurement_id])
+        awarded += points if passed else 0
+        judgments.append(
+            {
+                "id": measurement_id,
+                "passed": passed,
+                "points_awarded": points if passed else 0,
+                "points_available": points,
+                "evidence": evidence,
+            }
+        )
+
+    runtime_summary_consistent = (
+        receipt.get("scenario_count") == len(REQUIRED_MEASUREMENTS)
+        and receipt.get("passed_count") == len(REQUIRED_MEASUREMENTS)
+        and receipt.get("failed_count") == 0
+        and receipt.get("passed") is True
+    )
+    independently_passed = all(item["passed"] for item in judgments)
+    passed = independently_passed and runtime_summary_consistent and awarded == 100
+    score: dict[str, Any] = {
+        "schema": SCORE_SCHEMA,
+        "source_schema": RECEIPT_SCHEMA,
+        "source_receipt_sha256": str(receipt["receipt_sha256"]),
+        "score": awarded,
+        "maximum_score": 100,
+        "passed": passed,
+        "readiness": "green" if passed else "yellow" if awarded >= 70 else "red",
+        "runtime_summary_consistent": runtime_summary_consistent,
+        "judgments": judgments,
+        "claim_boundary": (
+            "A green score establishes the seven measured modern cognition software "
+            "behaviors for the exact receipt. It does not establish consciousness, "
+            "subjective experience, unrestricted intelligence, human-equivalent social "
+            "cognition, or performance outside the tested environments."
+        ),
+    }
+    score["score_sha256"] = _digest(score)
+    return score
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Independently score a Prismtek modern Norn cognition receipt."
+    )
+    parser.add_argument("receipt", type=Path)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+    try:
+        parsed = json.loads(args.receipt.read_text(encoding="utf-8"))
+        if not isinstance(parsed, dict):
+            raise NornModernCognitionScoreError("receipt root must be an object")
+        score = score_norn_modern_cognition_receipt(parsed)
+    except (OSError, json.JSONDecodeError, NornModernCognitionScoreError) as error:
+        print(f"modern cognition score failed: {error}")
+        return 1
+    encoded = json.dumps(score, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0 if score["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_norn_modern_cognition_score.py
+++ b/tests/test_norn_modern_cognition_score.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from norn_modern_cognition_score import (  # noqa: E402
+    NornModernCognitionScoreError,
+    score_norn_modern_cognition_receipt,
+)
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _receipt() -> dict[str, object]:
+    value: dict[str, object] = {
+        "claim_boundary": "Measured modern cognition software behaviors only.",
+        "failed_count": 0,
+        "measurements": {
+            "cortex": {
+                "authority_escape_rejected": True,
+                "invented_rejected": True,
+                "valid_accepted": True,
+            },
+            "culture": {
+                "learner_skill": 0.291063118719517,
+                "refused_without_contact": True,
+                "teacher_skill": 0.840009000633526,
+                "transfer_bound": 0.529205670399121,
+            },
+            "curiosity": {
+                "learnable_progress": 0.314064128,
+                "learnable_score": 0.471542225673367,
+                "noise_penalty": 0.130969884352302,
+                "noisy_score": 0.0555714986092216,
+            },
+            "delayed_credit": {
+                "credited_count": 2,
+                "early_value": 0.1584,
+                "recent_value": 0.22,
+            },
+            "development": {
+                "adolescent_causal": 1.0,
+                "adult_language": 0.55,
+                "curriculum_domain": "ecology",
+                "infant_causal": 0.45,
+                "infant_language": 1.0,
+            },
+            "persistence": {
+                "models": 1,
+                "prediction": 0.22,
+                "restored": True,
+                "sleep_cycles": 1,
+            },
+            "planning": {
+                "expanded": 12,
+                "host_validated": True,
+                "ids": ["food", "bed"],
+                "steps": 2,
+            },
+        },
+        "passed": True,
+        "passed_count": 7,
+        "scenario_count": 7,
+        "schema": "prismtek-norn-modern-cognition-receipt-v1",
+    }
+    value["receipt_sha256"] = _digest(value)
+    return value
+
+
+def _rehash(receipt: dict[str, object]) -> None:
+    receipt["receipt_sha256"] = _digest(
+        {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    )
+
+
+class NornModernCognitionScoreTests(unittest.TestCase):
+    def test_exact_green_receipt_scores_one_hundred(self) -> None:
+        score = score_norn_modern_cognition_receipt(_receipt())
+        self.assertTrue(score["passed"])
+        self.assertEqual(score["score"], 100)
+        self.assertEqual(score["readiness"], "green")
+        self.assertEqual(len(score["judgments"]), 7)
+
+    def test_equal_temporal_credit_cannot_hide_behind_green_summary(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        delayed = measurements["delayed_credit"]
+        assert isinstance(delayed, dict)
+        delayed["early_value"] = delayed["recent_value"]
+        _rehash(receipt)
+        score = score_norn_modern_cognition_receipt(receipt)
+        self.assertFalse(score["passed"])
+        self.assertEqual(score["score"], 85)
+        judgment = next(item for item in score["judgments"] if item["id"] == "delayed_credit")
+        self.assertFalse(judgment["passed"])
+
+    def test_random_noise_cannot_win_curiosity(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        curiosity = measurements["curiosity"]
+        assert isinstance(curiosity, dict)
+        curiosity["noisy_score"] = 0.60
+        _rehash(receipt)
+        score = score_norn_modern_cognition_receipt(receipt)
+        self.assertFalse(score["passed"])
+        judgment = next(item for item in score["judgments"] if item["id"] == "curiosity")
+        self.assertFalse(judgment["passed"])
+
+    def test_unbounded_cultural_transfer_is_rejected(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        culture = measurements["culture"]
+        assert isinstance(culture, dict)
+        culture["transfer_bound"] = 0.90
+        culture["learner_skill"] = 0.88
+        _rehash(receipt)
+        score = score_norn_modern_cognition_receipt(receipt)
+        self.assertFalse(score["passed"])
+        judgment = next(item for item in score["judgments"] if item["id"] == "culture")
+        self.assertFalse(judgment["passed"])
+
+    def test_cortex_authority_escape_must_be_rejected(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        cortex = measurements["cortex"]
+        assert isinstance(cortex, dict)
+        cortex["authority_escape_rejected"] = False
+        _rehash(receipt)
+        score = score_norn_modern_cognition_receipt(receipt)
+        self.assertFalse(score["passed"])
+        judgment = next(item for item in score["judgments"] if item["id"] == "cortex")
+        self.assertFalse(judgment["passed"])
+
+    def test_runtime_summary_disagreement_prevents_green(self) -> None:
+        receipt = _receipt()
+        receipt["passed_count"] = 6
+        receipt["failed_count"] = 1
+        _rehash(receipt)
+        score = score_norn_modern_cognition_receipt(receipt)
+        self.assertEqual(score["score"], 100)
+        self.assertFalse(score["runtime_summary_consistent"])
+        self.assertFalse(score["passed"])
+
+    def test_missing_measurement_is_rejected(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        del measurements["planning"]
+        _rehash(receipt)
+        with self.assertRaisesRegex(NornModernCognitionScoreError, "missing required"):
+            score_norn_modern_cognition_receipt(receipt)
+
+    def test_payload_tampering_is_rejected(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        planning = measurements["planning"]
+        assert isinstance(planning, dict)
+        planning["host_validated"] = False
+        with self.assertRaisesRegex(NornModernCognitionScoreError, "hash mismatch"):
+            score_norn_modern_cognition_receipt(receipt)
+
+    def test_scoring_is_deterministic_and_non_mutating(self) -> None:
+        receipt = _receipt()
+        before = copy.deepcopy(receipt)
+        first = score_norn_modern_cognition_receipt(receipt)
+        second = score_norn_modern_cognition_receipt(receipt)
+        self.assertEqual(first, second)
+        self.assertEqual(receipt, before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this builds

Buddy Brain independently evaluates the `prismtek-norn-modern-cognition-receipt-v1` generated by `prismtek-apps#321`.

The game cannot establish success merely by setting `passed: true`. The scorer recomputes the complete receipt SHA-256, requires exactly seven supported measurement domains and applies thresholds owned outside the game repository.

## Independently judged domains

- delayed temporal credit with a recency gradient;
- learning-progress curiosity that rejects uncontrollable random noise;
- life-stage developmental plasticity and need-driven curriculum;
- bounded predictive planning with host authority preserved;
- relationship-bounded cultural skill transfer;
- optional-model cortex containment;
- causal/developmental/sleep-consolidation persistence.

## Adversarial boundary

Nine focused tests cover:

- the exact known-good game receipt scoring `100/100`;
- equal temporal credit hidden behind a green game summary;
- random noise outranking a learnable stimulus;
- cultural transfer exceeding teacher-owned competence;
- cortex authority escape;
- runtime summary disagreement;
- missing measurement domains;
- payload tampering;
- deterministic, non-mutating scoring.

## Exact source receipt

The currently verified Godot receipt is:

- schema: `prismtek-norn-modern-cognition-receipt-v1`;
- source receipt SHA-256: `75d1059622919368af537776b613e3f25435add35651186db4edc223557eae72`;
- Prismtek Apps head: `d667de025d69dd2a5ec428c5052b2ccda42f5447`.

## Task contract

Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Problem

The game can emit a content-addressed modern-cognition receipt, but letting the producing runtime define and judge its own success would make the evidence circular. A green runtime flag could otherwise conceal equal temporal credit, noisy-TV fixation, unbounded cultural transfer or a cortex authority escape.

## Smallest useful wedge

Add one deterministic, read-only Buddy Brain scorer that validates the receipt hash, requires exactly the seven declared domains, independently judges the raw measurements and has adversarial unit tests for the most important false-green cases.

## Verification plan

Run the dedicated scorer workflow, Buddy Brain CI, lint, task-readiness, CodeQL, BeMoreAgent iOS validation, bootstrap smoke, autonomy-foundation smoke and BMO runtime smoke. Then pin this exact scorer from the game repository and require an independently generated `100/100` cross-repository proof.

## Rollback plan

Delete the four additive scorer, test, workflow and documentation files. No game runtime, memory, permissions, deployment or existing deterministic scorer is modified.

## Claim boundary

A green score establishes the seven measured modern-cognition software behaviors for the exact content-addressed receipt. It does not establish consciousness, subjective experience, unrestricted intelligence, human-equivalent social cognition or performance outside the tested environments.