### PR TITLE
feat(readiness): add harness-aware economics and model governance

### DIFF
--- a/.github/workflows/agent-readiness-metrics.yml
+++ b/.github/workflows/agent-readiness-metrics.yml
@@ -5,20 +5,26 @@ on:
     paths:
       - "scripts/buddy_agent_readiness.py"
       - "scripts/buddy_task_economics.py"
+      - "scripts/buddy_model_registry.py"
       - "tests/test_agent_readiness.py"
       - "tests/test_task_economics.py"
+      - "tests/test_model_registry.py"
       - "config/agent-readiness*.json"
       - "config/task-economics.schema.json"
+      - "config/model-registry*.json"
       - ".github/workflows/agent-readiness-metrics.yml"
   push:
     branches: [master]
     paths:
       - "scripts/buddy_agent_readiness.py"
       - "scripts/buddy_task_economics.py"
+      - "scripts/buddy_model_registry.py"
       - "tests/test_agent_readiness.py"
       - "tests/test_task_economics.py"
+      - "tests/test_model_registry.py"
       - "config/agent-readiness*.json"
       - "config/task-economics.schema.json"
+      - "config/model-registry*.json"
 
 permissions:
   contents: read
@@ -35,7 +41,19 @@ jobs:
         with:
           python-version: "3.12"
       - run: python -m pip install pytest
-      - run: python -m py_compile scripts/buddy_agent_readiness.py scripts/buddy_task_economics.py
-      - run: python -m pytest -q tests/test_agent_readiness.py tests/test_task_economics.py
+      - name: Compile readiness and governance scripts
+        run: >-
+          python -m py_compile
+          scripts/buddy_agent_readiness.py
+          scripts/buddy_task_economics.py
+          scripts/buddy_model_registry.py
+      - name: Test readiness, economics, and model governance
+        run: >-
+          python -m pytest -q
+          tests/test_agent_readiness.py
+          tests/test_task_economics.py
+          tests/test_model_registry.py
+      - name: Validate model registry
+        run: python scripts/buddy_model_registry.py config/model-registry.json
       - name: Score this repository without treating missing telemetry as success
         run: python scripts/buddy_agent_readiness.py . --format json --output /tmp/readiness.json

--- a/config/model-registry.json
+++ b/config/model-registry.json
@@ -1,0 +1,5 @@
+{
+  "schema": "buddy.model-registry.v1",
+  "default_status": "quarantined",
+  "models": {}
+}

--- a/config/model-registry.schema.json
+++ b/config/model-registry.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://prismtek.dev/schemas/model-registry.schema.json",
+  "title": "Buddy model lifecycle registry",
+  "type": "object",
+  "required": ["schema", "default_status", "models"],
+  "properties": {
+    "schema": { "const": "buddy.model-registry.v1" },
+    "default_status": { "enum": ["discovered", "quarantined"] },
+    "models": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["provider", "model", "status"],
+        "properties": {
+          "provider": { "type": "string", "minLength": 1 },
+          "model": { "type": "string", "minLength": 1 },
+          "status": {
+            "enum": [
+              "discovered",
+              "quarantined",
+              "benchmarked",
+              "security_reviewed",
+              "supervised",
+              "approved",
+              "deprecated"
+            ]
+          },
+          "task_classes": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "discovered_at": { "type": "string" },
+          "reviewed_by": { "type": "string" },
+          "notes": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/config/task-economics.schema.json
+++ b/config/task-economics.schema.json
@@ -10,6 +10,20 @@
     "workflow": { "type": "string" },
     "provider": { "type": "string", "minLength": 1 },
     "model": { "type": "string", "minLength": 1 },
+    "harness_identity": {
+      "type": "object",
+      "properties": {
+        "harness": { "type": "string", "minLength": 1 },
+        "effort": { "type": "string", "minLength": 1 },
+        "buap_artifact_hash": { "type": "string", "minLength": 1 },
+        "runtime_adapter_version": { "type": "string", "minLength": 1 },
+        "memory_strategy": { "type": "string", "minLength": 1 },
+        "context_strategy": { "enum": ["truncate", "compact", "summarize", "unknown"] },
+        "reasoning_retention": { "type": "boolean" },
+        "tool_policy_version": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
     "attempts": { "type": "integer", "minimum": 1 },
     "model_cost": { "type": "number", "minimum": 0 },
     "tool_cost": { "type": "number", "minimum": 0 },

--- a/context/plans/2026-08-03-harness-model-governance.md
+++ b/context/plans/2026-08-03-harness-model-governance.md
@@ -1,0 +1,38 @@
+## Problem
+
+Buddy Brain currently aggregates task economics primarily by provider and model. That can silently combine runs with different BUAP artifacts, runtime adapters, memory strategies, context handling, reasoning retention, effort, and tool policy. A model can appear newly available through a provider before Buddy has benchmarked, security-reviewed, supervised, or approved it for any task class.
+
+This makes routing evidence less trustworthy and creates a policy gap between provider availability and Buddy approval.
+
+## Smallest useful wedge
+
+Extend the existing task-economics record with a backward-compatible harness identity and group results by a stable harness fingerprint. Keep legacy records readable, but mark their harness evidence incomplete.
+
+Add a separate quarantine-first model lifecycle registry that:
+
+- defaults newly discovered models to `quarantined`;
+- enforces evidence-bearing lifecycle transitions;
+- requires attributable review for security-reviewed, supervised, and approved states;
+- requires explicit task classes before approval;
+- requires caller opt-in for supervised routing;
+- permits immediate re-quarantine when behavior changes;
+- commits no approved provider models in this change.
+
+Do not mix model discovery with automatic routing approval, and do not store prompts, credentials, or private conversation content as lifecycle evidence.
+
+## Verification plan
+
+- Compile the readiness, economics, and model-governance scripts with Python 3.12.
+- Run economics regression tests, including separation of identical models under different harness identities.
+- Run model-registry tests for quarantine defaults, invalid transition refusal, evidence requirements, reviewer requirements, supervised opt-in, approved task classes, re-quarantine, deterministic persistence, and identity collisions.
+- Validate the committed empty registry through the CLI.
+- Run the focused Agent readiness metrics workflow.
+- Require the repository CI, lint, CodeQL, bootstrap, autonomy, runtime smoke, iOS validation, and task-readiness checks to pass before merge.
+- Confirm no provider model becomes approved and no runtime route changes in this PR.
+
+## Rollback plan
+
+- Revert the PR to restore provider/model-only grouping and remove the model registry.
+- Existing task-economics producers remain compatible because the new harness identity is optional and legacy records are parsed explicitly.
+- The committed registry contains no approved models, so rollback does not revoke an active approved route.
+- If a later producer emits malformed harness data, quarantine those records from comparative reports rather than weakening validation.

--- a/docs/AGENT_READINESS_LAYER.md
+++ b/docs/AGENT_READINESS_LAYER.md
@@ -28,6 +28,41 @@ python3 scripts/buddy_task_economics.py task-records.jsonl
 python3 scripts/buddy_task_economics.py task-records.jsonl --human-hour-rate 100 --format json
 ```
 
-Each task record stores provider, model, attempts, model/tool cost, elapsed time, review time, verification, artifact acceptance, rollback state, and security gate. The report calculates completion rate, retry rate, rollback rate, and cost per verified completion.
+Each task record stores provider, model, attempts, model/tool cost, elapsed time, review time, verification, artifact acceptance, rollback state, and security gate. Records may also include a `harness_identity` object:
+
+```json
+{
+  "harness": "buddy-agent",
+  "effort": "medium",
+  "buap_artifact_hash": "abc123",
+  "runtime_adapter_version": "local-container-v1",
+  "memory_strategy": "knowledge-vault-public-safe",
+  "context_strategy": "compact",
+  "reasoning_retention": true,
+  "tool_policy_version": "policy-v1"
+}
+```
+
+The report calculates completion rate, retry rate, rollback rate, and cost per verified completion. Provider/model results are grouped by the complete harness fingerprint, preventing records with different prompts, adapters, memory, compaction, reasoning retention, or tool policy from being averaged together. Legacy records remain readable but are marked as incomplete harness evidence.
 
 Model routing should use a meaningful sample and optimize expected cost to an accepted, verified result—not token price in isolation.
+
+## Model lifecycle registry
+
+`config/model-registry.json` is Buddy's routing authority. Provider catalogs and newly enabled models do not become approved automatically. The default status is `quarantined`.
+
+```bash
+python3 scripts/buddy_model_registry.py config/model-registry.json
+python3 scripts/buddy_model_registry.py config/model-registry.json \
+  --check-route provider/model bounded_edit
+```
+
+The lifecycle is:
+
+```text
+discovered -> quarantined -> benchmarked -> security_reviewed -> supervised -> approved -> deprecated
+```
+
+The implementation enforces evidence-bearing transitions rather than treating the sequence as documentation only. Security-reviewed, supervised, and approved states require an attributable reviewer. Approved models require explicit task classes. Supervised models are denied unless the caller opts into supervised routing, and any approved model can be immediately re-quarantined when behavior changes.
+
+Provider/model discovery should add metadata under quarantine. Benchmark, security, supervised-run, approval, and deprecation evidence should be durable references rather than raw prompts, credentials, or private conversation content.

--- a/scripts/buddy_model_registry.py
+++ b/scripts/buddy_model_registry.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Quarantine-first lifecycle governance for Buddy model routing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+STATUSES = (
+    "discovered",
+    "quarantined",
+    "benchmarked",
+    "security_reviewed",
+    "supervised",
+    "approved",
+    "deprecated",
+)
+ROUTABLE_STATUSES = {"supervised", "approved"}
+EVIDENCE_REQUIRED_STATUSES = {
+    "benchmarked",
+    "security_reviewed",
+    "supervised",
+    "approved",
+    "deprecated",
+}
+ALLOWED_TRANSITIONS = {
+    "discovered": {"quarantined", "deprecated"},
+    "quarantined": {"benchmarked", "deprecated"},
+    "benchmarked": {"security_reviewed", "quarantined", "deprecated"},
+    "security_reviewed": {"supervised", "quarantined", "deprecated"},
+    "supervised": {"approved", "quarantined", "deprecated"},
+    "approved": {"quarantined", "deprecated"},
+    "deprecated": {"quarantined"},
+}
+
+
+@dataclass(frozen=True)
+class ModelEntry:
+    model_id: str
+    provider: str
+    model: str
+    status: str = "quarantined"
+    task_classes: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    discovered_at: str = ""
+    reviewed_by: str = ""
+    notes: str = ""
+
+    @classmethod
+    def from_dict(cls, model_id: str, payload: dict[str, Any]) -> "ModelEntry":
+        entry = cls(
+            model_id=model_id,
+            provider=str(payload.get("provider", "")).strip(),
+            model=str(payload.get("model", "")).strip(),
+            status=str(payload.get("status", "quarantined")).strip(),
+            task_classes=tuple(str(item) for item in payload.get("task_classes", [])),
+            evidence_refs=tuple(str(item) for item in payload.get("evidence_refs", [])),
+            discovered_at=str(payload.get("discovered_at", "")).strip(),
+            reviewed_by=str(payload.get("reviewed_by", "")).strip(),
+            notes=str(payload.get("notes", "")).strip(),
+        )
+        entry.validate()
+        return entry
+
+    def validate(self) -> None:
+        if not self.model_id or not self.provider or not self.model:
+            raise ValueError("model_id, provider, and model are required")
+        if self.status not in STATUSES:
+            raise ValueError(f"unsupported model status: {self.status}")
+        if len(set(self.task_classes)) != len(self.task_classes):
+            raise ValueError(f"duplicate task class for {self.model_id}")
+        if len(set(self.evidence_refs)) != len(self.evidence_refs):
+            raise ValueError(f"duplicate evidence reference for {self.model_id}")
+        if self.status in EVIDENCE_REQUIRED_STATUSES and not self.evidence_refs:
+            raise ValueError(f"status {self.status} requires evidence for {self.model_id}")
+        if self.status in {"security_reviewed", "supervised", "approved"} and not self.reviewed_by:
+            raise ValueError(f"status {self.status} requires reviewed_by for {self.model_id}")
+        if self.status == "approved" and not self.task_classes:
+            raise ValueError(f"approved model requires task_classes: {self.model_id}")
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload.pop("model_id")
+        payload["task_classes"] = list(self.task_classes)
+        payload["evidence_refs"] = list(self.evidence_refs)
+        return payload
+
+
+@dataclass(frozen=True)
+class ModelRegistry:
+    schema: str
+    default_status: str
+    models: dict[str, ModelEntry]
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ModelRegistry":
+        schema = str(payload.get("schema", "buddy.model-registry.v1"))
+        if schema != "buddy.model-registry.v1":
+            raise ValueError(f"unsupported registry schema: {schema}")
+        default_status = str(payload.get("default_status", "quarantined"))
+        if default_status not in {"discovered", "quarantined"}:
+            raise ValueError("default_status must be discovered or quarantined")
+        raw_models = payload.get("models", {})
+        if not isinstance(raw_models, dict):
+            raise ValueError("models must be an object")
+        models = {
+            str(model_id): ModelEntry.from_dict(str(model_id), model_payload)
+            for model_id, model_payload in raw_models.items()
+        }
+        return cls(schema=schema, default_status=default_status, models=models)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "default_status": self.default_status,
+            "models": {
+                model_id: entry.to_dict()
+                for model_id, entry in sorted(self.models.items())
+            },
+        }
+
+
+def load_registry(path: Path) -> ModelRegistry:
+    return ModelRegistry.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def save_registry(path: Path, registry: ModelRegistry) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(registry.to_dict(), indent=2) + "\n", encoding="utf-8")
+
+
+def discover_model(
+    registry: ModelRegistry,
+    *,
+    model_id: str,
+    provider: str,
+    model: str,
+    discovered_at: str = "",
+    evidence_ref: str = "",
+) -> ModelRegistry:
+    if model_id in registry.models:
+        existing = registry.models[model_id]
+        if existing.provider != provider or existing.model != model:
+            raise ValueError(f"model identity collision: {model_id}")
+        return registry
+    entry = ModelEntry(
+        model_id=model_id,
+        provider=provider.strip(),
+        model=model.strip(),
+        status=registry.default_status,
+        discovered_at=discovered_at.strip(),
+        evidence_refs=(evidence_ref.strip(),) if evidence_ref.strip() else (),
+    )
+    entry.validate()
+    return replace(registry, models={**registry.models, model_id: entry})
+
+
+def transition_model(
+    registry: ModelRegistry,
+    *,
+    model_id: str,
+    status: str,
+    evidence_ref: str = "",
+    reviewed_by: str = "",
+    task_classes: tuple[str, ...] | None = None,
+    notes: str | None = None,
+) -> ModelRegistry:
+    try:
+        current = registry.models[model_id]
+    except KeyError as error:
+        raise ValueError(f"unknown model: {model_id}") from error
+    if status not in STATUSES:
+        raise ValueError(f"unsupported model status: {status}")
+    if status == current.status:
+        return registry
+    if status not in ALLOWED_TRANSITIONS[current.status]:
+        raise ValueError(f"invalid transition for {model_id}: {current.status} -> {status}")
+    evidence = list(current.evidence_refs)
+    if evidence_ref.strip() and evidence_ref.strip() not in evidence:
+        evidence.append(evidence_ref.strip())
+    updated = replace(
+        current,
+        status=status,
+        evidence_refs=tuple(evidence),
+        reviewed_by=reviewed_by.strip() or current.reviewed_by,
+        task_classes=current.task_classes if task_classes is None else tuple(task_classes),
+        notes=current.notes if notes is None else notes.strip(),
+    )
+    updated.validate()
+    return replace(registry, models={**registry.models, model_id: updated})
+
+
+def route_allowed(
+    registry: ModelRegistry,
+    model_id: str,
+    task_class: str,
+    *,
+    allow_supervised: bool = False,
+) -> bool:
+    entry = registry.models.get(model_id)
+    if entry is None or entry.status not in ROUTABLE_STATUSES:
+        return False
+    if entry.status == "supervised" and not allow_supervised:
+        return False
+    return task_class in entry.task_classes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate and inspect Buddy's model lifecycle registry.")
+    parser.add_argument("registry", type=Path)
+    parser.add_argument("--format", choices=("json", "text"), default="text")
+    parser.add_argument("--check-route", nargs=2, metavar=("MODEL_ID", "TASK_CLASS"))
+    parser.add_argument("--allow-supervised", action="store_true")
+    args = parser.parse_args()
+
+    registry = load_registry(args.registry)
+    if args.check_route:
+        model_id, task_class = args.check_route
+        allowed = route_allowed(
+            registry,
+            model_id,
+            task_class,
+            allow_supervised=args.allow_supervised,
+        )
+        result = {"model_id": model_id, "task_class": task_class, "allowed": allowed}
+        if args.format == "json":
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"{'allow' if allowed else 'deny'} {model_id} {task_class}")
+        return 0 if allowed else 1
+
+    if args.format == "json":
+        print(json.dumps(registry.to_dict(), indent=2))
+    else:
+        for model_id, entry in sorted(registry.models.items()):
+            tasks = ",".join(entry.task_classes) or "none"
+            print(f"{entry.status:17} {model_id} tasks={tasks}")
+        print(f"ok model-registry models={len(registry.models)} default={registry.default_status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/buddy_task_economics.py
+++ b/scripts/buddy_task_economics.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -23,6 +24,61 @@ REQUIRED_FIELDS = {
     "verification_passed",
     "artifacts_accepted",
 }
+CONTEXT_STRATEGIES = {"truncate", "compact", "summarize", "unknown"}
+
+
+@dataclass(frozen=True)
+class HarnessIdentity:
+    harness: str = "unknown"
+    effort: str = "unknown"
+    buap_artifact_hash: str = "unknown"
+    runtime_adapter_version: str = "unknown"
+    memory_strategy: str = "unknown"
+    context_strategy: str = "unknown"
+    reasoning_retention: bool = False
+    tool_policy_version: str = "unknown"
+
+    @classmethod
+    def from_dict(cls, payload: Any) -> "HarnessIdentity":
+        if payload is None:
+            return cls()
+        if not isinstance(payload, dict):
+            raise ValueError("harness_identity must be an object")
+        context_strategy = str(payload.get("context_strategy", "unknown"))
+        if context_strategy not in CONTEXT_STRATEGIES:
+            allowed = ", ".join(sorted(CONTEXT_STRATEGIES))
+            raise ValueError(f"context_strategy must be one of: {allowed}")
+        return cls(
+            harness=str(payload.get("harness", "unknown")) or "unknown",
+            effort=str(payload.get("effort", "unknown")) or "unknown",
+            buap_artifact_hash=str(payload.get("buap_artifact_hash", "unknown")) or "unknown",
+            runtime_adapter_version=str(payload.get("runtime_adapter_version", "unknown")) or "unknown",
+            memory_strategy=str(payload.get("memory_strategy", "unknown")) or "unknown",
+            context_strategy=context_strategy,
+            reasoning_retention=bool(payload.get("reasoning_retention", False)),
+            tool_policy_version=str(payload.get("tool_policy_version", "unknown")) or "unknown",
+        )
+
+    @property
+    def complete(self) -> bool:
+        values = (
+            self.harness,
+            self.effort,
+            self.buap_artifact_hash,
+            self.runtime_adapter_version,
+            self.memory_strategy,
+            self.context_strategy,
+            self.tool_policy_version,
+        )
+        return all(value != "unknown" for value in values)
+
+    @property
+    def fingerprint(self) -> str:
+        encoded = json.dumps(asdict(self), sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()[:16]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**asdict(self), "complete": self.complete, "fingerprint": self.fingerprint}
 
 
 @dataclass(frozen=True)
@@ -41,6 +97,7 @@ class TaskRecord:
     repository: str = ""
     workflow: str = ""
     security_gate: str = "not-run"
+    harness_identity: HarnessIdentity = HarnessIdentity()
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "TaskRecord":
@@ -53,6 +110,9 @@ class TaskRecord:
         for field in ("model_cost", "tool_cost", "human_review_minutes"):
             if float(payload[field]) < 0:
                 raise ValueError(f"{field} cannot be negative")
+        elapsed_ms = int(payload["elapsed_ms"])
+        if elapsed_ms < 0:
+            raise ValueError("elapsed_ms cannot be negative")
         return cls(
             task_id=str(payload["task_id"]),
             provider=str(payload["provider"]),
@@ -60,7 +120,7 @@ class TaskRecord:
             attempts=attempts,
             model_cost=float(payload["model_cost"]),
             tool_cost=float(payload["tool_cost"]),
-            elapsed_ms=int(payload["elapsed_ms"]),
+            elapsed_ms=elapsed_ms,
             human_review_minutes=float(payload["human_review_minutes"]),
             verification_passed=bool(payload["verification_passed"]),
             artifacts_accepted=bool(payload["artifacts_accepted"]),
@@ -68,11 +128,17 @@ class TaskRecord:
             repository=str(payload.get("repository", "")),
             workflow=str(payload.get("workflow", "")),
             security_gate=str(payload.get("security_gate", "not-run")),
+            harness_identity=HarnessIdentity.from_dict(payload.get("harness_identity")),
         )
 
     @property
     def verified_completion(self) -> bool:
-        return self.verification_passed and self.artifacts_accepted and not self.rolled_back and self.security_gate != "block"
+        return (
+            self.verification_passed
+            and self.artifacts_accepted
+            and not self.rolled_back
+            and self.security_gate != "block"
+        )
 
 
 def read_records(path: Path) -> list[TaskRecord]:
@@ -100,6 +166,7 @@ def summarize(records: Iterable[TaskRecord], human_hour_rate: float = 0.0) -> di
     retry_tasks = sum(item.attempts > 1 for item in items)
     rollbacks = sum(item.rolled_back for item in items)
     security_blocks = sum(item.security_gate == "block" for item in items)
+    incomplete_harness_records = sum(not item.harness_identity.complete for item in items)
     return {
         "tasks": tasks,
         "attempts": attempts,
@@ -109,12 +176,17 @@ def summarize(records: Iterable[TaskRecord], human_hour_rate: float = 0.0) -> di
         "retry_rate": round(retry_tasks / tasks, 4) if tasks else 0.0,
         "rollback_rate": round(rollbacks / tasks, 4) if tasks else 0.0,
         "security_block_rate": round(security_blocks / tasks, 4) if tasks else 0.0,
+        "incomplete_harness_records": incomplete_harness_records,
         "direct_cost": round(direct_cost, 6),
         "human_review_minutes": round(review_minutes, 2),
         "human_review_cost": round(review_cost, 6),
         "total_cost": round(total_cost, 6),
         "cost_per_verified_completion": round(total_cost / completions, 6) if completions else None,
-        "expected_cost_to_verified_completion": round((total_cost / tasks) / completion_rate, 6) if tasks and completion_rate else None,
+        "expected_cost_to_verified_completion": (
+            round((total_cost / tasks) / completion_rate, 6)
+            if tasks and completion_rate
+            else None
+        ),
         "median_elapsed_ms": _median([item.elapsed_ms for item in items]),
         "median_review_minutes": _median([item.human_review_minutes for item in items]),
     }
@@ -130,20 +202,21 @@ def _median(values: list[float | int]) -> float | None:
 
 
 def grouped_summary(records: list[TaskRecord], human_hour_rate: float = 0.0) -> dict[str, Any]:
-    groups: dict[tuple[str, str], list[TaskRecord]] = defaultdict(list)
+    groups: dict[tuple[str, str, str], list[TaskRecord]] = defaultdict(list)
     for record in records:
-        groups[(record.provider, record.model)].append(record)
+        groups[(record.provider, record.model, record.harness_identity.fingerprint)].append(record)
     return {
-        "version": 1,
+        "version": 2,
         "human_hour_rate": human_hour_rate,
         "overall": summarize(records, human_hour_rate),
-        "providers": [
+        "harnesses": [
             {
                 "provider": provider,
                 "model": model,
+                "harness_identity": items[0].harness_identity.to_dict(),
                 **summarize(items, human_hour_rate),
             }
-            for (provider, model), items in sorted(groups.items())
+            for (provider, model, _fingerprint), items in sorted(groups.items())
         ],
     }
 
@@ -158,19 +231,22 @@ def render_markdown(summary: dict[str, Any]) -> str:
         f"- Retry rate: {overall['retry_rate'] * 100:.1f}%",
         f"- Median human review: {overall['median_review_minutes'] or 0:g} minutes",
         f"- Rollback rate: {overall['rollback_rate'] * 100:.1f}%",
+        f"- Records missing complete harness identity: {overall['incomplete_harness_records']}",
         "",
-        "| Provider | Model | Tasks | Verified | Cost / verified completion | Retry rate | Median review |",
-        "|---|---|---:|---:|---:|---:|---:|",
+        "| Provider | Model | Harness | Context | Tasks | Verified | Cost / verified completion | Retry rate |",
+        "|---|---|---|---|---:|---:|---:|---:|",
     ]
-    for item in summary["providers"]:
+    for item in summary["harnesses"]:
+        identity = item["harness_identity"]
         lines.append(
-            f"| {item['provider']} | {item['model']} | {item['tasks']} | "
-            f"{item['verified_completion_rate'] * 100:.1f}% | {_money(item['cost_per_verified_completion'])} | "
-            f"{item['retry_rate'] * 100:.1f}% | {item['median_review_minutes'] or 0:g} min |"
+            f"| {item['provider']} | {item['model']} | {identity['fingerprint']} "
+            f"({identity['harness']}) | {identity['context_strategy']} | {item['tasks']} | "
+            f"{item['verified_completion_rate'] * 100:.1f}% | "
+            f"{_money(item['cost_per_verified_completion'])} | {item['retry_rate'] * 100:.1f}% |"
         )
     lines.extend([
         "",
-        "Use this report as routing feedback only after each provider/model group has a meaningful sample. Do not route on token price alone.",
+        "Compare routing results only within complete, matching harness identities and meaningful samples. A model name alone is not an experimental control.",
     ])
     return "\n".join(lines) + "\n"
 
@@ -180,7 +256,9 @@ def _money(value: float | None) -> str:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Calculate cost to verified completion from Buddy task records.")
+    parser = argparse.ArgumentParser(
+        description="Calculate cost to verified completion from Buddy task records."
+    )
     parser.add_argument("records", type=Path, help="JSON array or JSONL task records")
     parser.add_argument("--human-hour-rate", type=float, default=0.0)
     parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
@@ -189,7 +267,11 @@ def main() -> int:
     if args.human_hour_rate < 0:
         raise SystemExit("--human-hour-rate cannot be negative")
     result = grouped_summary(read_records(args.records), args.human_hour_rate)
-    rendered = json.dumps(result, indent=2) + "\n" if args.format == "json" else render_markdown(result)
+    rendered = (
+        json.dumps(result, indent=2) + "\n"
+        if args.format == "json"
+        else render_markdown(result)
+    )
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(rendered, encoding="utf-8")

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,171 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.buddy_model_registry import (
+    ModelRegistry,
+    discover_model,
+    load_registry,
+    route_allowed,
+    save_registry,
+    transition_model,
+)
+
+
+def empty_registry() -> ModelRegistry:
+    return ModelRegistry.from_dict(
+        {
+            "schema": "buddy.model-registry.v1",
+            "default_status": "quarantined",
+            "models": {},
+        }
+    )
+
+
+def test_discovered_provider_models_default_to_quarantine():
+    registry = discover_model(
+        empty_registry(),
+        model_id="provider/new-model",
+        provider="provider",
+        model="new-model",
+        discovered_at="2026-08-03",
+    )
+    assert registry.models["provider/new-model"].status == "quarantined"
+    assert route_allowed(registry, "provider/new-model", "bounded_edit") is False
+
+
+def test_model_cannot_skip_benchmark_and_security_review():
+    registry = discover_model(
+        empty_registry(),
+        model_id="provider/model",
+        provider="provider",
+        model="model",
+    )
+    with pytest.raises(ValueError, match="invalid transition"):
+        transition_model(
+            registry,
+            model_id="provider/model",
+            status="approved",
+            evidence_ref="evidence://shortcut",
+            reviewed_by="reviewer",
+            task_classes=("bounded_edit",),
+        )
+
+
+def test_full_lifecycle_requires_evidence_and_explicit_review():
+    registry = discover_model(
+        empty_registry(),
+        model_id="provider/model",
+        provider="provider",
+        model="model",
+    )
+    with pytest.raises(ValueError, match="requires evidence"):
+        transition_model(registry, model_id="provider/model", status="benchmarked")
+
+    registry = transition_model(
+        registry,
+        model_id="provider/model",
+        status="benchmarked",
+        evidence_ref="benchmark://suite-v1",
+    )
+    with pytest.raises(ValueError, match="requires reviewed_by"):
+        transition_model(
+            registry,
+            model_id="provider/model",
+            status="security_reviewed",
+            evidence_ref="security://review-v1",
+        )
+    registry = transition_model(
+        registry,
+        model_id="provider/model",
+        status="security_reviewed",
+        evidence_ref="security://review-v1",
+        reviewed_by="peppermint-butler",
+    )
+    registry = transition_model(
+        registry,
+        model_id="provider/model",
+        status="supervised",
+        evidence_ref="supervised://run-set-v1",
+        reviewed_by="neptr",
+        task_classes=("bounded_edit",),
+    )
+    assert route_allowed(registry, "provider/model", "bounded_edit") is False
+    assert (
+        route_allowed(
+            registry,
+            "provider/model",
+            "bounded_edit",
+            allow_supervised=True,
+        )
+        is True
+    )
+    registry = transition_model(
+        registry,
+        model_id="provider/model",
+        status="approved",
+        evidence_ref="approval://routing-v1",
+        reviewed_by="prismo",
+    )
+    assert route_allowed(registry, "provider/model", "bounded_edit") is True
+    assert route_allowed(registry, "provider/model", "security_review") is False
+
+
+def test_approved_model_can_be_requarantined_immediately():
+    registry = ModelRegistry.from_dict(
+        {
+            "schema": "buddy.model-registry.v1",
+            "default_status": "quarantined",
+            "models": {
+                "provider/model": {
+                    "provider": "provider",
+                    "model": "model",
+                    "status": "approved",
+                    "task_classes": ["bounded_edit"],
+                    "evidence_refs": ["approval://v1"],
+                    "reviewed_by": "prismo",
+                }
+            },
+        }
+    )
+    registry = transition_model(
+        registry,
+        model_id="provider/model",
+        status="quarantined",
+        notes="Unexpected tool behavior under observation.",
+    )
+    assert registry.models["provider/model"].status == "quarantined"
+    assert route_allowed(registry, "provider/model", "bounded_edit") is False
+
+
+def test_registry_round_trip_is_deterministic(tmp_path: Path):
+    registry = discover_model(
+        empty_registry(),
+        model_id="provider/model",
+        provider="provider",
+        model="model",
+        evidence_ref="discovery://provider-catalog",
+    )
+    path = tmp_path / "registry.json"
+    save_registry(path, registry)
+    loaded = load_registry(path)
+    assert loaded == registry
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert list(payload["models"]) == ["provider/model"]
+
+
+def test_identity_collision_is_rejected():
+    registry = discover_model(
+        empty_registry(),
+        model_id="provider/model",
+        provider="provider",
+        model="model",
+    )
+    with pytest.raises(ValueError, match="identity collision"):
+        discover_model(
+            registry,
+            model_id="provider/model",
+            provider="other-provider",
+            model="different-model",
+        )

--- a/tests/test_task_economics.py
+++ b/tests/test_task_economics.py
@@ -1,4 +1,21 @@
-from scripts.buddy_task_economics import TaskRecord, grouped_summary
+import pytest
+
+from scripts.buddy_task_economics import HarnessIdentity, TaskRecord, grouped_summary
+
+
+def complete_harness(**overrides):
+    values = {
+        "harness": "buddy-agent",
+        "effort": "medium",
+        "buap_artifact_hash": "abc123",
+        "runtime_adapter_version": "local-container-v1",
+        "memory_strategy": "knowledge-vault-public-safe",
+        "context_strategy": "compact",
+        "reasoning_retention": True,
+        "tool_policy_version": "policy-v1",
+    }
+    values.update(overrides)
+    return values
 
 
 def record(task_id: str, **overrides):
@@ -15,6 +32,7 @@ def record(task_id: str, **overrides):
         "artifacts_accepted": True,
         "rolled_back": False,
         "security_gate": "pass",
+        "harness_identity": complete_harness(),
     }
     values.update(overrides)
     return TaskRecord.from_dict(values)
@@ -41,3 +59,53 @@ def test_retry_rate_counts_tasks_requiring_more_than_one_attempt():
     summary = grouped_summary([record("one"), record("two", attempts=3)])
     assert summary["overall"]["retry_rate"] == 0.5
     assert summary["overall"]["attempts"] == 4
+
+
+def test_same_model_with_different_harnesses_is_not_averaged_together():
+    summary = grouped_summary([
+        record("compact"),
+        record(
+            "truncate",
+            harness_identity=complete_harness(
+                context_strategy="truncate",
+                reasoning_retention=False,
+            ),
+        ),
+    ])
+    assert summary["version"] == 2
+    assert len(summary["harnesses"]) == 2
+    fingerprints = {
+        item["harness_identity"]["fingerprint"] for item in summary["harnesses"]
+    }
+    assert len(fingerprints) == 2
+
+
+def test_legacy_records_remain_readable_but_are_marked_incomplete():
+    legacy = record("legacy")
+    payload = {
+        "task_id": legacy.task_id,
+        "provider": legacy.provider,
+        "model": legacy.model,
+        "attempts": legacy.attempts,
+        "model_cost": legacy.model_cost,
+        "tool_cost": legacy.tool_cost,
+        "elapsed_ms": legacy.elapsed_ms,
+        "human_review_minutes": legacy.human_review_minutes,
+        "verification_passed": legacy.verification_passed,
+        "artifacts_accepted": legacy.artifacts_accepted,
+    }
+    parsed = TaskRecord.from_dict(payload)
+    assert parsed.harness_identity == HarnessIdentity()
+    summary = grouped_summary([parsed])
+    assert summary["overall"]["incomplete_harness_records"] == 1
+    assert summary["harnesses"][0]["harness_identity"]["complete"] is False
+
+
+def test_invalid_context_strategy_is_rejected():
+    with pytest.raises(ValueError, match="context_strategy"):
+        record("bad", harness_identity=complete_harness(context_strategy="rolling-mystery"))
+
+
+def test_negative_elapsed_time_is_rejected():
+    with pytest.raises(ValueError, match="elapsed_ms"):
+        record("bad-time", elapsed_ms=-1)


### PR DESCRIPTION
## Summary

Adds the two Buddy Brain governance pieces needed to evaluate the new runtime adapters safely.

## Task contract
- Plan: context/plans/2026-08-03-harness-model-governance.md
- Verification: yes
- Rollback: yes

## Problem

Provider/model-only economics can silently average different prompts, adapters, memory strategies, context handling, and tool policy. Provider catalogs can also make new models appear before Buddy has benchmarked or approved them.

## Smallest useful wedge

### Harness-aware economics

Task economics records can now identify:

- harness
- effort
- BUAP artifact hash
- runtime adapter version
- memory strategy
- context strategy
- reasoning retention
- tool policy version

Provider/model results are grouped by a stable harness fingerprint. Legacy records still load, but the report marks them as incomplete rather than silently treating them as comparable experiments.

### Quarantine-first model lifecycle

Adds `config/model-registry.json`, its schema, and `scripts/buddy_model_registry.py`.

- newly discovered models default to `quarantined`
- provider availability does not grant routing approval
- invalid lifecycle jumps are rejected
- benchmark and later states require durable evidence
- security-reviewed, supervised, and approved states require an attributable reviewer
- approved models require explicit task classes
- supervised routing requires an explicit caller opt-in
- approved models can be immediately re-quarantined

Lifecycle:

```text
discovered -> quarantined -> benchmarked -> security_reviewed -> supervised -> approved -> deprecated
```

## Verification plan
- [x] Python compilation for all readiness/governance scripts
- [x] Economics regression and harness-separation tests
- [x] Lifecycle transition, evidence, reviewer, route, re-quarantine, collision, and persistence tests
- [x] Registry validation in focused CI
- [x] Prior exact-head CI, lint, CodeQL, bootstrap, autonomy, runtime smoke, and iOS validation passed
- [ ] Required GitHub checks green on the current exact head before merge

## Rollback plan

Revert this PR. Existing telemetry producers remain compatible because missing harness identity is represented as incomplete legacy evidence. The committed model registry contains no approved models, so reverting does not revoke an active approved route.

## Checklist
- [x] No secrets committed
- [x] Docs, schemas, workflow, and dated plan updated
- [x] No direct lead-branch writes
- [x] No provider model approved by this PR
- [ ] Merge only after green checks

## Notes

The committed registry is intentionally empty and defaults discoveries to quarantine.