### PR TITLE
rename the Buddy Life scorers off the legacy token

### DIFF
--- a/.github/workflows/buddy-life-memory-navigation-skills-score.yml
+++ b/.github/workflows/buddy-life-memory-navigation-skills-score.yml
@@ -3,15 +3,15 @@ name: Norn memory navigation skills score
 on:
   pull_request:
     paths:
-      - "scripts/norn_memory_navigation_skills_score.py"
-      - "tests/test_norn_memory_navigation_skills_score.py"
+      - "scripts/buddy_life_memory_navigation_skills_score.py"
+      - "tests/test_buddy_life_memory_navigation_skills_score.py"
       - "docs/NORN_MEMORY_NAVIGATION_SKILLS_SCORE.md"
       - ".github/workflows/norn-memory-navigation-skills-score.yml"
   push:
     branches: [master]
     paths:
-      - "scripts/norn_memory_navigation_skills_score.py"
-      - "tests/test_norn_memory_navigation_skills_score.py"
+      - "scripts/buddy_life_memory_navigation_skills_score.py"
+      - "tests/test_buddy_life_memory_navigation_skills_score.py"
       - "docs/NORN_MEMORY_NAVIGATION_SKILLS_SCORE.md"
       - ".github/workflows/norn-memory-navigation-skills-score.yml"
   workflow_dispatch:
@@ -29,6 +29,6 @@ jobs:
         with:
           python-version: "3.12"
       - name: Compile scorer
-        run: python -m py_compile scripts/norn_memory_navigation_skills_score.py
+        run: python -m py_compile scripts/buddy_life_memory_navigation_skills_score.py
       - name: Test independent thresholds and adversarial rejection
-        run: python -m unittest -v tests/test_norn_memory_navigation_skills_score.py
+        run: python -m unittest -v tests/test_buddy_life_memory_navigation_skills_score.py

--- a/.github/workflows/buddy-life-modern-cognition-score.yml
+++ b/.github/workflows/buddy-life-modern-cognition-score.yml
@@ -3,15 +3,15 @@ name: Norn modern cognition score
 on:
   pull_request:
     paths:
-      - "scripts/norn_modern_cognition_score.py"
-      - "tests/test_norn_modern_cognition_score.py"
+      - "scripts/buddy_life_modern_cognition_score.py"
+      - "tests/test_buddy_life_modern_cognition_score.py"
       - "docs/NORN_MODERN_COGNITION_SCORE.md"
       - ".github/workflows/norn-modern-cognition-score.yml"
   push:
     branches: [master]
     paths:
-      - "scripts/norn_modern_cognition_score.py"
-      - "tests/test_norn_modern_cognition_score.py"
+      - "scripts/buddy_life_modern_cognition_score.py"
+      - "tests/test_buddy_life_modern_cognition_score.py"
       - "docs/NORN_MODERN_COGNITION_SCORE.md"
       - ".github/workflows/norn-modern-cognition-score.yml"
   workflow_dispatch:
@@ -29,6 +29,6 @@ jobs:
         with:
           python-version: "3.12"
       - name: Compile scorer
-        run: python -m py_compile scripts/norn_modern_cognition_score.py
+        run: python -m py_compile scripts/buddy_life_modern_cognition_score.py
       - name: Test independent thresholds and adversarial rejection
-        run: python -m unittest -v tests/test_norn_modern_cognition_score.py
+        run: python -m unittest -v tests/test_buddy_life_modern_cognition_score.py

--- a/.github/workflows/buddy-life-parity-score.yml
+++ b/.github/workflows/buddy-life-parity-score.yml
@@ -3,15 +3,15 @@ name: Norn parity score
 on:
   pull_request:
     paths:
-      - "scripts/norn_parity_score.py"
-      - "tests/test_norn_parity_score.py"
+      - "scripts/buddy_life_parity_score.py"
+      - "tests/test_buddy_life_parity_score.py"
       - "docs/NORN_PARITY_SCORE.md"
       - ".github/workflows/norn-parity-score.yml"
   push:
     branches: [master]
     paths:
-      - "scripts/norn_parity_score.py"
-      - "tests/test_norn_parity_score.py"
+      - "scripts/buddy_life_parity_score.py"
+      - "tests/test_buddy_life_parity_score.py"
       - "docs/NORN_PARITY_SCORE.md"
       - ".github/workflows/norn-parity-score.yml"
   workflow_dispatch:
@@ -29,6 +29,6 @@ jobs:
         with:
           python-version: "3.12"
       - name: Compile scorer
-        run: python -m py_compile scripts/norn_parity_score.py
+        run: python -m py_compile scripts/buddy_life_parity_score.py
       - name: Test independent measurements and tamper rejection
-        run: python -m unittest -v tests/test_norn_parity_score.py
+        run: python -m unittest -v tests/test_buddy_life_parity_score.py

--- a/.github/workflows/buddy-life-stochastic-score.yml
+++ b/.github/workflows/buddy-life-stochastic-score.yml
@@ -3,15 +3,15 @@ name: Norn stochastic score
 on:
   pull_request:
     paths:
-      - "scripts/norn_stochastic_score.py"
-      - "tests/test_norn_stochastic_score.py"
+      - "scripts/buddy_life_stochastic_score.py"
+      - "tests/test_buddy_life_stochastic_score.py"
       - "docs/NORN_STOCHASTIC_SCORE.md"
       - ".github/workflows/norn-stochastic-score.yml"
   push:
     branches: [master]
     paths:
-      - "scripts/norn_stochastic_score.py"
-      - "tests/test_norn_stochastic_score.py"
+      - "scripts/buddy_life_stochastic_score.py"
+      - "tests/test_buddy_life_stochastic_score.py"
       - "docs/NORN_STOCHASTIC_SCORE.md"
       - ".github/workflows/norn-stochastic-score.yml"
   workflow_dispatch:
@@ -29,6 +29,6 @@ jobs:
         with:
           python-version: "3.12"
       - name: Compile scorer
-        run: python -m py_compile scripts/norn_stochastic_score.py
+        run: python -m py_compile scripts/buddy_life_stochastic_score.py
       - name: Test aggregate thresholds and adversarial rejection
-        run: python -m unittest -v tests/test_norn_stochastic_score.py
+        run: python -m unittest -v tests/test_buddy_life_stochastic_score.py

--- a/scripts/buddy_life_memory_navigation_skills_score.py
+++ b/scripts/buddy_life_memory_navigation_skills_score.py
@@ -10,7 +10,13 @@ import json
 from pathlib import Path
 from typing import Any, Callable
 
-RECEIPT_SCHEMA = "prismtek-norn-memory-navigation-skills-receipt-v1"
+# The runtime retired the legacy token from its own vocabulary, but a receipt that has
+# already been published cannot be re-emitted -- and a score is only meaningful if the
+# scorer can still read the evidence it was asked to judge. Both spellings are accepted;
+# the receipt names itself, and this file does not care which name it chose.
+RECEIPT_SCHEMA = "prismtek-buddy_life-memory-navigation-skills-receipt-v1"
+LEGACY_RECEIPT_SCHEMA = "prismtek-norn-memory-navigation-skills-receipt-v1"
+ACCEPTED_RECEIPT_SCHEMAS = (RECEIPT_SCHEMA, LEGACY_RECEIPT_SCHEMA)
 SCORE_SCHEMA = "prismtek-norn-memory-navigation-skills-score-v1"
 REQUIRED_MEASUREMENTS = {
     "autobiographical_recall": 15,
@@ -23,7 +29,7 @@ REQUIRED_MEASUREMENTS = {
 }
 
 
-class NornMemoryNavigationSkillsScoreError(ValueError):
+class BuddyLifeMemoryNavigationSkillsScoreError(ValueError):
     """The source receipt is malformed, tampered with, or incomplete."""
 
 
@@ -41,37 +47,37 @@ def _without_hash(value: dict[str, Any]) -> dict[str, Any]:
 def _verify_hash(receipt: dict[str, Any]) -> None:
     supplied = str(receipt.get("receipt_sha256", ""))
     if not supplied:
-        raise NornMemoryNavigationSkillsScoreError("receipt is missing receipt_sha256")
+        raise BuddyLifeMemoryNavigationSkillsScoreError("receipt is missing receipt_sha256")
     if supplied != _digest(_without_hash(receipt)):
-        raise NornMemoryNavigationSkillsScoreError("receipt hash mismatch")
+        raise BuddyLifeMemoryNavigationSkillsScoreError("receipt hash mismatch")
 
 
 def _number(value: Any, field: str) -> float:
     if isinstance(value, bool):
-        raise NornMemoryNavigationSkillsScoreError(f"{field} must be numeric")
+        raise BuddyLifeMemoryNavigationSkillsScoreError(f"{field} must be numeric")
     try:
         return float(value)
     except (TypeError, ValueError) as error:
-        raise NornMemoryNavigationSkillsScoreError(f"{field} must be numeric") from error
+        raise BuddyLifeMemoryNavigationSkillsScoreError(f"{field} must be numeric") from error
 
 
 def _measurement_map(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
     raw = receipt.get("measurements")
     if not isinstance(raw, dict):
-        raise NornMemoryNavigationSkillsScoreError("receipt.measurements must be an object")
+        raise BuddyLifeMemoryNavigationSkillsScoreError("receipt.measurements must be an object")
     result: dict[str, dict[str, Any]] = {}
     for key, value in raw.items():
         if not isinstance(value, dict):
-            raise NornMemoryNavigationSkillsScoreError(f"measurement {key} must be an object")
+            raise BuddyLifeMemoryNavigationSkillsScoreError(f"measurement {key} must be an object")
         result[str(key)] = value
     missing = sorted(set(REQUIRED_MEASUREMENTS) - set(result))
     extra = sorted(set(result) - set(REQUIRED_MEASUREMENTS))
     if missing:
-        raise NornMemoryNavigationSkillsScoreError(
+        raise BuddyLifeMemoryNavigationSkillsScoreError(
             f"missing required measurements: {', '.join(missing)}"
         )
     if extra:
-        raise NornMemoryNavigationSkillsScoreError(
+        raise BuddyLifeMemoryNavigationSkillsScoreError(
             f"unknown measurements: {', '.join(extra)}"
         )
     return result
@@ -123,7 +129,7 @@ def _judge_semantic(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
 def _judge_spatial(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
     raw_rooms = row.get("route_rooms")
     if not isinstance(raw_rooms, list):
-        raise NornMemoryNavigationSkillsScoreError("spatial_routing.route_rooms must be an array")
+        raise BuddyLifeMemoryNavigationSkillsScoreError("spatial_routing.route_rooms must be an array")
     rooms = [str(value) for value in raw_rooms]
     steps = int(_number(row.get("steps"), "spatial_routing.steps"))
     host_validated = bool(row.get("host_validated", False))
@@ -214,10 +220,10 @@ JUDGES: dict[str, Judge] = {
 }
 
 
-def score_norn_memory_navigation_skills_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+def score_buddy_life_memory_navigation_skills_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     """Recompute the source hash and independently judge all seven domains."""
-    if receipt.get("schema") != RECEIPT_SCHEMA:
-        raise NornMemoryNavigationSkillsScoreError("unsupported receipt schema")
+    if receipt.get("schema") not in ACCEPTED_RECEIPT_SCHEMAS:
+        raise BuddyLifeMemoryNavigationSkillsScoreError("unsupported receipt schema")
     _verify_hash(receipt)
     measurements = _measurement_map(receipt)
 
@@ -246,7 +252,7 @@ def score_norn_memory_navigation_skills_receipt(receipt: dict[str, Any]) -> dict
     passed = independently_passed and runtime_summary_consistent and awarded == 100
     score: dict[str, Any] = {
         "schema": SCORE_SCHEMA,
-        "source_schema": RECEIPT_SCHEMA,
+        "source_schema": str(receipt.get("schema", RECEIPT_SCHEMA)),
         "source_receipt_sha256": str(receipt["receipt_sha256"]),
         "score": awarded,
         "maximum_score": 100,
@@ -275,9 +281,9 @@ def main() -> int:
     try:
         parsed = json.loads(args.receipt.read_text(encoding="utf-8"))
         if not isinstance(parsed, dict):
-            raise NornMemoryNavigationSkillsScoreError("receipt root must be an object")
-        score = score_norn_memory_navigation_skills_receipt(parsed)
-    except (OSError, json.JSONDecodeError, NornMemoryNavigationSkillsScoreError) as error:
+            raise BuddyLifeMemoryNavigationSkillsScoreError("receipt root must be an object")
+        score = score_buddy_life_memory_navigation_skills_receipt(parsed)
+    except (OSError, json.JSONDecodeError, BuddyLifeMemoryNavigationSkillsScoreError) as error:
         print(f"memory/navigation/skills score failed: {error}")
         return 1
     encoded = json.dumps(score, indent=2, sort_keys=True) + "\n"

--- a/scripts/buddy_life_modern_cognition_score.py
+++ b/scripts/buddy_life_modern_cognition_score.py
@@ -10,7 +10,13 @@ import json
 from pathlib import Path
 from typing import Any, Callable
 
-RECEIPT_SCHEMA = "prismtek-norn-modern-cognition-receipt-v1"
+# The runtime retired the legacy token from its own vocabulary, but a receipt that has
+# already been published cannot be re-emitted -- and a score is only meaningful if the
+# scorer can still read the evidence it was asked to judge. Both spellings are accepted;
+# the receipt names itself, and this file does not care which name it chose.
+RECEIPT_SCHEMA = "prismtek-buddy_life-modern-cognition-receipt-v1"
+LEGACY_RECEIPT_SCHEMA = "prismtek-norn-modern-cognition-receipt-v1"
+ACCEPTED_RECEIPT_SCHEMAS = (RECEIPT_SCHEMA, LEGACY_RECEIPT_SCHEMA)
 SCORE_SCHEMA = "prismtek-norn-modern-cognition-score-v1"
 REQUIRED_MEASUREMENTS = {
     "delayed_credit": 15,
@@ -23,7 +29,7 @@ REQUIRED_MEASUREMENTS = {
 }
 
 
-class NornModernCognitionScoreError(ValueError):
+class BuddyLifeModernCognitionScoreError(ValueError):
     """The cognition receipt is malformed, tampered with, or incomplete."""
 
 
@@ -41,37 +47,37 @@ def _without_hash(value: dict[str, Any]) -> dict[str, Any]:
 def _verify_hash(receipt: dict[str, Any]) -> None:
     supplied = str(receipt.get("receipt_sha256", ""))
     if not supplied:
-        raise NornModernCognitionScoreError("receipt is missing receipt_sha256")
+        raise BuddyLifeModernCognitionScoreError("receipt is missing receipt_sha256")
     if supplied != _digest(_without_hash(receipt)):
-        raise NornModernCognitionScoreError("receipt hash mismatch")
+        raise BuddyLifeModernCognitionScoreError("receipt hash mismatch")
 
 
 def _number(value: Any, field: str) -> float:
     if isinstance(value, bool):
-        raise NornModernCognitionScoreError(f"{field} must be numeric")
+        raise BuddyLifeModernCognitionScoreError(f"{field} must be numeric")
     try:
         return float(value)
     except (TypeError, ValueError) as error:
-        raise NornModernCognitionScoreError(f"{field} must be numeric") from error
+        raise BuddyLifeModernCognitionScoreError(f"{field} must be numeric") from error
 
 
 def _measurement_map(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
     raw = receipt.get("measurements")
     if not isinstance(raw, dict):
-        raise NornModernCognitionScoreError("receipt.measurements must be an object")
+        raise BuddyLifeModernCognitionScoreError("receipt.measurements must be an object")
     result: dict[str, dict[str, Any]] = {}
     for key, value in raw.items():
         if not isinstance(value, dict):
-            raise NornModernCognitionScoreError(f"measurement {key} must be an object")
+            raise BuddyLifeModernCognitionScoreError(f"measurement {key} must be an object")
         result[str(key)] = value
     missing = sorted(set(REQUIRED_MEASUREMENTS) - set(result))
     extra = sorted(set(result) - set(REQUIRED_MEASUREMENTS))
     if missing:
-        raise NornModernCognitionScoreError(
+        raise BuddyLifeModernCognitionScoreError(
             f"missing required measurements: {', '.join(missing)}"
         )
     if extra:
-        raise NornModernCognitionScoreError(
+        raise BuddyLifeModernCognitionScoreError(
             f"unknown measurements: {', '.join(extra)}"
         )
     return result
@@ -146,7 +152,7 @@ def _judge_development(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
 def _judge_planning(row: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
     raw_ids = row.get("ids")
     if not isinstance(raw_ids, list):
-        raise NornModernCognitionScoreError("planning.ids must be an array")
+        raise BuddyLifeModernCognitionScoreError("planning.ids must be an array")
     ids = [str(value) for value in raw_ids]
     steps = int(_number(row.get("steps"), "planning.steps"))
     expanded = int(_number(row.get("expanded"), "planning.expanded"))
@@ -227,10 +233,10 @@ JUDGES: dict[str, Judge] = {
 }
 
 
-def score_norn_modern_cognition_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+def score_buddy_life_modern_cognition_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     """Recompute the hash and independently judge all modern cognition measurements."""
-    if receipt.get("schema") != RECEIPT_SCHEMA:
-        raise NornModernCognitionScoreError("unsupported modern cognition receipt schema")
+    if receipt.get("schema") not in ACCEPTED_RECEIPT_SCHEMAS:
+        raise BuddyLifeModernCognitionScoreError("unsupported modern cognition receipt schema")
     _verify_hash(receipt)
     measurements = _measurement_map(receipt)
 
@@ -259,7 +265,7 @@ def score_norn_modern_cognition_receipt(receipt: dict[str, Any]) -> dict[str, An
     passed = independently_passed and runtime_summary_consistent and awarded == 100
     score: dict[str, Any] = {
         "schema": SCORE_SCHEMA,
-        "source_schema": RECEIPT_SCHEMA,
+        "source_schema": str(receipt.get("schema", RECEIPT_SCHEMA)),
         "source_receipt_sha256": str(receipt["receipt_sha256"]),
         "score": awarded,
         "maximum_score": 100,
@@ -288,9 +294,9 @@ def main() -> int:
     try:
         parsed = json.loads(args.receipt.read_text(encoding="utf-8"))
         if not isinstance(parsed, dict):
-            raise NornModernCognitionScoreError("receipt root must be an object")
-        score = score_norn_modern_cognition_receipt(parsed)
-    except (OSError, json.JSONDecodeError, NornModernCognitionScoreError) as error:
+            raise BuddyLifeModernCognitionScoreError("receipt root must be an object")
+        score = score_buddy_life_modern_cognition_receipt(parsed)
+    except (OSError, json.JSONDecodeError, BuddyLifeModernCognitionScoreError) as error:
         print(f"modern cognition score failed: {error}")
         return 1
     encoded = json.dumps(score, indent=2, sort_keys=True) + "\n"

--- a/scripts/buddy_life_parity_score.py
+++ b/scripts/buddy_life_parity_score.py
@@ -10,7 +10,13 @@ import json
 from pathlib import Path
 from typing import Any, Callable
 
-RECEIPT_SCHEMA = "prismtek-norn-parity-arena-v1"
+# The runtime retired the legacy token from its own vocabulary, but a receipt that has
+# already been published cannot be re-emitted -- and a score is only meaningful if the
+# scorer can still read the evidence it was asked to judge. Both spellings are accepted;
+# the receipt names itself, and this file does not care which name it chose.
+RECEIPT_SCHEMA = "prismtek-buddy_life-parity-arena-v1"
+LEGACY_RECEIPT_SCHEMA = "prismtek-norn-parity-arena-v1"
+ACCEPTED_RECEIPT_SCHEMAS = (RECEIPT_SCHEMA, LEGACY_RECEIPT_SCHEMA)
 SCORE_SCHEMA = "prismtek-norn-parity-score-v1"
 REQUIRED_SCENARIOS = {
     "object-learning-reversal": 20,
@@ -23,7 +29,7 @@ REQUIRED_SCENARIOS = {
 }
 
 
-class NornParityScoreError(ValueError):
+class BuddyLifeParityScoreError(ValueError):
     """The game receipt is malformed, tampered with, or incomplete."""
 
 
@@ -41,25 +47,25 @@ def _without_hash(value: dict[str, Any]) -> dict[str, Any]:
 def _verify_hash(payload: dict[str, Any], label: str) -> None:
     supplied = str(payload.get("receipt_sha256", ""))
     if not supplied:
-        raise NornParityScoreError(f"{label} is missing receipt_sha256")
+        raise BuddyLifeParityScoreError(f"{label} is missing receipt_sha256")
     expected = _digest(_without_hash(payload))
     if supplied != expected:
-        raise NornParityScoreError(f"{label} hash mismatch")
+        raise BuddyLifeParityScoreError(f"{label} hash mismatch")
 
 
 def _number(value: Any, field: str) -> float:
     if isinstance(value, bool):
-        raise NornParityScoreError(f"{field} must be numeric")
+        raise BuddyLifeParityScoreError(f"{field} must be numeric")
     try:
         return float(value)
     except (TypeError, ValueError) as error:
-        raise NornParityScoreError(f"{field} must be numeric") from error
+        raise BuddyLifeParityScoreError(f"{field} must be numeric") from error
 
 
 def _measurement(scenario: dict[str, Any], name: str) -> Any:
     measurements = scenario.get("measurements")
     if not isinstance(measurements, dict) or name not in measurements:
-        raise NornParityScoreError(
+        raise BuddyLifeParityScoreError(
             f"scenario {scenario.get('id')} is missing measurement {name}"
         )
     return measurements[name]
@@ -68,24 +74,24 @@ def _measurement(scenario: dict[str, Any], name: str) -> Any:
 def _scenario_map(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
     raw = receipt.get("scenarios")
     if not isinstance(raw, list):
-        raise NornParityScoreError("receipt.scenarios must be an array")
+        raise BuddyLifeParityScoreError("receipt.scenarios must be an array")
     result: dict[str, dict[str, Any]] = {}
     for index, scenario in enumerate(raw):
         if not isinstance(scenario, dict):
-            raise NornParityScoreError(f"scenario[{index}] must be an object")
+            raise BuddyLifeParityScoreError(f"scenario[{index}] must be an object")
         scenario_id = str(scenario.get("id", ""))
         if not scenario_id:
-            raise NornParityScoreError(f"scenario[{index}] requires id")
+            raise BuddyLifeParityScoreError(f"scenario[{index}] requires id")
         if scenario_id in result:
-            raise NornParityScoreError(f"duplicate scenario {scenario_id}")
+            raise BuddyLifeParityScoreError(f"duplicate scenario {scenario_id}")
         _verify_hash(scenario, f"scenario {scenario_id}")
         result[scenario_id] = scenario
     missing = sorted(set(REQUIRED_SCENARIOS) - set(result))
     extra = sorted(set(result) - set(REQUIRED_SCENARIOS))
     if missing:
-        raise NornParityScoreError(f"missing required scenarios: {', '.join(missing)}")
+        raise BuddyLifeParityScoreError(f"missing required scenarios: {', '.join(missing)}")
     if extra:
-        raise NornParityScoreError(f"unknown scenarios: {', '.join(extra)}")
+        raise BuddyLifeParityScoreError(f"unknown scenarios: {', '.join(extra)}")
     return result
 
 
@@ -130,13 +136,13 @@ def _judge_transfer(scenario: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
 def _judge_planning(scenario: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
     raw_ids = _measurement(scenario, "plan_ids")
     if not isinstance(raw_ids, list):
-        raise NornParityScoreError("plan_ids must be an array")
+        raise BuddyLifeParityScoreError("plan_ids must be an array")
     ids = [str(value) for value in raw_ids]
     steps = int(_number(_measurement(scenario, "steps"), "steps"))
     host_validated = bool(_measurement(scenario, "all_steps_require_host_validation"))
     final_drives = _measurement(scenario, "projected_final_drives")
     if not isinstance(final_drives, dict):
-        raise NornParityScoreError("projected_final_drives must be an object")
+        raise BuddyLifeParityScoreError("projected_final_drives must be an object")
     hunger = _number(final_drives.get("hunger"), "projected_final_drives.hunger")
     sleepiness = _number(final_drives.get("sleepiness"), "projected_final_drives.sleepiness")
     boredom = _number(final_drives.get("boredom"), "projected_final_drives.boredom")
@@ -240,12 +246,12 @@ JUDGES: dict[str, Judge] = {
 }
 
 
-def score_norn_parity_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+def score_buddy_life_parity_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     """Recompute hashes and independently judge every behavioral measurement."""
-    if receipt.get("schema") != RECEIPT_SCHEMA:
-        raise NornParityScoreError("unsupported Norn parity receipt schema")
+    if receipt.get("schema") not in ACCEPTED_RECEIPT_SCHEMAS:
+        raise BuddyLifeParityScoreError("unsupported Norn parity receipt schema")
     if receipt.get("mode") != "cortex-off":
-        raise NornParityScoreError("Norn parity requires a cortex-off receipt")
+        raise BuddyLifeParityScoreError("Norn parity requires a cortex-off receipt")
     _verify_hash(receipt, "Norn parity receipt")
     scenarios = _scenario_map(receipt)
 
@@ -277,7 +283,7 @@ def score_norn_parity_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     passed = independently_passed and runtime_summary_consistent and awarded == 100
     score: dict[str, Any] = {
         "schema": SCORE_SCHEMA,
-        "source_schema": RECEIPT_SCHEMA,
+        "source_schema": str(receipt.get("schema", RECEIPT_SCHEMA)),
         "source_receipt_sha256": str(receipt["receipt_sha256"]),
         "mode": "cortex-off",
         "score": awarded,
@@ -307,9 +313,9 @@ def main() -> int:
     try:
         parsed = json.loads(args.receipt.read_text(encoding="utf-8"))
         if not isinstance(parsed, dict):
-            raise NornParityScoreError("receipt must be a JSON object")
-        score = score_norn_parity_receipt(parsed)
-    except (NornParityScoreError, json.JSONDecodeError, OSError) as error:
+            raise BuddyLifeParityScoreError("receipt must be a JSON object")
+        score = score_buddy_life_parity_receipt(parsed)
+    except (BuddyLifeParityScoreError, json.JSONDecodeError, OSError) as error:
         parser.error(str(error))
     rendered = json.dumps(score, indent=2, sort_keys=True) + "\n"
     if args.out is not None:

--- a/scripts/buddy_life_stochastic_score.py
+++ b/scripts/buddy_life_stochastic_score.py
@@ -10,7 +10,13 @@ import json
 from pathlib import Path
 from typing import Any, Callable
 
-RECEIPT_SCHEMA = "prismtek-norn-stochastic-arena-v1"
+# The runtime retired the legacy token from its own vocabulary, but a receipt that has
+# already been published cannot be re-emitted -- and a score is only meaningful if the
+# scorer can still read the evidence it was asked to judge. Both spellings are accepted;
+# the receipt names itself, and this file does not care which name it chose.
+RECEIPT_SCHEMA = "prismtek-buddy_life-stochastic-arena-v1"
+LEGACY_RECEIPT_SCHEMA = "prismtek-norn-stochastic-arena-v1"
+ACCEPTED_RECEIPT_SCHEMAS = (RECEIPT_SCHEMA, LEGACY_RECEIPT_SCHEMA)
 SCORE_SCHEMA = "prismtek-norn-stochastic-score-v1"
 EXPECTED_SEED = 90210
 EXPECTED_TRIALS = 32
@@ -24,7 +30,7 @@ REQUIRED_SCENARIOS = {
 }
 
 
-class NornStochasticScoreError(ValueError):
+class BuddyLifeStochasticScoreError(ValueError):
     """The stochastic receipt is malformed, tampered with, or insufficient."""
 
 
@@ -42,24 +48,24 @@ def _without_hash(value: dict[str, Any]) -> dict[str, Any]:
 def _verify_hash(payload: dict[str, Any], label: str) -> None:
     supplied = str(payload.get("receipt_sha256", ""))
     if not supplied:
-        raise NornStochasticScoreError(f"{label} is missing receipt_sha256")
+        raise BuddyLifeStochasticScoreError(f"{label} is missing receipt_sha256")
     if supplied != _digest(_without_hash(payload)):
-        raise NornStochasticScoreError(f"{label} hash mismatch")
+        raise BuddyLifeStochasticScoreError(f"{label} hash mismatch")
 
 
 def _number(value: Any, field: str) -> float:
     if isinstance(value, bool):
-        raise NornStochasticScoreError(f"{field} must be numeric")
+        raise BuddyLifeStochasticScoreError(f"{field} must be numeric")
     try:
         return float(value)
     except (TypeError, ValueError) as error:
-        raise NornStochasticScoreError(f"{field} must be numeric") from error
+        raise BuddyLifeStochasticScoreError(f"{field} must be numeric") from error
 
 
 def _measurement(scenario: dict[str, Any], name: str) -> Any:
     measurements = scenario.get("measurements")
     if not isinstance(measurements, dict) or name not in measurements:
-        raise NornStochasticScoreError(
+        raise BuddyLifeStochasticScoreError(
             f"scenario {scenario.get('id')} is missing measurement {name}"
         )
     return measurements[name]
@@ -68,24 +74,24 @@ def _measurement(scenario: dict[str, Any], name: str) -> Any:
 def _scenario_map(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
     raw = receipt.get("scenarios")
     if not isinstance(raw, list):
-        raise NornStochasticScoreError("receipt.scenarios must be an array")
+        raise BuddyLifeStochasticScoreError("receipt.scenarios must be an array")
     result: dict[str, dict[str, Any]] = {}
     for index, scenario in enumerate(raw):
         if not isinstance(scenario, dict):
-            raise NornStochasticScoreError(f"scenario[{index}] must be an object")
+            raise BuddyLifeStochasticScoreError(f"scenario[{index}] must be an object")
         scenario_id = str(scenario.get("id", ""))
         if not scenario_id:
-            raise NornStochasticScoreError(f"scenario[{index}] requires id")
+            raise BuddyLifeStochasticScoreError(f"scenario[{index}] requires id")
         if scenario_id in result:
-            raise NornStochasticScoreError(f"duplicate scenario {scenario_id}")
+            raise BuddyLifeStochasticScoreError(f"duplicate scenario {scenario_id}")
         _verify_hash(scenario, f"scenario {scenario_id}")
         result[scenario_id] = scenario
     missing = sorted(set(REQUIRED_SCENARIOS) - set(result))
     extra = sorted(set(result) - set(REQUIRED_SCENARIOS))
     if missing:
-        raise NornStochasticScoreError(f"missing required scenarios: {', '.join(missing)}")
+        raise BuddyLifeStochasticScoreError(f"missing required scenarios: {', '.join(missing)}")
     if extra:
-        raise NornStochasticScoreError(f"unknown scenarios: {', '.join(extra)}")
+        raise BuddyLifeStochasticScoreError(f"unknown scenarios: {', '.join(extra)}")
     return result
 
 
@@ -258,13 +264,13 @@ JUDGES: dict[str, Judge] = {
 }
 
 
-def score_norn_stochastic_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
-    if receipt.get("schema") != RECEIPT_SCHEMA:
-        raise NornStochasticScoreError("unsupported stochastic Norn receipt schema")
+def score_buddy_life_stochastic_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    if receipt.get("schema") not in ACCEPTED_RECEIPT_SCHEMAS:
+        raise BuddyLifeStochasticScoreError("unsupported stochastic Norn receipt schema")
     if receipt.get("mode") != "cortex-off":
-        raise NornStochasticScoreError("stochastic Norn scoring requires cortex-off mode")
+        raise BuddyLifeStochasticScoreError("stochastic Norn scoring requires cortex-off mode")
     if receipt.get("seed") != EXPECTED_SEED or receipt.get("trials") != EXPECTED_TRIALS:
-        raise NornStochasticScoreError("unexpected stochastic seed or trial count")
+        raise BuddyLifeStochasticScoreError("unexpected stochastic seed or trial count")
     _verify_hash(receipt, "stochastic Norn receipt")
     scenarios = _scenario_map(receipt)
 
@@ -295,7 +301,7 @@ def score_norn_stochastic_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     passed = all(item["passed"] for item in judgments) and summary_consistent and awarded == 100
     score: dict[str, Any] = {
         "schema": SCORE_SCHEMA,
-        "source_schema": RECEIPT_SCHEMA,
+        "source_schema": str(receipt.get("schema", RECEIPT_SCHEMA)),
         "source_receipt_sha256": str(receipt["receipt_sha256"]),
         "mode": "cortex-off",
         "seed": EXPECTED_SEED,
@@ -325,9 +331,9 @@ def main() -> int:
     try:
         parsed = json.loads(args.receipt.read_text(encoding="utf-8"))
         if not isinstance(parsed, dict):
-            raise NornStochasticScoreError("receipt must be a JSON object")
-        score = score_norn_stochastic_receipt(parsed)
-    except (NornStochasticScoreError, json.JSONDecodeError, OSError) as error:
+            raise BuddyLifeStochasticScoreError("receipt must be a JSON object")
+        score = score_buddy_life_stochastic_receipt(parsed)
+    except (BuddyLifeStochasticScoreError, json.JSONDecodeError, OSError) as error:
         parser.error(str(error))
     rendered = json.dumps(score, indent=2, sort_keys=True) + "\n"
     if args.out is not None:

--- a/tests/test_buddy_life_memory_navigation_skills_score.py
+++ b/tests/test_buddy_life_memory_navigation_skills_score.py
@@ -10,15 +10,23 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from norn_memory_navigation_skills_score import (  # noqa: E402
-    NornMemoryNavigationSkillsScoreError,
-    score_norn_memory_navigation_skills_receipt,
+from buddy_life_memory_navigation_skills_score import (  # noqa: E402
+    LEGACY_RECEIPT_SCHEMA,
+    RECEIPT_SCHEMA,
+    BuddyLifeMemoryNavigationSkillsScoreError,
+    score_buddy_life_memory_navigation_skills_receipt,
 )
 
 
 def _digest(value: object) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _reseal(receipt: dict[str, object]) -> None:
+    """Re-stamp the receipt hash after editing it, the way the runtime stamps it."""
+    receipt.pop("receipt_sha256", None)
+    receipt["receipt_sha256"] = _digest(receipt)
 
 
 def _receipt() -> dict[str, object]:
@@ -87,9 +95,26 @@ def _rehash(receipt: dict[str, object]) -> None:
     )
 
 
-class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
+class BuddyLifeMemoryNavigationSkillsScoreTests(unittest.TestCase):
+    def test_current_and_legacy_receipt_schemas_both_score(self) -> None:
+        """A published receipt keeps its old name; a fresh one carries the new one."""
+        legacy = _receipt()
+        self.assertEqual(legacy["schema"], LEGACY_RECEIPT_SCHEMA)
+        legacy_score = score_buddy_life_memory_navigation_skills_receipt(legacy)
+
+        current = _receipt()
+        current["schema"] = RECEIPT_SCHEMA
+        _reseal(current)
+        current_score = score_buddy_life_memory_navigation_skills_receipt(current)
+
+        self.assertTrue(legacy_score["passed"])
+        self.assertTrue(current_score["passed"])
+        self.assertEqual(legacy_score["score"], current_score["score"])
+        self.assertEqual(legacy_score["source_schema"], LEGACY_RECEIPT_SCHEMA)
+        self.assertEqual(current_score["source_schema"], RECEIPT_SCHEMA)
+
     def test_exact_green_receipt_scores_one_hundred(self) -> None:
-        score = score_norn_memory_navigation_skills_receipt(_receipt())
+        score = score_buddy_life_memory_navigation_skills_receipt(_receipt())
         self.assertTrue(score["passed"])
         self.assertEqual(score["score"], 100)
         self.assertEqual(score["readiness"], "green")
@@ -103,7 +128,7 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         assert isinstance(memory, dict)
         memory["selected_target"] = "berry"
         _rehash(receipt)
-        score = score_norn_memory_navigation_skills_receipt(receipt)
+        score = score_buddy_life_memory_navigation_skills_receipt(receipt)
         self.assertFalse(score["passed"])
         self.assertEqual(score["score"], 85)
 
@@ -116,7 +141,7 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         semantic["object_after_weak_contradiction"] = False
         semantic["retained_confidence"] = 0.20
         _rehash(receipt)
-        score = score_norn_memory_navigation_skills_receipt(receipt)
+        score = score_buddy_life_memory_navigation_skills_receipt(receipt)
         judgment = next(item for item in score["judgments"] if item["id"] == "semantic_knowledge")
         self.assertFalse(score["passed"])
         self.assertFalse(judgment["passed"])
@@ -130,7 +155,7 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         spatial["route_rooms"] = ["garden"]
         spatial["steps"] = 1
         _rehash(receipt)
-        score = score_norn_memory_navigation_skills_receipt(receipt)
+        score = score_buddy_life_memory_navigation_skills_receipt(receipt)
         judgment = next(item for item in score["judgments"] if item["id"] == "spatial_routing")
         self.assertFalse(score["passed"])
         self.assertFalse(judgment["passed"])
@@ -144,7 +169,7 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         skill["learned"] = False
         skill["host_validated"] = False
         _rehash(receipt)
-        score = score_norn_memory_navigation_skills_receipt(receipt)
+        score = score_buddy_life_memory_navigation_skills_receipt(receipt)
         judgment = next(item for item in score["judgments"] if item["id"] == "hierarchical_skill")
         self.assertFalse(score["passed"])
         self.assertFalse(judgment["passed"])
@@ -157,7 +182,7 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         assert isinstance(adaptation, dict)
         adaptation["reliability_after"] = 0.8
         _rehash(receipt)
-        score = score_norn_memory_navigation_skills_receipt(receipt)
+        score = score_buddy_life_memory_navigation_skills_receipt(receipt)
         judgment = next(item for item in score["judgments"] if item["id"] == "skill_adaptation")
         self.assertFalse(score["passed"])
         self.assertFalse(judgment["passed"])
@@ -170,7 +195,7 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         assert isinstance(persistence, dict)
         persistence["skills"] = 0
         _rehash(receipt)
-        score = score_norn_memory_navigation_skills_receipt(receipt)
+        score = score_buddy_life_memory_navigation_skills_receipt(receipt)
         judgment = next(item for item in score["judgments"] if item["id"] == "persistence")
         self.assertFalse(score["passed"])
         self.assertFalse(judgment["passed"])
@@ -180,7 +205,7 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         receipt["passed_count"] = 6
         receipt["failed_count"] = 1
         _rehash(receipt)
-        score = score_norn_memory_navigation_skills_receipt(receipt)
+        score = score_buddy_life_memory_navigation_skills_receipt(receipt)
         self.assertEqual(score["score"], 100)
         self.assertFalse(score["runtime_summary_consistent"])
         self.assertFalse(score["passed"])
@@ -191,8 +216,8 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         assert isinstance(measurements, dict)
         del measurements["spatial_routing"]
         _rehash(receipt)
-        with self.assertRaisesRegex(NornMemoryNavigationSkillsScoreError, "missing required"):
-            score_norn_memory_navigation_skills_receipt(receipt)
+        with self.assertRaisesRegex(BuddyLifeMemoryNavigationSkillsScoreError, "missing required"):
+            score_buddy_life_memory_navigation_skills_receipt(receipt)
 
     def test_payload_tampering_is_rejected(self) -> None:
         receipt = _receipt()
@@ -201,14 +226,14 @@ class NornMemoryNavigationSkillsScoreTests(unittest.TestCase):
         persistence = measurements["persistence"]
         assert isinstance(persistence, dict)
         persistence["restored"] = False
-        with self.assertRaisesRegex(NornMemoryNavigationSkillsScoreError, "hash mismatch"):
-            score_norn_memory_navigation_skills_receipt(receipt)
+        with self.assertRaisesRegex(BuddyLifeMemoryNavigationSkillsScoreError, "hash mismatch"):
+            score_buddy_life_memory_navigation_skills_receipt(receipt)
 
     def test_scoring_is_deterministic_and_non_mutating(self) -> None:
         receipt = _receipt()
         before = copy.deepcopy(receipt)
-        first = score_norn_memory_navigation_skills_receipt(receipt)
-        second = score_norn_memory_navigation_skills_receipt(receipt)
+        first = score_buddy_life_memory_navigation_skills_receipt(receipt)
+        second = score_buddy_life_memory_navigation_skills_receipt(receipt)
         self.assertEqual(first, second)
         self.assertEqual(receipt, before)
 

--- a/tests/test_buddy_life_modern_cognition_score.py
+++ b/tests/test_buddy_life_modern_cognition_score.py
@@ -10,15 +10,23 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from norn_modern_cognition_score import (  # noqa: E402
-    NornModernCognitionScoreError,
-    score_norn_modern_cognition_receipt,
+from buddy_life_modern_cognition_score import (  # noqa: E402
+    LEGACY_RECEIPT_SCHEMA,
+    RECEIPT_SCHEMA,
+    BuddyLifeModernCognitionScoreError,
+    score_buddy_life_modern_cognition_receipt,
 )
 
 
 def _digest(value: object) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _reseal(receipt: dict[str, object]) -> None:
+    """Re-stamp the receipt hash after editing it, the way the runtime stamps it."""
+    receipt.pop("receipt_sha256", None)
+    receipt["receipt_sha256"] = _digest(receipt)
 
 
 def _receipt() -> dict[str, object]:
@@ -83,9 +91,26 @@ def _rehash(receipt: dict[str, object]) -> None:
     )
 
 
-class NornModernCognitionScoreTests(unittest.TestCase):
+class BuddyLifeModernCognitionScoreTests(unittest.TestCase):
+    def test_current_and_legacy_receipt_schemas_both_score(self) -> None:
+        """A published receipt keeps its old name; a fresh one carries the new one."""
+        legacy = _receipt()
+        self.assertEqual(legacy["schema"], LEGACY_RECEIPT_SCHEMA)
+        legacy_score = score_buddy_life_modern_cognition_receipt(legacy)
+
+        current = _receipt()
+        current["schema"] = RECEIPT_SCHEMA
+        _reseal(current)
+        current_score = score_buddy_life_modern_cognition_receipt(current)
+
+        self.assertTrue(legacy_score["passed"])
+        self.assertTrue(current_score["passed"])
+        self.assertEqual(legacy_score["score"], current_score["score"])
+        self.assertEqual(legacy_score["source_schema"], LEGACY_RECEIPT_SCHEMA)
+        self.assertEqual(current_score["source_schema"], RECEIPT_SCHEMA)
+
     def test_exact_green_receipt_scores_one_hundred(self) -> None:
-        score = score_norn_modern_cognition_receipt(_receipt())
+        score = score_buddy_life_modern_cognition_receipt(_receipt())
         self.assertTrue(score["passed"])
         self.assertEqual(score["score"], 100)
         self.assertEqual(score["readiness"], "green")
@@ -99,7 +124,7 @@ class NornModernCognitionScoreTests(unittest.TestCase):
         assert isinstance(delayed, dict)
         delayed["early_value"] = delayed["recent_value"]
         _rehash(receipt)
-        score = score_norn_modern_cognition_receipt(receipt)
+        score = score_buddy_life_modern_cognition_receipt(receipt)
         self.assertFalse(score["passed"])
         self.assertEqual(score["score"], 85)
         judgment = next(item for item in score["judgments"] if item["id"] == "delayed_credit")
@@ -113,7 +138,7 @@ class NornModernCognitionScoreTests(unittest.TestCase):
         assert isinstance(curiosity, dict)
         curiosity["noisy_score"] = 0.60
         _rehash(receipt)
-        score = score_norn_modern_cognition_receipt(receipt)
+        score = score_buddy_life_modern_cognition_receipt(receipt)
         self.assertFalse(score["passed"])
         judgment = next(item for item in score["judgments"] if item["id"] == "curiosity")
         self.assertFalse(judgment["passed"])
@@ -127,7 +152,7 @@ class NornModernCognitionScoreTests(unittest.TestCase):
         culture["transfer_bound"] = 0.90
         culture["learner_skill"] = 0.88
         _rehash(receipt)
-        score = score_norn_modern_cognition_receipt(receipt)
+        score = score_buddy_life_modern_cognition_receipt(receipt)
         self.assertFalse(score["passed"])
         judgment = next(item for item in score["judgments"] if item["id"] == "culture")
         self.assertFalse(judgment["passed"])
@@ -140,7 +165,7 @@ class NornModernCognitionScoreTests(unittest.TestCase):
         assert isinstance(cortex, dict)
         cortex["authority_escape_rejected"] = False
         _rehash(receipt)
-        score = score_norn_modern_cognition_receipt(receipt)
+        score = score_buddy_life_modern_cognition_receipt(receipt)
         self.assertFalse(score["passed"])
         judgment = next(item for item in score["judgments"] if item["id"] == "cortex")
         self.assertFalse(judgment["passed"])
@@ -150,7 +175,7 @@ class NornModernCognitionScoreTests(unittest.TestCase):
         receipt["passed_count"] = 6
         receipt["failed_count"] = 1
         _rehash(receipt)
-        score = score_norn_modern_cognition_receipt(receipt)
+        score = score_buddy_life_modern_cognition_receipt(receipt)
         self.assertEqual(score["score"], 100)
         self.assertFalse(score["runtime_summary_consistent"])
         self.assertFalse(score["passed"])
@@ -161,8 +186,8 @@ class NornModernCognitionScoreTests(unittest.TestCase):
         assert isinstance(measurements, dict)
         del measurements["planning"]
         _rehash(receipt)
-        with self.assertRaisesRegex(NornModernCognitionScoreError, "missing required"):
-            score_norn_modern_cognition_receipt(receipt)
+        with self.assertRaisesRegex(BuddyLifeModernCognitionScoreError, "missing required"):
+            score_buddy_life_modern_cognition_receipt(receipt)
 
     def test_payload_tampering_is_rejected(self) -> None:
         receipt = _receipt()
@@ -171,14 +196,14 @@ class NornModernCognitionScoreTests(unittest.TestCase):
         planning = measurements["planning"]
         assert isinstance(planning, dict)
         planning["host_validated"] = False
-        with self.assertRaisesRegex(NornModernCognitionScoreError, "hash mismatch"):
-            score_norn_modern_cognition_receipt(receipt)
+        with self.assertRaisesRegex(BuddyLifeModernCognitionScoreError, "hash mismatch"):
+            score_buddy_life_modern_cognition_receipt(receipt)
 
     def test_scoring_is_deterministic_and_non_mutating(self) -> None:
         receipt = _receipt()
         before = copy.deepcopy(receipt)
-        first = score_norn_modern_cognition_receipt(receipt)
-        second = score_norn_modern_cognition_receipt(receipt)
+        first = score_buddy_life_modern_cognition_receipt(receipt)
+        second = score_buddy_life_modern_cognition_receipt(receipt)
         self.assertEqual(first, second)
         self.assertEqual(receipt, before)
 

--- a/tests/test_buddy_life_parity_score.py
+++ b/tests/test_buddy_life_parity_score.py
@@ -10,15 +10,23 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from norn_parity_score import (  # noqa: E402
-    NornParityScoreError,
-    score_norn_parity_receipt,
+from buddy_life_parity_score import (  # noqa: E402
+    LEGACY_RECEIPT_SCHEMA,
+    RECEIPT_SCHEMA,
+    BuddyLifeParityScoreError,
+    score_buddy_life_parity_receipt,
 )
 
 
 def _digest(value: object) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _reseal(receipt: dict[str, object]) -> None:
+    """Re-stamp the receipt hash after editing it, the way the runtime stamps it."""
+    receipt.pop("receipt_sha256", None)
+    receipt["receipt_sha256"] = _digest(receipt)
 
 
 def _scenario(scenario_id: str, measurements: dict[str, object]) -> dict[str, object]:
@@ -128,9 +136,26 @@ def _rehash(receipt: dict[str, object]) -> None:
     )
 
 
-class NornParityScoreTests(unittest.TestCase):
+class BuddyLifeParityScoreTests(unittest.TestCase):
+    def test_current_and_legacy_receipt_schemas_both_score(self) -> None:
+        """A published receipt keeps its old name; a fresh one carries the new one."""
+        legacy = _receipt()
+        self.assertEqual(legacy["schema"], LEGACY_RECEIPT_SCHEMA)
+        legacy_score = score_buddy_life_parity_receipt(legacy)
+
+        current = _receipt()
+        current["schema"] = RECEIPT_SCHEMA
+        _reseal(current)
+        current_score = score_buddy_life_parity_receipt(current)
+
+        self.assertTrue(legacy_score["passed"])
+        self.assertTrue(current_score["passed"])
+        self.assertEqual(legacy_score["score"], current_score["score"])
+        self.assertEqual(legacy_score["source_schema"], LEGACY_RECEIPT_SCHEMA)
+        self.assertEqual(current_score["source_schema"], RECEIPT_SCHEMA)
+
     def test_exact_green_receipt_scores_one_hundred(self) -> None:
-        score = score_norn_parity_receipt(_receipt())
+        score = score_buddy_life_parity_receipt(_receipt())
         self.assertTrue(score["passed"])
         self.assertEqual(score["score"], 100)
         self.assertEqual(score["readiness"], "green")
@@ -146,7 +171,7 @@ class NornParityScoreTests(unittest.TestCase):
         assert isinstance(measurements, dict)
         measurements["learned_food_category"] = 0.05
         _rehash(receipt)
-        score = score_norn_parity_receipt(receipt)
+        score = score_buddy_life_parity_receipt(receipt)
         self.assertFalse(score["passed"])
         self.assertEqual(score["score"], 85)
         judgment = next(
@@ -166,7 +191,7 @@ class NornParityScoreTests(unittest.TestCase):
         measurements["transfer"] = 1.0
         measurements["learner_strength"] = 0.9
         _rehash(receipt)
-        score = score_norn_parity_receipt(receipt)
+        score = score_buddy_life_parity_receipt(receipt)
         self.assertFalse(score["passed"])
         judgment = next(
             item
@@ -178,21 +203,21 @@ class NornParityScoreTests(unittest.TestCase):
     def test_tampered_receipt_is_rejected(self) -> None:
         receipt = _receipt()
         receipt["passed_count"] = 2
-        with self.assertRaisesRegex(NornParityScoreError, "hash mismatch"):
-            score_norn_parity_receipt(receipt)
+        with self.assertRaisesRegex(BuddyLifeParityScoreError, "hash mismatch"):
+            score_buddy_life_parity_receipt(receipt)
 
     def test_cortex_on_receipt_is_rejected(self) -> None:
         receipt = _receipt()
         receipt["mode"] = "cortex-on"
         _rehash(receipt)
-        with self.assertRaisesRegex(NornParityScoreError, "cortex-off"):
-            score_norn_parity_receipt(receipt)
+        with self.assertRaisesRegex(BuddyLifeParityScoreError, "cortex-off"):
+            score_buddy_life_parity_receipt(receipt)
 
     def test_scoring_is_deterministic_and_non_mutating(self) -> None:
         receipt = _receipt()
         before = copy.deepcopy(receipt)
-        first = score_norn_parity_receipt(receipt)
-        second = score_norn_parity_receipt(receipt)
+        first = score_buddy_life_parity_receipt(receipt)
+        second = score_buddy_life_parity_receipt(receipt)
         self.assertEqual(first, second)
         self.assertEqual(receipt, before)
 

--- a/tests/test_buddy_life_stochastic_score.py
+++ b/tests/test_buddy_life_stochastic_score.py
@@ -10,15 +10,23 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from norn_stochastic_score import (  # noqa: E402
-    NornStochasticScoreError,
-    score_norn_stochastic_receipt,
+from buddy_life_stochastic_score import (  # noqa: E402
+    LEGACY_RECEIPT_SCHEMA,
+    RECEIPT_SCHEMA,
+    BuddyLifeStochasticScoreError,
+    score_buddy_life_stochastic_receipt,
 )
 
 
 def _digest(value: object) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _reseal(receipt: dict[str, object]) -> None:
+    """Re-stamp the receipt hash after editing it, the way the runtime stamps it."""
+    receipt.pop("receipt_sha256", None)
+    receipt["receipt_sha256"] = _digest(receipt)
 
 
 def _scenario(scenario_id: str, measurements: dict[str, object]) -> dict[str, object]:
@@ -127,9 +135,26 @@ def _rehash(receipt: dict[str, object]) -> None:
     )
 
 
-class NornStochasticScoreTests(unittest.TestCase):
+class BuddyLifeStochasticScoreTests(unittest.TestCase):
+    def test_current_and_legacy_receipt_schemas_both_score(self) -> None:
+        """A published receipt keeps its old name; a fresh one carries the new one."""
+        legacy = _receipt()
+        self.assertEqual(legacy["schema"], LEGACY_RECEIPT_SCHEMA)
+        legacy_score = score_buddy_life_stochastic_receipt(legacy)
+
+        current = _receipt()
+        current["schema"] = RECEIPT_SCHEMA
+        _reseal(current)
+        current_score = score_buddy_life_stochastic_receipt(current)
+
+        self.assertTrue(legacy_score["passed"])
+        self.assertTrue(current_score["passed"])
+        self.assertEqual(legacy_score["score"], current_score["score"])
+        self.assertEqual(legacy_score["source_schema"], LEGACY_RECEIPT_SCHEMA)
+        self.assertEqual(current_score["source_schema"], RECEIPT_SCHEMA)
+
     def test_exact_green_receipt_scores_one_hundred(self) -> None:
-        score = score_norn_stochastic_receipt(_receipt())
+        score = score_buddy_life_stochastic_receipt(_receipt())
         self.assertTrue(score["passed"])
         self.assertEqual(score["score"], 100)
         self.assertEqual(score["readiness"], "green")
@@ -145,7 +170,7 @@ class NornStochasticScoreTests(unittest.TestCase):
         assert isinstance(measurements, dict)
         measurements["mean_category_value"] = 0.10
         _rehash(receipt)
-        score = score_norn_stochastic_receipt(receipt)
+        score = score_buddy_life_stochastic_receipt(receipt)
         self.assertFalse(score["passed"])
         self.assertEqual(score["score"], 80)
         judgment = next(
@@ -164,7 +189,7 @@ class NornStochasticScoreTests(unittest.TestCase):
         assert isinstance(measurements, dict)
         measurements["acquisition_successes"] = 20
         _rehash(receipt)
-        score = score_norn_stochastic_receipt(receipt)
+        score = score_buddy_life_stochastic_receipt(receipt)
         self.assertFalse(score["passed"])
         judgment = next(
             item for item in score["judgments"] if item["id"] == "noisy-adaptation"
@@ -181,27 +206,27 @@ class NornStochasticScoreTests(unittest.TestCase):
         assert isinstance(measurements, dict)
         measurements["ticks"] = 100
         _rehash(receipt)
-        score = score_norn_stochastic_receipt(receipt)
+        score = score_buddy_life_stochastic_receipt(receipt)
         self.assertFalse(score["passed"])
 
     def test_tampered_receipt_is_rejected(self) -> None:
         receipt = _receipt()
         receipt["seed"] = 7
-        with self.assertRaisesRegex(NornStochasticScoreError, "seed or trial count"):
-            score_norn_stochastic_receipt(receipt)
+        with self.assertRaisesRegex(BuddyLifeStochasticScoreError, "seed or trial count"):
+            score_buddy_life_stochastic_receipt(receipt)
 
     def test_cortex_on_receipt_is_rejected(self) -> None:
         receipt = _receipt()
         receipt["mode"] = "cortex-on"
         _rehash(receipt)
-        with self.assertRaisesRegex(NornStochasticScoreError, "cortex-off"):
-            score_norn_stochastic_receipt(receipt)
+        with self.assertRaisesRegex(BuddyLifeStochasticScoreError, "cortex-off"):
+            score_buddy_life_stochastic_receipt(receipt)
 
     def test_scoring_is_deterministic_and_non_mutating(self) -> None:
         receipt = _receipt()
         before = copy.deepcopy(receipt)
-        first = score_norn_stochastic_receipt(receipt)
-        second = score_norn_stochastic_receipt(receipt)
+        first = score_buddy_life_stochastic_receipt(receipt)
+        second = score_buddy_life_stochastic_receipt(receipt)
         self.assertEqual(first, second)
         self.assertEqual(receipt, before)
 


### PR DESCRIPTION
## Task contract
Plan: PR_BODY
- Verification: yes
- Rollback: yes

## Problem

`prismtek-apps` [#330](https://github.com/codysumpter-cloud/prismtek-apps/pull/330) is retiring the Creatures-era token from its own vocabulary. The rename reached the two things that cross this repository boundary — the script paths its workflows invoke, and the schema string its receipts carry — and since both are pinned by SHA on this side, it landed as four hard CI failures:

```
can't open file '.../brain/scripts/buddy_life_parity_score.py': [Errno 2] No such file or directory
```

Fixing it on the caller's side would mean keeping the retired token in the runtime's source, so it is fixed here instead.

## Smallest useful wedge

- `scripts/norn_*_score.py` → `scripts/buddy_life_*_score.py`, with tests, public functions, error classes and this repo's own workflows renamed to match.
- Each scorer accepts the receipt under **both** spellings. A receipt that has already been published cannot be re-emitted, and a score is only meaningful if the scorer can still read the evidence it was asked to judge.
- `source_schema` reports the name the receipt actually used rather than the one the scorer prefers, so a score still traces back to its evidence.

No scoring logic, threshold, or judgment changes — only names and the set of accepted receipt schemas.

## Verification plan

All four suites pass under `python3 -m unittest`. Each gained `test_current_and_legacy_receipt_schemas_both_score`, asserting the two spellings produce identical scores and distinct `source_schema` values; every pre-existing test used the legacy fixture, so the case the migration depends on was the one case nothing covered.

The new test was confirmed to fail when acceptance is narrowed back to a single schema, so it is a real check rather than a passing no-op.

The independence property is untouched: the caller still pins an immutable SHA of a scorer it does not control.

## Rollback plan

Revert the merge commit. The caller pins scorer SHAs explicitly, so no consumer follows `master` implicitly — `prismtek-apps` keeps working against the pre-merge SHA until its own pins are bumped, and this branch is the only thing that would need re-landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)