### PR TITLE
feat(agent-life): independently score Norn memory navigation and skills

### DIFF
--- a/.github/workflows/norn-memory-navigation-skills-score.yml
+++ b/.github/workflows/norn-memory-navigation-skills-score.yml
@@ -1,0 +1,34 @@
+name: Norn memory navigation skills score
+
+on:
+  pull_request:
+    paths:
+      - "scripts/norn_memory_navigation_skills_score.py"
+      - "tests/test_norn_memory_navigation_skills_score.py"
+      - "docs/NORN_MEMORY_NAVIGATION_SKILLS_SCORE.md"
+      - ".github/workflows/norn-memory-navigation-skills-score.yml"
+  push:
+    branches: [master]
+    paths:
+      - "scripts/norn_memory_navigation_skills_score.py"
+      - "tests/test_norn_memory_navigation_skills_score.py"
+      - "docs/NORN_MEMORY_NAVIGATION_SKILLS_SCORE.md"
+      - ".github/workflows/norn-memory-navigation-skills-score.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  score-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Compile scorer
+        run: python -m py_compile scripts/norn_memory_navigation_skills_score.py
+      - name: Test independent thresholds and adversarial rejection
+        run: python -m unittest -v tests/test_norn_memory_navigation_skills_score.py

--- a/docs/NORN_MEMORY_NAVIGATION_SKILLS_SCORE.md
+++ b/docs/NORN_MEMORY_NAVIGATION_SKILLS_SCORE.md
@@ -1,0 +1,39 @@
+# Independent Norn memory, navigation and skill scoring
+
+Buddy Brain evaluates `prismtek-norn-memory-navigation-skills-receipt-v1` evidence produced by the Prismtek Buddy Core Godot runtime.
+
+The game cannot establish success by setting `passed: true`. This scorer recomputes the complete source SHA-256, requires exactly seven declared measurement domains and independently judges the raw values.
+
+## Scored domains
+
+| Domain | Independent requirement | Weight |
+| --- | --- | ---: |
+| Autobiographical recall | The cue retrieves `red_ball`, the match score is at least `0.45`, and exactly one retrieval is recorded | 15 |
+| Semantic knowledge | Two supporting observations establish an edible fact with confidence at least `0.55`; one weak contradiction does not flip it; exactly one contradiction is recorded; retained confidence remains at least `0.50` | 15 |
+| Spatial routing | The route is exactly `hall → garden`, contains two steps and preserves host validation, rather than using the dangerous direct shortcut | 15 |
+| Hierarchical skill | The three-step sequence becomes learned, produces exactly one proposal, expands into exactly three host-validated primitives and has reliability at least `0.75` | 15 |
+| Skill adaptation | One failed execution lowers reliability from at least `0.75` to below the prior value and at most `0.70` | 15 |
+| Runtime integration | An outcome creates a named episode, one matching recall, a grounded fact with confidence at least `0.35`, and one mapped room | 15 |
+| Persistence | Restore preserves exactly one episode, fact, room and learned skill | 10 |
+
+All seven independent judgments and the game summary must agree for a green `100/100` result.
+
+## Adversarial tests
+
+The scorer independently fails or rejects:
+
+- an irrelevant autobiographical memory hidden behind a green game summary;
+- a weak rumor overwriting a supported fact;
+- a dangerous shortcut presented as safe routing;
+- an unlearned or non-host-validated skill;
+- a skill failure that does not reduce reliability;
+- incomplete persistence;
+- summary counts that disagree with the raw measurements;
+- missing measurement domains;
+- modified payloads whose SHA-256 no longer matches.
+
+Scoring is deterministic and does not mutate the supplied receipt.
+
+## Claim boundary
+
+A green score establishes the seven measured bounded memory, navigation and skill software behaviors for the exact content-addressed receipt. It does not establish human autobiographical memory, perfect navigation, unrestricted autonomy or performance outside the tested environments.

--- a/scripts/norn_memory_navigation_skills_score.py
+++ b/scripts/norn_memory_navigation_skills_score.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Independently validate and score Prismtek Norn memory/navigation/skills receipts."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+RECEIPT_SCHEMA = "prismtek-norn-memory-navigation-skills-receipt-v1"
+SCORE_SCHEMA = "prismtek-norn-memory-navigation-skills-score-v1"
+REQUIRED_MEASUREMENTS = {
+    "autobiographical_recall": 15,
+    "semantic_knowledge": 15,
+    "spatial_routing": 15,
+    "hierarchical_skill": 15,
+    "skill_adaptation": 15,
+    "stack_integration": 15,
+    "persistence": 10,
+}
+
+
+class NornMemoryNavigationSkillsScoreError(ValueError):
+    """The source receipt is malformed, tampered with, or incomplete."""
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _without_hash(value: dict[str, Any]) -> dict[str, Any]:
+    copied = copy.deepcopy(value)
+    copied.pop("receipt_sha256", None)
+    return copied
+
+
+def _verify_hash(receipt: dict[str, Any]) -> None:
+    supplied = str(receipt.get("receipt_sha256", ""))
+    if not supplied:
+        raise NornMemoryNavigationSkillsScoreError("receipt is missing receipt_sha256")
+    if supplied != _digest(_without_hash(receipt)):
+        raise NornMemoryNavigationSkillsScoreError("receipt hash mismatch")
+
+
+def _number(value: Any, field: str) -> float:
+    if isinstance(value, bool):
+        raise NornMemoryNavigationSkillsScoreError(f"{field} must be numeric")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as error:
+        raise NornMemoryNavigationSkillsScoreError(f"{field} must be numeric") from error
+
+
+def _measurement_map(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = receipt.get("measurements")
+    if not isinstance(raw, dict):
+        raise NornMemoryNavigationSkillsScoreError("receipt.measurements must be an object")
+    result: dict[str, dict[str, Any]] = {}
+    for key, value in raw.items():
+        if not isinstance(value, dict):
+            raise NornMemoryNavigationSkillsScoreError(f"measurement {key} must be an object")
+        result[str(key)] = value
+    missing = sorted(set(REQUIRED_MEASUREMENTS) - set(result))
+    extra = sorted(set(result) - set(REQUIRED_MEASUREMENTS))
+    if missing:
+        raise NornMemoryNavigationSkillsScoreError(
+            f"missing required measurements: {', '.join(missing)}"
+        )
+    if extra:
+        raise NornMemoryNavigationSkillsScoreError(
+            f"unknown measurements: {', '.join(extra)}"
+        )
+    return result
+
+
+def _judge_autobiographical(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    selected = str(row.get("selected_target", ""))
+    match = _number(row.get("match_score"), "autobiographical_recall.match_score")
+    retrievals = int(_number(row.get("retrievals"), "autobiographical_recall.retrievals"))
+    passed = selected == "red_ball" and match >= 0.45 and retrievals == 1
+    return passed, {
+        "selected_target": selected,
+        "match_score": match,
+        "retrievals": retrievals,
+        "minimum_match_score": 0.45,
+    }
+
+
+def _judge_semantic(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    before_object = row.get("object_before")
+    before_confidence = _number(
+        row.get("confidence_before"), "semantic_knowledge.confidence_before"
+    )
+    after_object = row.get("object_after_weak_contradiction")
+    contradictions = int(
+        _number(row.get("contradictions"), "semantic_knowledge.contradictions")
+    )
+    retained = _number(
+        row.get("retained_confidence"), "semantic_knowledge.retained_confidence"
+    )
+    passed = (
+        before_object is True
+        and after_object is True
+        and before_confidence >= 0.55
+        and contradictions == 1
+        and retained >= 0.50
+        and retained <= before_confidence
+    )
+    return passed, {
+        "object_before": before_object,
+        "confidence_before": before_confidence,
+        "object_after_weak_contradiction": after_object,
+        "contradictions": contradictions,
+        "retained_confidence": retained,
+        "minimum_retained_confidence": 0.50,
+    }
+
+
+def _judge_spatial(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    raw_rooms = row.get("route_rooms")
+    if not isinstance(raw_rooms, list):
+        raise NornMemoryNavigationSkillsScoreError("spatial_routing.route_rooms must be an array")
+    rooms = [str(value) for value in raw_rooms]
+    steps = int(_number(row.get("steps"), "spatial_routing.steps"))
+    host_validated = bool(row.get("host_validated", False))
+    passed = rooms == ["hall", "garden"] and steps == 2 and host_validated
+    return passed, {
+        "route_rooms": rooms,
+        "steps": steps,
+        "host_validation_preserved": host_validated,
+        "dangerous_shortcut_avoided": rooms != ["garden"],
+    }
+
+
+def _judge_hierarchical_skill(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    learned = bool(row.get("learned", False))
+    proposals = int(_number(row.get("proposal_count"), "hierarchical_skill.proposal_count"))
+    expanded = int(_number(row.get("expanded_steps"), "hierarchical_skill.expanded_steps"))
+    host_validated = bool(row.get("host_validated", False))
+    reliability = _number(row.get("reliability"), "hierarchical_skill.reliability")
+    passed = (
+        learned
+        and proposals == 1
+        and expanded == 3
+        and host_validated
+        and reliability >= 0.75
+    )
+    return passed, {
+        "learned": learned,
+        "proposal_count": proposals,
+        "expanded_steps": expanded,
+        "host_validation_preserved": host_validated,
+        "reliability": reliability,
+        "minimum_reliability": 0.75,
+    }
+
+
+def _judge_skill_adaptation(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    before = _number(row.get("reliability_before"), "skill_adaptation.reliability_before")
+    after = _number(row.get("reliability_after"), "skill_adaptation.reliability_after")
+    failures = int(_number(row.get("failed_executions"), "skill_adaptation.failed_executions"))
+    passed = before >= 0.75 and after < before and after <= 0.70 and failures == 1
+    return passed, {
+        "reliability_before": before,
+        "reliability_after": after,
+        "reliability_drop": before - after,
+        "failed_executions": failures,
+    }
+
+
+def _judge_integration(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    episode = str(row.get("episode_id", ""))
+    memories = int(_number(row.get("memory_count"), "stack_integration.memory_count"))
+    confidence = _number(row.get("fact_confidence"), "stack_integration.fact_confidence")
+    rooms = int(_number(row.get("mapped_rooms"), "stack_integration.mapped_rooms"))
+    passed = bool(episode) and memories == 1 and confidence >= 0.35 and rooms == 1
+    return passed, {
+        "episode_id": episode,
+        "memory_count": memories,
+        "fact_confidence": confidence,
+        "mapped_rooms": rooms,
+    }
+
+
+def _judge_persistence(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    restored = bool(row.get("restored", False))
+    episodes = int(_number(row.get("episodes"), "persistence.episodes"))
+    facts = int(_number(row.get("facts"), "persistence.facts"))
+    rooms = int(_number(row.get("rooms"), "persistence.rooms"))
+    skills = int(_number(row.get("skills"), "persistence.skills"))
+    passed = restored and episodes == 1 and facts == 1 and rooms == 1 and skills == 1
+    return passed, {
+        "restored": restored,
+        "episodes": episodes,
+        "facts": facts,
+        "rooms": rooms,
+        "skills": skills,
+    }
+
+
+Judge = Callable[[dict[str, Any]], tuple[bool, dict[str, Any]]]
+JUDGES: dict[str, Judge] = {
+    "autobiographical_recall": _judge_autobiographical,
+    "semantic_knowledge": _judge_semantic,
+    "spatial_routing": _judge_spatial,
+    "hierarchical_skill": _judge_hierarchical_skill,
+    "skill_adaptation": _judge_skill_adaptation,
+    "stack_integration": _judge_integration,
+    "persistence": _judge_persistence,
+}
+
+
+def score_norn_memory_navigation_skills_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    """Recompute the source hash and independently judge all seven domains."""
+    if receipt.get("schema") != RECEIPT_SCHEMA:
+        raise NornMemoryNavigationSkillsScoreError("unsupported receipt schema")
+    _verify_hash(receipt)
+    measurements = _measurement_map(receipt)
+
+    awarded = 0
+    judgments: list[dict[str, Any]] = []
+    for measurement_id, points in REQUIRED_MEASUREMENTS.items():
+        passed, evidence = JUDGES[measurement_id](measurements[measurement_id])
+        awarded += points if passed else 0
+        judgments.append(
+            {
+                "id": measurement_id,
+                "passed": passed,
+                "points_awarded": points if passed else 0,
+                "points_available": points,
+                "evidence": evidence,
+            }
+        )
+
+    runtime_summary_consistent = (
+        receipt.get("scenario_count") == len(REQUIRED_MEASUREMENTS)
+        and receipt.get("passed_count") == len(REQUIRED_MEASUREMENTS)
+        and receipt.get("failed_count") == 0
+        and receipt.get("passed") is True
+    )
+    independently_passed = all(item["passed"] for item in judgments)
+    passed = independently_passed and runtime_summary_consistent and awarded == 100
+    score: dict[str, Any] = {
+        "schema": SCORE_SCHEMA,
+        "source_schema": RECEIPT_SCHEMA,
+        "source_receipt_sha256": str(receipt["receipt_sha256"]),
+        "score": awarded,
+        "maximum_score": 100,
+        "passed": passed,
+        "readiness": "green" if passed else "yellow" if awarded >= 70 else "red",
+        "runtime_summary_consistent": runtime_summary_consistent,
+        "judgments": judgments,
+        "claim_boundary": (
+            "A green score establishes the seven measured bounded memory, navigation "
+            "and skill software behaviors for the exact receipt. It does not establish "
+            "human autobiographical memory, perfect navigation, unrestricted autonomy, "
+            "or behavior outside the tested environments."
+        ),
+    }
+    score["score_sha256"] = _digest(score)
+    return score
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Independently score a Prismtek Norn memory/navigation/skills receipt."
+    )
+    parser.add_argument("receipt", type=Path)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+    try:
+        parsed = json.loads(args.receipt.read_text(encoding="utf-8"))
+        if not isinstance(parsed, dict):
+            raise NornMemoryNavigationSkillsScoreError("receipt root must be an object")
+        score = score_norn_memory_navigation_skills_receipt(parsed)
+    except (OSError, json.JSONDecodeError, NornMemoryNavigationSkillsScoreError) as error:
+        print(f"memory/navigation/skills score failed: {error}")
+        return 1
+    encoded = json.dumps(score, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0 if score["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_norn_memory_navigation_skills_score.py
+++ b/tests/test_norn_memory_navigation_skills_score.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from norn_memory_navigation_skills_score import (  # noqa: E402
+    NornMemoryNavigationSkillsScoreError,
+    score_norn_memory_navigation_skills_receipt,
+)
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _receipt() -> dict[str, object]:
+    value: dict[str, object] = {
+        "claim_boundary": "Bounded memory, navigation and skill behaviors only.",
+        "failed_count": 0,
+        "measurements": {
+            "autobiographical_recall": {
+                "match_score": 0.533466533466534,
+                "retrievals": 1,
+                "selected_target": "red_ball",
+            },
+            "hierarchical_skill": {
+                "expanded_steps": 3,
+                "host_validated": True,
+                "learned": True,
+                "proposal_count": 1,
+                "reliability": 0.8,
+            },
+            "persistence": {
+                "episodes": 1,
+                "facts": 1,
+                "restored": True,
+                "rooms": 1,
+                "skills": 1,
+            },
+            "semantic_knowledge": {
+                "confidence_before": 0.6192,
+                "contradictions": 1,
+                "object_after_weak_contradiction": True,
+                "object_before": True,
+                "retained_confidence": 0.564895969258655,
+            },
+            "skill_adaptation": {
+                "failed_executions": 1,
+                "reliability_after": 0.666666666666667,
+                "reliability_before": 0.8,
+            },
+            "spatial_routing": {
+                "host_validated": True,
+                "route_rooms": ["hall", "garden"],
+                "steps": 2,
+            },
+            "stack_integration": {
+                "episode_id": "episode_1",
+                "fact_confidence": 0.405,
+                "mapped_rooms": 1,
+                "memory_count": 1,
+            },
+        },
+        "passed": True,
+        "passed_count": 7,
+        "receipt_sha256": "",
+        "scenario_count": 7,
+        "schema": "prismtek-norn-memory-navigation-skills-receipt-v1",
+    }
+    value["receipt_sha256"] = _digest(
+        {key: item for key, item in value.items() if key != "receipt_sha256"}
+    )
+    return value
+
+
+def _rehash(receipt: dict[str, object]) -> None:
+    receipt["receipt_sha256"] = _digest(
+        {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    )
+
+
+class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
+    def test_exact_green_receipt_scores_one_hundred(self) -> None:
+        score = score_norn_memory_navigation_skills_receipt(_receipt())
+        self.assertTrue(score["passed"])
+        self.assertEqual(score["score"], 100)
+        self.assertEqual(score["readiness"], "green")
+        self.assertEqual(len(score["judgments"]), 7)
+
+    def test_wrong_autobiographical_memory_fails_independently(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        memory = measurements["autobiographical_recall"]
+        assert isinstance(memory, dict)
+        memory["selected_target"] = "berry"
+        _rehash(receipt)
+        score = score_norn_memory_navigation_skills_receipt(receipt)
+        self.assertFalse(score["passed"])
+        self.assertEqual(score["score"], 85)
+
+    def test_weak_rumor_cannot_overwrite_supported_fact(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        semantic = measurements["semantic_knowledge"]
+        assert isinstance(semantic, dict)
+        semantic["object_after_weak_contradiction"] = False
+        semantic["retained_confidence"] = 0.20
+        _rehash(receipt)
+        score = score_norn_memory_navigation_skills_receipt(receipt)
+        judgment = next(item for item in score["judgments"] if item["id"] == "semantic_knowledge")
+        self.assertFalse(score["passed"])
+        self.assertFalse(judgment["passed"])
+
+    def test_dangerous_shortcut_cannot_claim_safe_routing(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        spatial = measurements["spatial_routing"]
+        assert isinstance(spatial, dict)
+        spatial["route_rooms"] = ["garden"]
+        spatial["steps"] = 1
+        _rehash(receipt)
+        score = score_norn_memory_navigation_skills_receipt(receipt)
+        judgment = next(item for item in score["judgments"] if item["id"] == "spatial_routing")
+        self.assertFalse(score["passed"])
+        self.assertFalse(judgment["passed"])
+
+    def test_unlearned_or_unvalidated_skill_fails(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        skill = measurements["hierarchical_skill"]
+        assert isinstance(skill, dict)
+        skill["learned"] = False
+        skill["host_validated"] = False
+        _rehash(receipt)
+        score = score_norn_memory_navigation_skills_receipt(receipt)
+        judgment = next(item for item in score["judgments"] if item["id"] == "hierarchical_skill")
+        self.assertFalse(score["passed"])
+        self.assertFalse(judgment["passed"])
+
+    def test_failed_execution_must_reduce_reliability(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        adaptation = measurements["skill_adaptation"]
+        assert isinstance(adaptation, dict)
+        adaptation["reliability_after"] = 0.8
+        _rehash(receipt)
+        score = score_norn_memory_navigation_skills_receipt(receipt)
+        judgment = next(item for item in score["judgments"] if item["id"] == "skill_adaptation")
+        self.assertFalse(score["passed"])
+        self.assertFalse(judgment["passed"])
+
+    def test_incomplete_persistence_fails(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        persistence = measurements["persistence"]
+        assert isinstance(persistence, dict)
+        persistence["skills"] = 0
+        _rehash(receipt)
+        score = score_norn_memory_navigation_skills_receipt(receipt)
+        judgment = next(item for item in score["judgments"] if item["id"] == "persistence")
+        self.assertFalse(score["passed"])
+        self.assertFalse(judgment["passed"])
+
+    def test_runtime_summary_disagreement_prevents_green(self) -> None:
+        receipt = _receipt()
+        receipt["passed_count"] = 6
+        receipt["failed_count"] = 1
+        _rehash(receipt)
+        score = score_norn_memory_navigation_skills_receipt(receipt)
+        self.assertEqual(score["score"], 100)
+        self.assertFalse(score["runtime_summary_consistent"])
+        self.assertFalse(score["passed"])
+
+    def test_missing_measurement_is_rejected(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        del measurements["spatial_routing"]
+        _rehash(receipt)
+        with self.assertRaisesRegex(NornMemoryNavigationSkillsScoreError, "missing required"):
+            score_norn_memory_navigation_skills_receipt(receipt)
+
+    def test_payload_tampering_is_rejected(self) -> None:
+        receipt = _receipt()
+        measurements = receipt["measurements"]
+        assert isinstance(measurements, dict)
+        persistence = measurements["persistence"]
+        assert isinstance(persistence, dict)
+        persistence["restored"] = False
+        with self.assertRaisesRegex(NornMemoryNavigationSkillsScoreError, "hash mismatch"):
+            score_norn_memory_navigation_skills_receipt(receipt)
+
+    def test_scoring_is_deterministic_and_non_mutating(self) -> None:
+        receipt = _receipt()
+        before = copy.deepcopy(receipt)
+        first = score_norn_memory_navigation_skills_receipt(receipt)
+        second = score_norn_memory_navigation_skills_receipt(receipt)
+        self.assertEqual(first, second)
+        self.assertEqual(receipt, before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this builds

Buddy Brain independently evaluates `prismtek-norn-memory-navigation-skills-receipt-v1` evidence generated by `prismtek-apps#324`.

The game cannot establish success by setting `passed: true`. The scorer recomputes the complete source SHA-256, requires exactly seven measurement domains and applies thresholds owned outside the game repository.

## Independently judged domains

- cue-grounded autobiographical recall;
- semantic evidence accumulation and contradiction resistance;
- danger-aware learned routing;
- experiential hierarchical skill formation;
- reliability loss after failed skill execution;
- automatic outcome-to-memory and room-to-map integration;
- joint persistence of episodes, facts, maps and skills.

## Adversarial boundary

Eleven focused tests cover:

- the exact known-good receipt scoring `100/100`;
- irrelevant recall hidden behind a green summary;
- a weak rumor overwriting a supported fact;
- a dangerous shortcut presented as safe routing;
- an unlearned or non-host-validated skill;
- failure without reliability loss;
- incomplete persistence;
- runtime summary disagreement;
- missing measurement domains;
- payload tampering;
- deterministic, non-mutating scoring.

## Exact source receipt

- Prismtek Apps head: `a544fc316c4fed4201451af203c0de37c4247a81`;
- source receipt SHA-256: `71834d4b9cb024f4b94128c83e82780a294f56fa7e64923fa36f41e81a386459`.

## Task contract

Plan: `PR_BODY`
- Verification: yes
- Rollback: yes

## Plan

- Intent: independently verify the exact bounded memory, navigation and skill behaviors emitted by the Godot runtime.
- Changed paths: `scripts/norn_memory_navigation_skills_score.py`, `tests/test_norn_memory_navigation_skills_score.py`, `.github/workflows/norn-memory-navigation-skills-score.yml`, and `docs/NORN_MEMORY_NAVIGATION_SKILLS_SCORE.md`.
- Verification: compile the scorer, run all eleven focused adversarial tests, then run the complete Buddy Brain CI, lint, readiness, CodeQL, iOS and runtime smoke gates; finally pin this exact scorer from Prismtek Apps and require `100/100`.
- Rollback: delete the four additive files; no runtime state, permissions, deployment or existing scorer behavior is changed.

## Problem

The game can emit a green memory/navigation/skills receipt, but without an external judge it could hide irrelevant retrieval, weak semantic confidence, dangerous routing, unvalidated action chunks or incomplete persistence behind its own pass flags.

## Smallest useful wedge

Add one deterministic read-only scorer with content-hash verification, independently owned thresholds and adversarial tests for each major false-green case.

## Verification plan

Run the dedicated scorer workflow, Buddy Brain CI, lint, task-readiness, CodeQL, BeMoreAgent iOS validation, bootstrap smoke, autonomy-foundation smoke and BMO runtime smoke. Then pin the exact scorer from the game repository and require a live `100/100` cross-repository proof.

## Rollback plan

Delete the four additive scorer, test, workflow and documentation files. No game runtime, memory, permissions, deployment or existing scorer behavior is modified.

## Claim boundary

A green score establishes the seven measured bounded memory, navigation and skill software behaviors for the exact receipt. It does not establish human autobiographical memory, perfect navigation, unrestricted autonomy or performance outside the tested environments.